### PR TITLE
Moved DMSetFromOptions() calls to occur after DMPlexDistribute().

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -131,9 +131,9 @@ int main(int argc, char **argv) {
   PetscPrintf(PETSC_COMM_WORLD,"grid: %d %d %d = %d\n",faces[0],faces[1],faces[2],faces[0]*faces[1]*faces[2]);
   ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD,dim,PETSC_FALSE,faces,lower,upper,
                              NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   /* Setup problem parameters */

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -237,9 +237,9 @@ int main(int argc, char **argv) {
     ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, mesh_filename, PETSC_TRUE, &dm); CHKERRQ(ierr);
   }
 
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   // Setup problem parameters

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -470,9 +470,9 @@ int main(int argc, char **argv) {
       }
     }
   }
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   /* Setup problem parameters */

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -95,9 +95,9 @@ int main(int argc, char **argv) {
 			       NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
     ierr = PerturbInteriorVertices(dm,1./N); CHKERRQ(ierr);
   }
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
   /* Setup problem parameters */


### PR DESCRIPTION
Moved DMSetFromOptions() calls to be after the calls to DMPlexDistribute(). We destroy the original 'dm' after the latter, so we were losing the DM-related options when we were doing things in the original order.