### PR TITLE
Fixes to slow assembly for WY and BDM.

### DIFF
--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -28,7 +28,8 @@ struct _p_TDy {
   PetscReal *V; /* volume of point (if applicable) */
   PetscReal *X; /* centroid of point */
   PetscReal *N; /* normal of point (if applicable) */
-
+  PetscInt ncv,nfv; /* number of {cell|face} vertices */
+  
   /* problem constants */
   PetscReal  rho;        /* density of water [kg m-3]*/
   PetscReal  mu;         /* viscosity of water [Pa s] */

--- a/src/tdybdm.c
+++ b/src/tdybdm.c
@@ -152,7 +152,8 @@ PetscErrorCode TDyBDMInitialize(TDy tdy) {
 
   /* use vmap, emap, and fmap to build a LtoG map for local element
      assembly */
-  ncv = TDyGetNumberOfCellVertices(dm);
+  tdy->ncv = TDyGetNumberOfCellVertices(dm);
+  ncv = tdy->ncv;
   nlocal = dim*ncv + 1;
   ierr = PetscMalloc((cEnd-cStart)*nlocal*sizeof(PetscInt),
                      &(tdy->LtoG)); CHKERRQ(ierr);
@@ -232,7 +233,7 @@ PetscErrorCode TDyBDMComputeSystem(TDy tdy,Mat K,Vec F) {
   /* Get domain constants */
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr); dim2 = dim*dim;
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  nv = TDyGetNumberOfCellVertices(dm);
+  nv = tdy->ncv;
   ehat = PetscPowReal(2,dim-1);
 
   /* Get quadrature */
@@ -424,8 +425,7 @@ PetscReal TDyBDMVelocityNorm(TDy tdy,Vec U) {
   PetscQuadrature quad;
   PetscScalar *u;
   ierr = VecGetArray(U,&u); CHKERRQ(ierr);
-  ncv  = TDyGetNumberOfCellVertices(dm);
-  //nfv  = TDyGetNumberOfFaceVertices(dm);
+  ncv  = tdy->ncv;
   ierr = PetscDTGaussTensorQuadrature(dim-1,1,nq1d,-1,+1,&quad); CHKERRQ(ierr);
   ierr = PetscQuadratureGetData(quad,NULL,NULL,&nq,&quad_x,&quad_w);
   CHKERRQ(ierr);

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -462,7 +462,7 @@ PetscErrorCode TDyCreateCellVertexMap(TDy tdy,PetscInt **map) {
   PetscReal x[24],DF[72],DFinv[72],J[8];
   DM dm = tdy->dm;
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
-  nv = TDyGetNumberOfCellVertices(dm);
+  nv = tdy->ncv;
   ierr = PetscQuadratureCreate(PETSC_COMM_SELF,&quad); CHKERRQ(ierr);
   ierr = TDyQuadrature(quad,dim); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum(dm,0,&vStart,&vEnd); CHKERRQ(ierr);
@@ -539,7 +539,7 @@ PetscErrorCode TDyCreateCellVertexDirFaceMap(TDy tdy,PetscInt **map) {
     local_dirs[18] = 0; local_dirs[19] = 3; local_dirs[20] = 5;
     local_dirs[21] = 1; local_dirs[22] = 2; local_dirs[23] = 4;
   }
-  nv = TDyGetNumberOfCellVertices(dm);
+  nv = tdy->ncv;
   ierr = DMPlexGetHeightStratum(dm,1,&fStart,&fEnd); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
   ierr = PetscMalloc(dim*nv*(cEnd-cStart)*sizeof(PetscInt),map); CHKERRQ(ierr);


### PR DESCRIPTION
This restores linear complexity to WY assembly and speeds it up by 100x. 
A function was implemented to check the number of vertices per cell and face 
and then called this inside a loop over cells. The fix is to store the integer and
read it when needed.