### PR TITLE
regression_tests: use exit code 0 for success [fix #34]

### DIFF
--- a/regression_tests/regression_tests.py
+++ b/regression_tests/regression_tests.py
@@ -94,7 +94,7 @@ class RegressionTest(object):
         self._TOL_TYPE = 1
         self._TOL_MIN_THRESHOLD = 2
         self._TOL_MAX_THRESHOLD = 3
-        self._EXEC_SUCCESS = 86
+        self._EXEC_SUCCESS = 0
         self._RESTART_PREFIX = "tmp-restart"
         # misc test parameters
         self._pprint = pprint.PrettyPrinter(indent=2)


### PR DESCRIPTION
Nonzero exit code generates error output with Open MPI, which we don't
want in case of successful completion.

Glenn:
  I don’t recall the original logic back in 2012. But we key off it
  now to differentiate between user error and a crash.  Just set it to
  zero