### PR TITLE
Jed/petsc3.12 testing python3

### DIFF
--- a/regression_tests/Makefile
+++ b/regression_tests/Makefile
@@ -28,7 +28,7 @@ ifdef TIMEOUT
 endif
 
 ifneq ($(strip $(MPIEXEC)),)
-	TEST_OPTIONS += --mpiexec $(MPIEXEC)
+	TEST_OPTIONS += --mpiexec "$(MPIEXEC)"
 endif
 
 #

--- a/regression_tests/regression_tests.py
+++ b/regression_tests/regression_tests.py
@@ -23,6 +23,7 @@ import hashlib
 import os
 import pprint
 import re
+import shlex
 import shutil
 import subprocess
 import textwrap
@@ -223,7 +224,7 @@ class RegressionTest(object):
         command = []
         if self._np is not None:
             if mpiexec:
-                command.append(mpiexec)
+                command += shlex.split(mpiexec)
                 command.append("-np")
                 command.append(self._np)
             else:
@@ -1846,7 +1847,7 @@ def check_for_mpiexec(options, testlog):
         print("MPI information :", file=testlog)
         print("-----------------", file=testlog)
         tempfile = "{0}/tmp-executable-regression-test-info.txt".format(os.getcwd())
-        command = [mpiexec, "--version"]
+        command = shlex.split(mpiexec) + ["--version"]
         append_command_to_log(command, testlog, tempfile)
         print("\n\n", file=testlog)
         os.remove(tempfile)

--- a/regression_tests/regression_tests.py
+++ b/regression_tests/regression_tests.py
@@ -225,7 +225,7 @@ class RegressionTest(object):
         if self._np is not None:
             if mpiexec:
                 command += shlex.split(mpiexec)
-                command.append("-np")
+                command.append("-n")
                 command.append(self._np)
             else:
                 # parallel test, but don't have mpiexec, we mark the

--- a/regression_tests/regression_tests.py
+++ b/regression_tests/regression_tests.py
@@ -441,7 +441,7 @@ class RegressionTest(object):
                         status.fail = 1
                         return
                     else:
-                        with open(current_filename, 'rU') as current_file:
+                        with open(current_filename, 'r') as current_file:
                             current_output = current_file.readlines()
 
                     gold_filename = current_filename + ".gold"
@@ -453,7 +453,7 @@ class RegressionTest(object):
                         status.fail = 1
                         return
                     else:
