### PR TITLE
Sets default quadrature for BDM spaces to be full

### DIFF
--- a/demo/steady/makefile
+++ b/demo/steady/makefile
@@ -21,7 +21,7 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/variables
 include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 
 build:
-	@cd ../; make
+	@cd ../../; make
 
 steady: steady.o chkopts
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -127,7 +127,8 @@ PetscErrorCode TDyCreate(DM dm,TDy *_tdy) {
   tdy->quad = NULL;
   tdy->faces = NULL; tdy->LtoG = NULL; tdy->orient = NULL;
   tdy->allow_unsuitable_mesh = PETSC_FALSE;
-
+  tdy->qtype = FULL;
+  
   /* initialize function pointers */
   tdy->forcing = NULL ; tdy->dirichlet = NULL ; tdy->flux = NULL ;
   PetscFunctionReturn(0);


### PR DESCRIPTION
This is a simple patch enforces default quadrature for BDM spaces to be full.