### PR TITLE
Modifications to improve SPE performance

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -150,6 +150,7 @@ int main(int argc, char **argv) {
   ierr = DMCreateGlobalVector(dm,&U); CHKERRQ(ierr);
   ierr = DMCreateGlobalVector(dm,&F); CHKERRQ(ierr);
   ierr = DMCreateMatrix      (dm,&K); CHKERRQ(ierr);
+  ierr = MatSetOption(K,MAT_IGNORE_ZERO_ENTRIES,PETSC_TRUE); CHKERRQ(ierr);
   ierr = TDyComputeSystem(tdy,K,F); CHKERRQ(ierr);
 
   /* Solve system */

--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
     faces[1] = (PetscInt)(fct*faces[1]);
     faces[2] = (PetscInt)(fct*faces[2]);
   }
-  printf("grid: %d %d %d = %d\n",faces[0],faces[1],faces[2],faces[0]*faces[1]*faces[2]);
+  PetscPrintf(PETSC_COMM_WORLD,"grid: %d %d %d = %d\n",faces[0],faces[1],faces[2],faces[0]*faces[1]*faces[2]);
   ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD,dim,PETSC_FALSE,faces,lower,upper,
                              NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);

--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -34,7 +34,9 @@ PetscErrorCode ReadSPE10Permeability(TDy tdy,PetscReal ang){
   const char filename[] = "spe_perm.dat";
   FILE *f = fopen(filename,"r");
   PetscReal *buffer;
-  ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
+  DM dm;
+  ierr = TDyGetDimension(tdy,&dim); CHKERRQ(ierr);
+  ierr = TDyGetDM(tdy,&dm); CHKERRQ(ierr);
   dim2 = dim*dim;
 
   // Rotation matrix
@@ -59,7 +61,7 @@ PetscErrorCode ReadSPE10Permeability(TDy tdy,PetscReal ang){
   PetscInt c,cStart,cEnd;
   PetscReal dx = 20, dy = 10, dz = 2;
   PetscReal xL = -600, yL = -1100, zL = -170;
-  ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
+  ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
   ierr = PetscMemzero(tdy->K,sizeof(PetscReal)*dim2*(cEnd-cStart)); CHKERRQ(ierr);
   for(c=cStart;c<cEnd;c++){
     if(dim==2){ /* in 2D we use the x-y plane */

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -38,6 +38,9 @@ PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy tdy,PetscViewer viewer);
 PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy tdy);
 
+PETSC_EXTERN PetscErrorCode TDyGetDimension(TDy tdy,PetscInt *dim);
+PETSC_EXTERN PetscErrorCode TDyGetDM(TDy tdy,DM *dm);
+
 PETSC_EXTERN PetscErrorCode TDySetPermeabilityFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
 PETSC_EXTERN PetscErrorCode TDySetForcingFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
 PETSC_EXTERN PetscErrorCode TDySetDirichletValueFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -40,6 +40,7 @@ PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy tdy);
 
 PETSC_EXTERN PetscErrorCode TDyGetDimension(TDy tdy,PetscInt *dim);
 PETSC_EXTERN PetscErrorCode TDyGetDM(TDy tdy,DM *dm);
+PETSC_EXTERN PetscErrorCode TDyGetCentroidArray(TDy tdy,PetscReal **X);
 
 PETSC_EXTERN PetscErrorCode TDySetPermeabilityFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
 PETSC_EXTERN PetscErrorCode TDySetForcingFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
@@ -52,6 +53,7 @@ PETSC_EXTERN PetscErrorCode TDySetPermeabilityDiagonal(TDy tdy,
     SpatialFunction f);
 PETSC_EXTERN PetscErrorCode TDySetPermeabilityTensor  (TDy tdy,
     SpatialFunction f);
+PETSC_EXTERN PetscErrorCode TDySetCellPermeability(TDy,PetscInt,PetscReal*);
 PETSC_EXTERN PetscErrorCode TDySetPorosity            (TDy tdy,
     SpatialFunction f);
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -167,6 +167,13 @@ PetscErrorCode TDyGetDM(TDy tdy,DM *dm) {
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDyGetCentroidArray(TDy tdy,PetscReal **X) {
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
+  *X = tdy->X;
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode TDyResetDiscretizationMethod(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -153,6 +153,20 @@ PetscErrorCode TDyDestroy(TDy *_tdy) {
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDyGetDimension(TDy tdy,PetscInt *dim) {
+  PetscErrorCode ierr;
+  PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
+  ierr = DMGetDimension(tdy->dm,dim); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDyGetDM(TDy tdy,DM *dm) {
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
+  *dm = tdy->dm;
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode TDyResetDiscretizationMethod(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
@@ -169,7 +183,6 @@ PetscErrorCode TDyResetDiscretizationMethod(TDy tdy) {
   if (tdy->quad  ) { ierr = PetscQuadratureDestroy(&(tdy->quad)); CHKERRQ(ierr); }
   PetscFunctionReturn(0);
 }
-
 
 PetscErrorCode TDyView(TDy tdy,PetscViewer viewer) {
   PetscErrorCode ierr;

--- a/src/tdypermeability.c
+++ b/src/tdypermeability.c
@@ -86,6 +86,18 @@ PetscErrorCode TDySetPermeabilityTensor(TDy tdy,SpatialFunction f) {
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDySetCellPermeability(TDy tdy,PetscInt c,PetscReal *K) {
+  PetscInt dim2,i,cStart;
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
+  ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&i); CHKERRQ(ierr);
+  ierr = DMGetDimension(tdy->dm,&dim2); CHKERRQ(ierr);
+  dim2 *= dim2;  
+  for(i=0;i<dim2;i++) tdy->K[dim2*(c-cStart)+i] = K[i];
+  PetscFunctionReturn(0);
+}
+
 void RelativePermeability_Irmay(PetscReal m,PetscReal Se,PetscReal *Kr,
                                 PetscReal *dKr_dSe) {
   *Kr = PetscPowReal(Se,m);

--- a/src/tdywy.c
+++ b/src/tdywy.c
@@ -432,7 +432,7 @@ PetscErrorCode TDyWYComputeSystem(TDy tdy,Mat K,Vec F) {
   PetscScalar A[MAX_LOCAL_SIZE],B[MAX_LOCAL_SIZE],C[MAX_LOCAL_SIZE],
               G[MAX_LOCAL_SIZE],D[MAX_LOCAL_SIZE],sign_row,sign_col;
   PetscInt Amap[MAX_LOCAL_SIZE],Bmap[MAX_LOCAL_SIZE];
-  PetscScalar pdirichlet,wgt;
+  PetscScalar pdirichlet,wgt,tol=1e4*PETSC_MACHINE_EPSILON;
   DM dm = tdy->dm;
   PetscFunctionBegin;
 
@@ -561,7 +561,7 @@ PetscErrorCode TDyWYComputeSystem(TDy tdy,Mat K,Vec F) {
       if(gStart < 0) continue;
       ierr = VecSetValue(F,gStart,D[c],ADD_VALUES); CHKERRQ(ierr);
       for(q=0; q<nB; q++) {
-	if (PetscAbsReal(C[q*nB+c])<(1e-12*maxC)) continue;
+	if (PetscAbsReal(C[q*nB+c])<(tol*maxC)) continue;
         ierr = DMPlexGetPointGlobal(dm,Bmap[q],&lStart,&junk); CHKERRQ(ierr);
         if (lStart < 0) lStart = -lStart-1;
         ierr = MatSetValue(K,gStart,lStart,C[q*nB+c],ADD_VALUES); CHKERRQ(ierr);

--- a/src/tdywy.c
+++ b/src/tdywy.c
@@ -554,17 +554,20 @@ PetscErrorCode TDyWYComputeSystem(TDy tdy,Mat K,Vec F) {
 
     /* C and D are in column major, but C is always symmetric and D is
        a vector so it should not matter. */
+    PetscReal maxC = 0;
+    for(c=0; c<nB*nB; c++) { maxC = PetscMax(maxC,PetscAbsReal(C[c])); }
     for(c=0; c<nB; c++) {
       ierr = DMPlexGetPointGlobal(dm,Bmap[c],&gStart,&junk); CHKERRQ(ierr);
       if(gStart < 0) continue;
       ierr = VecSetValue(F,gStart,D[c],ADD_VALUES); CHKERRQ(ierr);
       for(q=0; q<nB; q++) {
+	if (PetscAbsReal(C[q*nB+c])<(1e-12*maxC)) continue;
         ierr = DMPlexGetPointGlobal(dm,Bmap[q],&lStart,&junk); CHKERRQ(ierr);
         if (lStart < 0) lStart = -lStart-1;
         ierr = MatSetValue(K,gStart,lStart,C[q*nB+c],ADD_VALUES); CHKERRQ(ierr);
       }
     }
-
+    
   }
 
   /* Integrate in the forcing */


### PR DESCRIPTION
Removes entries in the system matrix when a diagonal permeability is used on a regular grid. 
This would result in fewer non-zero entries and reduce the cost of MatVec products. 
Additionally, adds some accessors for TDy data such as the dimension such that we need
not include private headers in application code.