-                        with open(gold_filename, 'rU') as gold_file:
+                        with open(gold_filename, 'r') as gold_file:
                             gold_output = gold_file.readlines()
 
                     print("    diff {0} {1}".format(gold_filename, 
@@ -483,7 +483,7 @@ class RegressionTest(object):
                 status.fail = 1
                 return
             else:
-                with open(gold_filename, 'rU') as gold_file:
+                with open(gold_filename, 'r') as gold_file:
                     gold_output = gold_file.readlines()
     
             if not os.path.isfile(current_filename):
@@ -495,7 +495,7 @@ class RegressionTest(object):
                 status.fail = 1
                 return
             else:
-                with open(current_filename, 'rU') as current_file:
+                with open(current_filename, 'r') as current_file:
                     current_output = current_file.readlines()
     
             print("    diff {0} {1}".format(gold_filename, current_filename),

--- a/src/tdybdm.c
+++ b/src/tdybdm.c
@@ -113,9 +113,9 @@ PetscErrorCode TDyBDMInitialize(TDy tdy) {
     ierr = PetscSectionSetDof     (sec,f,dofs_per_face); CHKERRQ(ierr);
   }
   ierr = PetscSectionSetUp(sec); CHKERRQ(ierr);
-  ierr = DMSetDefaultSection(dm,sec); CHKERRQ(ierr);
+  ierr = DMSetSection(dm,sec); CHKERRQ(ierr);
   ierr = PetscSectionDestroy(&sec); CHKERRQ(ierr);
-  ierr = DMGetDefaultGlobalSection(dm,&sec); CHKERRQ(ierr);
+  ierr = DMGetGlobalSection(dm,&sec); CHKERRQ(ierr);
 
   /* I am not sure what we want here, but this seems to be a
      conservative estimate on the sparsity we need. */
@@ -379,7 +379,7 @@ PetscReal TDyBDMPressureNorm(TDy tdy,Vec U) {
   norm = 0;
   ierr = VecGetArray(U,&u); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = DMGetDefaultSection(dm,&sec); CHKERRQ(ierr);
+  ierr = DMGetSection(dm,&sec); CHKERRQ(ierr);
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
   for(c=cStart; c<cEnd; c++) {
     ierr = DMPlexGetPointGlobal(dm,c,&gref,&junk); CHKERRQ(ierr);

--- a/src/tdympfao.c
+++ b/src/tdympfao.c
@@ -1714,7 +1714,7 @@ PetscErrorCode TDyMPFAOInitialize(TDy tdy) {
     ierr = PetscSectionSetDof(sec,p,1); CHKERRQ(ierr);
   }
   ierr = PetscSectionSetUp(sec); CHKERRQ(ierr);
-  ierr = DMSetDefaultSection(dm,sec); CHKERRQ(ierr);
+  ierr = DMSetSection(dm,sec); CHKERRQ(ierr);
   ierr = PetscSectionViewFromOptions(sec, NULL, "-layout_view"); CHKERRQ(ierr);
   ierr = PetscSectionDestroy(&sec); CHKERRQ(ierr);
   ierr = DMSetBasicAdjacency(dm,PETSC_TRUE,PETSC_TRUE); CHKERRQ(ierr);

--- a/src/tdytpf.c
+++ b/src/tdytpf.c
@@ -32,7 +32,7 @@ PetscErrorCode TDyTPFInitialize(TDy tdy) {
     ierr = PetscSectionSetDof(sec,c,1); CHKERRQ(ierr);
   }
   ierr = PetscSectionSetUp(sec); CHKERRQ(ierr);
-  ierr = DMSetDefaultSection(dm,sec); CHKERRQ(ierr);
+  ierr = DMSetSection(dm,sec); CHKERRQ(ierr);
   ierr = PetscSectionViewFromOptions(sec, NULL, "-layout_view"); CHKERRQ(ierr);
   ierr = PetscSectionDestroy(&sec); CHKERRQ(ierr);
   //ierr = DMPlexSetAdjacencyUseCone(dm,PETSC_TRUE); CHKERRQ(ierr);
@@ -142,7 +142,7 @@ PetscReal TDyTPFPressureNorm(TDy tdy,Vec U) {
   norm = 0;
   ierr = VecGetArray(U,&u); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = DMGetDefaultSection(dm,&sec); CHKERRQ(ierr);
+  ierr = DMGetSection(dm,&sec); CHKERRQ(ierr);
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
   for(c=cStart; c<cEnd; c++) {
     ierr = DMPlexGetPointGlobal(dm,c,&gref,&junk); CHKERRQ(ierr);

--- a/src/tdywy.c
+++ b/src/tdywy.c
@@ -327,7 +327,7 @@ PetscErrorCode TDyWYInitialize(TDy tdy) {
     ierr = PetscSectionSetDof(sec,p,1); CHKERRQ(ierr);
   }
   ierr = PetscSectionSetUp(sec); CHKERRQ(ierr);
-  ierr = DMSetDefaultSection(dm,sec); CHKERRQ(ierr);
+  ierr = DMSetSection(dm,sec); CHKERRQ(ierr);
   ierr = PetscSectionViewFromOptions(sec, NULL, "-layout_view"); CHKERRQ(ierr);
   ierr = PetscSectionDestroy(&sec); CHKERRQ(ierr);
   ierr = DMSetBasicAdjacency(dm,PETSC_TRUE,PETSC_TRUE); CHKERRQ(ierr);
@@ -633,7 +633,7 @@ PetscErrorCode TDyWYRecoverVelocity(TDy tdy,Vec U) {
   ierr = DMGlobalToLocalBegin(dm,U,INSERT_VALUES,localU); CHKERRQ(ierr);
   ierr = DMGlobalToLocalEnd  (dm,U,INSERT_VALUES,localU); CHKERRQ(ierr);
   ierr = VecGetArray(localU,&u); CHKERRQ(ierr);
-  ierr = DMGetDefaultSection(dm, &section); CHKERRQ(ierr);
+  ierr = DMGetSection(dm, &section); CHKERRQ(ierr);
   nq   = tdy->ncv;
   nv   = tdy->nfv;
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
@@ -773,7 +773,7 @@ PetscReal TDyWYPressureNorm(TDy tdy,Vec U) {
   norm = 0;
   ierr = VecGetArray(U,&u); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = DMGetDefaultSection(dm,&sec); CHKERRQ(ierr);
+  ierr = DMGetSection(dm,&sec); CHKERRQ(ierr);
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
   for(c=cStart; c<cEnd; c++) {
     ierr = DMPlexGetPointGlobal(dm,c,&gref,&junk); CHKERRQ(ierr);


### PR DESCRIPTION
I just noticed the first commit here is duplicative of #31, but it can be applied with old PETSc.

I don't know why universal newlines was used, but it's default in Python-3 and newer versions warn of its deprecation. If we need to support Python-2 *and* that flag is necessary for correctness, I'll need to amend 49c81ca7ed329b24ac889b9bb472e6b72bded842