### PR TITLE
Adds an option to output mesh connectivity

### DIFF
--- a/demo/mpfao/makefile
+++ b/demo/mpfao/makefile
@@ -13,7 +13,7 @@ FPPFLAGS = ${MYFLAGS}
 
 ALL: $(TARGETS)
 clean::
-	-@$(RM) $(TARGETS) *.gcov *.regression *.old *.stdout
+	-@$(RM) $(TARGETS) *.gcov *.regression *.old *.stdout *.bin *.bin.info
 
 topdir := $(shell cd ../.. && pwd)
 TDYCORE_DIR ?= $(topdir)

--- a/demo/mpfao/mpfao.cfg
+++ b/demo/mpfao/mpfao.cfg
@@ -13,7 +13,7 @@ standard_parallel=
 pressure = 1.0e-12 relative
 
 [mpfao-prob1]
-input_arguments=-problem 1 -tdy_regression_test -tdy_regression_test_num_cells_per_process 2 -tdy_regression_test_filename mpfao-prob1
+input_arguments=-problem 1 -tdy_regression_test -tdy_regression_test_num_cells_per_process 2 -tdy_regression_test_filename mpfao-prob1 -tdy_output_mesh
 
 [mpfao-prob2]
 input_arguments=-problem 2 -tdy_regression_test -tdy_regression_test_num_cells_per_process 2 -tdy_regression_test_filename mpfao-prob2

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -76,6 +76,7 @@ struct _p_TDy {
   PetscReal ****subc_Gmatrix; /* Gmatrix for subcells */
   PetscReal ***Trans;
 
+  PetscBool output_mesh;
   PetscBool regression_testing;
   TDy_regression *regression;
   

--- a/include/private/tdymeshimpl.h
+++ b/include/private/tdymeshimpl.h
@@ -133,6 +133,7 @@ struct _TDy_mesh {
 
 };
 
+PETSC_EXTERN PetscErrorCode OutputMesh(TDy);
 PETSC_EXTERN PetscErrorCode BuildTwoDimMesh(TDy);
 PETSC_EXTERN PetscErrorCode AllocateMemoryForMesh(DM,TDy_mesh*);
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -205,8 +205,19 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
                           "Enable output of a regression file","",tdy->regression_testing,
                           &(tdy->regression_testing),NULL); CHKERRQ(ierr);
 
+  ierr = PetscOptionsBool("-tdy_output_mesh",
+                          "Enable output of mesh attributes","",tdy->output_mesh,
+                          &(tdy->output_mesh),NULL); CHKERRQ(ierr);
+
   if (tdy->regression_testing) {
     ierr = TDyRegressionInitialize(tdy); CHKERRQ(ierr);
+  }
+
+  if (tdy->output_mesh) {
+    if (tdy->method != MPFA_O) {
+      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"-tdy_output_mesh only supported for MPFA-O method");
+    }
+    ierr = OutputMesh(tdy); CHKERRQ(ierr);
   }
 
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);

--- a/src/tdycoremesh.c
+++ b/src/tdycoremesh.c
@@ -1222,6 +1222,26 @@ PetscErrorCode OutputTwoDimMesh(TDy tdy) {
 }
 
 /* -------------------------------------------------------------------------- */
+PetscErrorCode OutputMesh(TDy tdy) {
+
+  PetscErrorCode ierr;
+  PetscInt dim;
+
+  PetscFunctionBegin;
+
+  ierr = DMGetDimension(tdy->dm, &dim); CHKERRQ(ierr);
+  switch(dim) {
+    case 2:
+      ierr = OutputTwoDimMesh(tdy); CHKERRQ(ierr);
+      break;
+    default:
+      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"Output of mesh only supported for 2D meshes");
+      break;
+  }
+  PetscFunctionReturn(0);
+}
+
+/* -------------------------------------------------------------------------- */
 PetscErrorCode BuildTwoDimMesh(TDy tdy) {
 
   PetscFunctionBegin;

--- a/src/tdympfao.c
+++ b/src/tdympfao.c
@@ -810,8 +810,6 @@ PetscErrorCode TDyMPFAOInitialize(TDy tdy) {
                      &(tdy->vel )); CHKERRQ(ierr);
   ierr = Initialize_RealArray_1D(tdy->vel, tdy->mesh->num_edges, 0.0); CHKERRQ(ierr);
 
-  //ierr = OutputTwoDimMesh(dm, tdy);
-
   /* Setup the section, 1 dof per cell */
   PetscSection sec;
   PetscInt p, pStart, pEnd;


### PR DESCRIPTION
By adding `-tdy_output_mesh` to command line, the mesh attributes and connectivity
information is outputted. Additionally, a regression test is updated to test the new option.