### PR TITLE
Corrects the data type while allocating memory

### DIFF
--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -142,8 +142,8 @@ int main(int argc, char **argv) {
   ierr = PetscSectionGetNumFields(sec, &num_fields);
 
   PetscReal *mass_p,*pres_p, *u_p;
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&pres_p);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&mass_p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&pres_p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&mass_p);CHKERRQ(ierr);
 
   if (num_fields == 2) {
     ierr = VecGetArray(U,&u_p); CHKERRQ(ierr);

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -195,8 +195,8 @@ int main(int argc, char **argv) {
   ierr = PetscSectionGetNumFields(sec,&num_fields);
 
   PetscReal *mass_p,*pres_p, *u_p;
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&pres_p);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&mass_p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&pres_p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&mass_p);CHKERRQ(ierr);
 
   /* Setup initial condition */
   Vec U;

--- a/src/mpfao/3D/tdympfao3D_th_ts.c
+++ b/src/mpfao/3D/tdympfao3D_th_ts.c
@@ -452,10 +452,10 @@ PetscErrorCode TDyMPFAOIFunction_3DMesh_TH(TS ts,PetscReal t,Vec U,Vec U_t,Vec R
 
   PetscInt c,cStart,cEnd;
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&dp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&dtemp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&p);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&temp);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dp_dt);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dtemp_dt);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&temp);CHKERRQ(ierr);
 
   for (c=0;c<cEnd-cStart;c++) {
     dp_dt[c]    = du_dt[c*2];
@@ -1328,9 +1328,9 @@ PetscErrorCode TDyMPFAOIJacobian_Accumulation_3DMesh_TH(Vec Ul,Vec Udotl,PetscRe
 
   PetscInt c,cStart,cEnd;
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&dp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&dT_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&temp);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dp_dt);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dT_dt);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&temp);CHKERRQ(ierr);
 
   for (c=0;c<cEnd-cStart;c++) {
     dp_dt[c] = du_dt[c*2];

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -682,7 +682,7 @@ PetscErrorCode TDyMPFAO_SetBoundaryPressure(TDy tdy, Vec Ul) {
   PetscFunctionBegin;
 
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&p);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&p);CHKERRQ(ierr);
 
   ierr = VecGetArray(Ul,&u_p); CHKERRQ(ierr);
   ierr = VecGetArray(tdy->P_vec,&p_vec_ptr); CHKERRQ(ierr);
@@ -750,7 +750,7 @@ PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
   PetscFunctionBegin;
 
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&t);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&t);CHKERRQ(ierr);
 
   ierr = VecGetArray(Ul,&u_p); CHKERRQ(ierr);
   ierr = VecGetArray(tdy->Temp_P_vec,&t_vec_ptr); CHKERRQ(ierr);

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -799,8 +799,8 @@ PetscErrorCode TDyUpdateState(TDy tdy,PetscReal *U) {
   ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
   dim2 = dim*dim;
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&P);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(Vec),&temp);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&P);CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&temp);CHKERRQ(ierr);
 
   if (tdy->mode == TH) {
     for (c=0;c<cEnd-cStart;c++) {


### PR DESCRIPTION
Changes `sizeof(Vec)` to `sizeof(PetscReal)`