### PR TITLE
Refactors residual and jacobian computation for RICHARDS + MPFA-O

### DIFF
--- a/include/private/tdympfao3Dtsimpl.h
+++ b/include/private/tdympfao3Dtsimpl.h
@@ -4,8 +4,7 @@
 #include <petsc.h>
 
 PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec,Vec,void*);
-PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec, Mat,void*);
-PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Vec, Mat,void*);
+PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec, Mat,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Vec, Mat,void*);
 #endif
 

--- a/include/private/tdympfao3Dtsimpl.h
+++ b/include/private/tdympfao3Dtsimpl.h
@@ -3,8 +3,7 @@
 
 #include <petsc.h>
 
-PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_InternalVertices_3DMesh(Vec,Vec,void*);
-PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_3DMesh(Vec,Vec,void*);
+PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec,Vec,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec, Mat,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Vec, Mat,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Vec, Mat,void*);

--- a/include/private/tdympfao3Dtsimpl.h
+++ b/include/private/tdympfao3Dtsimpl.h
@@ -4,8 +4,7 @@
 #include <petsc.h>
 
 PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_InternalVertices_3DMesh(Vec,Vec,void*);
-PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DMesh(Vec,Vec,void*);
-PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Vec,Vec,void*);
+PETSC_EXTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_3DMesh(Vec,Vec,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec, Mat,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Vec, Mat,void*);
 PETSC_EXTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Vec, Mat,void*);

--- a/src/mpfao/3D/tdympfao3D_snes.c
+++ b/src/mpfao/3D/tdympfao3D_snes.c
@@ -144,8 +144,7 @@ PetscErrorCode TDyMPFAOSNESJacobian_3DMesh(SNES snes,Vec U,Mat A,Mat B,void *ctx
   ierr = DMGlobalToLocalBegin(dm,U,INSERT_VALUES,Ul); CHKERRQ(ierr);
   ierr = DMGlobalToLocalEnd  (dm,U,INSERT_VALUES,Ul); CHKERRQ(ierr);
 
-  ierr = TDyMPFAOIJacobian_InternalVertices_3DMesh(Ul, A, ctx);
-  ierr = TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Ul, A, ctx);
+  ierr = TDyMPFAOIJacobian_Vertices_3DMesh(Ul, A, ctx);
 
   PetscReal dtInv = 1.0/tdy->dtime;
 

--- a/src/mpfao/3D/tdympfao3D_snes.c
+++ b/src/mpfao/3D/tdympfao3D_snes.c
@@ -90,8 +90,7 @@ PetscErrorCode TDyMPFAOSNESFunction_3DMesh(SNES snes,Vec U,Vec R,void *ctx) {
 
   PetscReal *accum_prev;
   
-  ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_Vertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(R,&r); CHKERRQ(ierr);
   ierr = VecGetArray(tdy->accumulation_prev,&accum_prev); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_snes.c
+++ b/src/mpfao/3D/tdympfao3D_snes.c
@@ -91,8 +91,7 @@ PetscErrorCode TDyMPFAOSNESFunction_3DMesh(SNES snes,Vec U,Vec R,void *ctx) {
   PetscReal *accum_prev;
   
   ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(R,&r); CHKERRQ(ierr);
   ierr = VecGetArray(tdy->accumulation_prev,&accum_prev); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -105,7 +105,7 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DM
   PetscInt ivertex;
   PetscInt dim;
   PetscInt ncells, ncells_bnd;
-  PetscInt npitf_bc, nflux_bc, nflux_in;
+  PetscInt npitf_bc, nflux_in;
   PetscInt irow;
   PetscInt cell_id_up, cell_id_dn;
   PetscReal den,fluxm,ukvr;
@@ -139,7 +139,6 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DM
     PetscInt vOffsetFace    = vertices->face_offset[ivertex];
 
     npitf_bc = vertices->num_boundary_cells[ivertex];
-    nflux_bc = npitf_bc/2;
 
     switch (ncells) {
     case 2:
@@ -154,8 +153,8 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DM
     }
 
     // Compute T*P
-    PetscScalar TtimesP[nflux_in + 2*nflux_bc];
-    for (irow=0; irow<nflux_in + 2*nflux_bc; irow++) {
+    PetscScalar TtimesP[nflux_in + npitf_bc];
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
 
       PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
@@ -534,7 +533,7 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
   TDy_vertex *vertices;
   DM dm;
   PetscInt ncells, ncells_bnd;
-  PetscInt npitf_bc, nflux_bc, nflux_in;
+  PetscInt npitf_bc, nflux_in;
   PetscInt fStart, fEnd;
   TDy_subcell    *subcells;
   PetscInt dim;
@@ -582,7 +581,6 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
     PetscInt vOffsetFace    = vertices->face_offset[ivertex];
 
     npitf_bc = vertices->num_boundary_cells[ivertex];
-    nflux_bc = npitf_bc/2;
 
     switch (ncells) {
     case 2:
@@ -622,8 +620,8 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
     }
     
     // Compute T*P
-    PetscScalar TtimesP[nflux_in + 2*nflux_bc];
-    for (irow=0; irow<nflux_in + 2*nflux_bc; irow++) {
+    PetscScalar TtimesP[nflux_in + npitf_bc];
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
 
       PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
@@ -634,7 +632,7 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
       if (fabs(TtimesP[irow])<PETSC_MACHINE_EPSILON) TtimesP[irow] = 0.0;
     }
 
-    for (irow=0; irow<nflux_in + 2*nflux_bc; irow++) {
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
 
       PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -59,18 +59,15 @@ PetscErrorCode TDyMPFAOIFunction_InternalVertices_3DMesh(Vec Ul, Vec R, void *ct
 
       TtimesP[irow] = TtimesP_vec_ptr[face_id*num_subfaces + subface_id];
       if (fabs(TtimesP[irow])<PETSC_MACHINE_EPSILON) TtimesP[irow] = 0.0;
-    }
 
-    //
-    // fluxm_ij = rho_ij * (kr/mu)_{ij,upwind} * [ T ] *  [ P+rho*g*z ]^T
-    // where
-    //      rho_ij = 0.5*(rho_i + rho_j)
-    //      (kr/mu)_{ij,upwind} = (kr/mu)_{i} if velocity is from i to j
-    //                          = (kr/mu)_{j} otherwise
-    //      T includes product of K and A_{ij}
-    for (irow=0; irow<nflux_in; irow++) {
-      
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+       //
+       // fluxm_ij = rho_ij * (kr/mu)_{ij,upwind} * [ T ] *  [ P+rho*g*z ]^T
+       // where
+       //      rho_ij = 0.5*(rho_i + rho_j)
+       //      (kr/mu)_{ij,upwind} = (kr/mu)_{i} if velocity is from i to j
+       //                          = (kr/mu)_{j} otherwise
+       //      T includes product of K and A_{ij}
+
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       cell_id_up = faces->cell_ids[fOffsetCell + 0];
@@ -167,11 +164,7 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DM
       TtimesP[irow] = TtimesP_vec_ptr[face_id*num_subfaces + subface_id];
 
       if (fabs(TtimesP[irow])<PETSC_MACHINE_EPSILON) TtimesP[irow] = 0.0;
-    }
 
-    for (irow=0; irow<nflux_in + 2*nflux_bc; irow++) {
-
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       if (!faces->is_local[face_id]) continue;
@@ -225,7 +218,7 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_
   PetscInt dim;
   TDy_subcell    *subcells;
   PetscInt irow;
-  PetscInt isubcell, iface;
+  PetscInt isubcell;
   PetscInt cell_id_up, cell_id_dn, cell_id;
   PetscReal den,fluxm,ukvr;
   PetscReal *TtimesP_vec_ptr;
@@ -280,18 +273,14 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_
 
       TtimesP[irow] = TtimesP_vec_ptr[face_id*num_subfaces + subface_id];
       if (fabs(TtimesP[irow])<PETSC_MACHINE_EPSILON) TtimesP[irow] = 0.0;
-    }
 
-    for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
-
-      PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       cell_id_up = faces->cell_ids[fOffsetCell + 0];
       cell_id_dn = faces->cell_ids[fOffsetCell + 1];
 
 
-      if (TtimesP[iface] < 0.0) { // up ---> dn
+      if (TtimesP[irow] < 0.0) { // up ---> dn
         if (cell_id_up>=0) ukvr = tdy->Kr[cell_id_up]/tdy->vis[cell_id_up];
         else               ukvr = tdy->Kr_BND[-cell_id_up-1]/tdy->vis_BND[-cell_id_up-1];
       } else {

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -139,18 +139,7 @@ PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DM
     PetscInt vOffsetFace    = vertices->face_offset[ivertex];
 
     npitf_bc = vertices->num_boundary_cells[ivertex];
-
-    switch (ncells) {
-    case 2:
-      nflux_in = 1;
-      break;
-    case 4:
-      nflux_in = 4;
-      break;
-    default:
-      SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, "Unsupported number of internal cells.");
-      break;
-    }
+    nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_cells[ivertex];
 
     // Compute T*P
     PetscScalar TtimesP[nflux_in + npitf_bc];

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -172,7 +172,7 @@ PetscErrorCode TDyMPFAOIFunction_3DMesh(TS ts,PetscReal t,Vec U,Vec U_t,Vec R,vo
 }
 
 /* -------------------------------------------------------------------------- */
-PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec Ul, Mat A, void *ctx) {
+PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
 
   TDy tdy = (TDy)ctx;
   TDy_mesh *mesh;
@@ -181,6 +181,7 @@ PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec Ul, Mat A, void *ct
   TDy_vertex *vertices;
   DM dm;
   PetscInt ivertex, vertex_id;
+  PetscInt npitf_bc, nflux_in;
   PetscInt cell_id, cell_id_up, cell_id_dn;
   PetscInt irow, icol;
   PetscInt dim;
@@ -211,16 +212,17 @@ PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec Ul, Mat A, void *ct
 
     vertex_id = ivertex;
 
-    if (vertices->num_boundary_cells[ivertex] != 0) continue;
+    if (vertices->num_boundary_cells[ivertex] > 0 && vertices->num_internal_cells[ivertex] < 2) continue;
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
     PetscInt vOffsetFace    = vertices->face_offset[ivertex];
 
-    PetscInt nflux_in = vertices->num_faces[ivertex];
-    PetscScalar TtimesP[nflux_in];
+    npitf_bc = vertices->num_boundary_cells[ivertex];
+    nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_cells[ivertex];
 
-    // Compute = T*P
-    for (irow=0; irow<nflux_in; irow++) {
+    // Compute T*P
+    PetscScalar TtimesP[nflux_in + npitf_bc];
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
       PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
@@ -248,7 +250,7 @@ PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec Ul, Mat A, void *ct
     // For k not equal to i and j, jacobian is given as:
     // d(fluxm_ij)/dP_k =   rho_ij       + (kr/mu)_{ij,upwind}         *   T_ik  *  (1+d(rho_k)/dP_k*g*z
     //
-    for (irow=0; irow<nflux_in; irow++) {
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
       PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
@@ -256,153 +258,6 @@ PetscErrorCode TDyMPFAOIJacobian_InternalVertices_3DMesh(Vec Ul, Mat A, void *ct
       cell_id_up = faces->cell_ids[fOffsetCell + 0];
       cell_id_dn = faces->cell_ids[fOffsetCell + 1];
       
-      dukvr_dPup = 0.0;
-      dukvr_dPdn = 0.0;
-
-      if (TtimesP[irow] < 0.0) {
-        ukvr       = tdy->Kr[cell_id_up]/tdy->vis[cell_id_up];
-        dukvr_dPup = tdy->dKr_dS[cell_id_up]*tdy->dS_dP[cell_id_up]/tdy->vis[cell_id_up] -
-                     tdy->Kr[cell_id_up]/(tdy->vis[cell_id_up]*tdy->vis[cell_id_up])*tdy->dvis_dP[cell_id_up];
-      } else {
-        ukvr       = tdy->Kr[cell_id_dn]/tdy->vis[cell_id_dn];
-        dukvr_dPdn = tdy->dKr_dS[cell_id_dn]*tdy->dS_dP[cell_id_dn]/tdy->vis[cell_id_dn] -
-                     tdy->Kr[cell_id_dn]/(tdy->vis[cell_id_dn]*tdy->vis[cell_id_dn])*tdy->dvis_dP[cell_id_dn];
-      }
-
-      den = 0.5*(tdy->rho[cell_id_up] + tdy->rho[cell_id_dn]);
-      dden_dPup = 0.5*tdy->drho_dP[cell_id_up];
-      dden_dPdn = 0.5*tdy->drho_dP[cell_id_dn];
-
-      for (icol=0; icol<vertices->num_internal_cells[ivertex]; icol++) {
-        cell_id = vertices->internal_cell_ids[vOffsetCell + icol];
-        
-        T = tdy->Trans[vertex_id][irow][icol];
-        
-        ierr = ComputeGtimesZ(tdy->gravity,cells->centroid[cell_id].X,dim,&gz); CHKERRQ(ierr);
-
-        if (cell_id == cell_id_up) {
-          Jac =
-            dden_dPup * ukvr       * TtimesP[irow] +
-            den       * dukvr_dPup * TtimesP[irow] +
-            den       * ukvr       * T * (1.0 + dden_dPup*gz) ;
-        } else if (cell_id == cell_id_dn) {
-          Jac =
-            dden_dPdn * ukvr       * TtimesP[irow] +
-            den       * dukvr_dPdn * TtimesP[irow] +
-            den       * ukvr       * T * (1.0 + dden_dPdn*gz) ;
-        } else {
-          Jac = den * ukvr * T * (1.0 + 0.*gz);
-        }
-        if (fabs(Jac)<PETSC_MACHINE_EPSILON) Jac = 0.0;
-
-        // Changing sign when bringing the term from RHS to LHS of the equation
-        Jac = -Jac;
-
-        if (cells->is_local[cell_id_up]) {
-          ierr = MatSetValuesLocal(A,1,&cell_id_up,1,&cell_id,&Jac,ADD_VALUES);CHKERRQ(ierr);
-        }
-
-        if (cells->is_local[cell_id_dn]) {
-          Jac = -Jac;
-          ierr = MatSetValuesLocal(A,1,&cell_id_dn,1,&cell_id,&Jac,ADD_VALUES);CHKERRQ(ierr);
-        }
-      }
-    }
-  }
-
-  ierr = VecRestoreArray(Ul,&p); CHKERRQ(ierr);
-  ierr = VecRestoreArray(tdy->TtimesP_vec,&TtimesP_vec_ptr); CHKERRQ(ierr);
-
-  ierr = MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-
-  PetscFunctionReturn(0);
-}
-
-/* -------------------------------------------------------------------------- */
-
-PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Vec Ul, Mat A, void *ctx) {
-
-  TDy tdy = (TDy)ctx;
-  TDy_mesh *mesh;
-  TDy_cell *cells;
-  TDy_face *faces;
-  TDy_vertex *vertices;
-  DM dm;
-  PetscInt ncells, ncells_bnd;
-  PetscInt npitf_bc, nflux_in;
-  PetscInt fStart, fEnd;
-  TDy_subcell    *subcells;
-  PetscInt dim;
-  PetscInt icell, ivertex;
-  PetscInt cell_id, cell_id_up, cell_id_dn, vertex_id;
-  PetscInt irow, icol;
-  PetscReal T;
-  PetscReal ukvr, den;
-  PetscReal dukvr_dPup, dukvr_dPdn, Jac;
-  PetscReal dden_dPup, dden_dPdn;
-  PetscReal *p;
-  PetscReal gz;
-  PetscScalar *TtimesP_vec_ptr;
-  PetscErrorCode ierr;
-
-  PetscFunctionBegin;
-
-  mesh     = tdy->mesh;
-  cells    = &mesh->cells;
-  faces    = &mesh->faces;
-  vertices = &mesh->vertices;
-  subcells = &mesh->subcells;
-  dm       = tdy->dm;
-
-  ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
-
-  ierr = VecGetArray(Ul,&p); CHKERRQ(ierr);
-  ierr = VecGetArray(tdy->TtimesP_vec,&TtimesP_vec_ptr); CHKERRQ(ierr);
-
-  ierr = DMPlexGetDepthStratum( dm, 2, &fStart, &fEnd); CHKERRQ(ierr);
-
-  for (ivertex=0; ivertex<mesh->num_vertices; ivertex++) {
-
-    vertex_id = ivertex;
-
-    ncells    = vertices->num_internal_cells[ivertex];
-    ncells_bnd= vertices->num_boundary_cells[ivertex];
-
-    if (ncells_bnd == 0) continue;
-    if (ncells     <  2) continue;
-    if (!vertices->is_local[ivertex]) continue;
-
-    PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
-    PetscInt vOffsetSubcell = vertices->subcell_offset[ivertex];
-    PetscInt vOffsetFace    = vertices->face_offset[ivertex];
-
-    npitf_bc = vertices->num_boundary_cells[ivertex];
-    nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_cells[ivertex];
-
-    // Compute T*P
-    PetscScalar TtimesP[nflux_in + npitf_bc];
-    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
-
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
-      PetscInt num_subfaces = 4;
-
-      TtimesP[irow] = TtimesP_vec_ptr[face_id*num_subfaces + subface_id];
-
-      if (fabs(TtimesP[irow])<PETSC_MACHINE_EPSILON) TtimesP[irow] = 0.0;
-    }
-
-    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
-
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
-
-      if (!faces->is_local[face_id]) continue;
-
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
-
       dukvr_dPup = 0.0;
       dukvr_dPdn = 0.0;
 
@@ -440,6 +295,7 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
       else               den += tdy->rho_BND[-cell_id_dn-1];
       den *= 0.5;
 
+      // If one of the cell is on the boundary
       if (cell_id_up<0) cell_id_up = cell_id_dn;
       if (cell_id_dn<0) cell_id_dn = cell_id_up;
 
@@ -449,7 +305,6 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
       if (cell_id_up>=0) dden_dPup = 0.5*tdy->drho_dP[cell_id_up];
       if (cell_id_dn>=0) dden_dPdn = 0.5*tdy->drho_dP[cell_id_dn];
 
-      // Deriviates will be computed only w.r.t. internal pressure
       for (icol=0; icol<vertices->num_internal_cells[ivertex]; icol++) {
         cell_id = vertices->internal_cell_ids[vOffsetCell + icol];
         
@@ -475,17 +330,18 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
         // Changing sign when bringing the term from RHS to LHS of the equation
         Jac = -Jac;
 
-        if (cell_id_up >-1 && cells->is_local[cell_id_up]) {
+        if (cells->is_local[cell_id_up]) {
           ierr = MatSetValuesLocal(A,1,&cell_id_up,1,&cell_id,&Jac,ADD_VALUES);CHKERRQ(ierr);
         }
 
-        if (cell_id_dn >-1 && cells->is_local[cell_id_dn]) {
+        if (cells->is_local[cell_id_dn]) {
           Jac = -Jac;
           ierr = MatSetValuesLocal(A,1,&cell_id_dn,1,&cell_id,&Jac,ADD_VALUES);CHKERRQ(ierr);
         }
       }
     }
   }
+
   ierr = VecRestoreArray(Ul,&p); CHKERRQ(ierr);
   ierr = VecRestoreArray(tdy->TtimesP_vec,&TtimesP_vec_ptr); CHKERRQ(ierr);
 
@@ -496,7 +352,7 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
 }
 
 /* -------------------------------------------------------------------------- */
-
+/*
 PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Vec Ul, Mat A, void *ctx) {
 
   TDy tdy = (TDy)ctx;
@@ -674,6 +530,7 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_
 
   PetscFunctionReturn(0);
 }
+*/
 
 /* -------------------------------------------------------------------------- */
 PetscErrorCode TDyMPFAOIJacobian_Accumulation_3DMesh(Vec Ul,Vec Udotl,PetscReal shift,Mat A,void *ctx) {
@@ -756,8 +613,7 @@ PetscErrorCode TDyMPFAOIJacobian_3DMesh(TS ts,PetscReal t,Vec U,Vec U_t,PetscRea
   ierr = DMGlobalToLocalBegin(dm,U_t,INSERT_VALUES,Udotl); CHKERRQ(ierr);
   ierr = DMGlobalToLocalEnd  (dm,U_t,INSERT_VALUES,Udotl); CHKERRQ(ierr);
 
-  ierr = TDyMPFAOIJacobian_InternalVertices_3DMesh(Ul, A, ctx);
-  ierr = TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DMesh(Ul, A, ctx);
+  ierr = TDyMPFAOIJacobian_Vertices_3DMesh(Ul, A, ctx);
   //ierr = TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Ul, A, ctx);
   ierr = TDyMPFAOIJacobian_Accumulation_3DMesh(Ul, Udotl, shift, A, ctx);
 

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -378,44 +378,8 @@ PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_3DM
     PetscInt vOffsetFace    = vertices->face_offset[ivertex];
 
     npitf_bc = vertices->num_boundary_cells[ivertex];
+    nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_cells[ivertex];
 
-    switch (ncells) {
-    case 2:
-      nflux_in = 1;
-      break;
-    case 4:
-      nflux_in = 4;
-      break;
-    default:
-      SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, "Unsupported number of internal cells.");
-      break;
-    }
-
-    PetscInt numBoundary;
-    
-    // For boundary edges, save following information:
-    //  - Dirichlet pressure value
-    numBoundary = 0;
-
-    for (irow=0; irow<ncells; irow++){
-      icell = vertices->internal_cell_ids[vOffsetCell + irow];
-      PetscInt isubcell = vertices->subcell_ids[vOffsetSubcell + irow];
-
-      PetscInt subcell_id = icell*cells->num_subcells[icell]+isubcell;
-      PetscInt sOffsetFace = subcells->face_offset[subcell_id];
-
-      PetscInt iface;
-      for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
-
-        PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
-
-        if (faces->is_internal[face_id] == 0) {
-
-          numBoundary++;
-        }
-      }
-    }
-    
     // Compute T*P
     PetscScalar TtimesP[nflux_in + npitf_bc];
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {

--- a/src/mpfao/3D/tdympfao3D_ts_dae.c
+++ b/src/mpfao/3D/tdympfao3D_ts_dae.c
@@ -51,8 +51,7 @@ PetscErrorCode TDyMPFAOIFunction_DAE_3DMesh(TS ts,PetscReal t,Vec U,Vec U_t,Vec 
   ierr = MatMult(tdy->Trans_mat, tdy->P_vec, tdy->TtimesP_vec);
 
   ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(M,&m); CHKERRQ(ierr);
   ierr = VecGetArray(U_t,&u_t); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_ts_dae.c
+++ b/src/mpfao/3D/tdympfao3D_ts_dae.c
@@ -50,8 +50,7 @@ PetscErrorCode TDyMPFAOIFunction_DAE_3DMesh(TS ts,PetscReal t,Vec U,Vec U_t,Vec 
   ierr = TDyUpdateBoundaryState(tdy); CHKERRQ(ierr);
   ierr = MatMult(tdy->Trans_mat, tdy->P_vec, tdy->TtimesP_vec);
 
-  ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_Vertices_3DMesh(P,R_P,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(M,&m); CHKERRQ(ierr);
   ierr = VecGetArray(U_t,&u_t); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_ts_transientvar.c
+++ b/src/mpfao/3D/tdympfao3D_ts_transientvar.c
@@ -89,8 +89,7 @@ PetscErrorCode TDyMPFAOIFunction_TransientVariable_3DMesh(TS ts,PetscReal t,Vec 
   ierr = MatMult(tdy->Trans_mat, tdy->P_vec, tdy->TtimesP_vec);
 
   ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(M_t,&dm_dt); CHKERRQ(ierr);
   ierr = VecGetArray(R,&r); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_ts_transientvar.c
+++ b/src/mpfao/3D/tdympfao3D_ts_transientvar.c
@@ -88,8 +88,7 @@ PetscErrorCode TDyMPFAOIFunction_TransientVariable_3DMesh(TS ts,PetscReal t,Vec 
   ierr = TDyUpdateBoundaryState(tdy); CHKERRQ(ierr);
   ierr = MatMult(tdy->Trans_mat, tdy->P_vec, tdy->TtimesP_vec);
 
-  ierr = TDyMPFAOIFunction_InternalVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
-  ierr = TDyMPFAOIFunction_BoundaryVertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
+  ierr = TDyMPFAOIFunction_Vertices_3DMesh(Ul,R,ctx); CHKERRQ(ierr);
 
   ierr = VecGetArray(M_t,&dm_dt); CHKERRQ(ierr);
   ierr = VecGetArray(R,&r); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -739,7 +739,6 @@ PetscErrorCode TDyMPFAO_SetBoundaryPressure(TDy tdy, Vec Ul) {
 PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
 
   TDy_mesh *mesh;
-  TDy_cell *cells;
   TDy_face *faces;
   PetscErrorCode ierr;
   PetscInt dim, ncells;
@@ -760,7 +759,6 @@ PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
   }
 
   mesh = tdy->mesh;
-  cells = &mesh->cells;
   faces = &mesh->faces;
   ncells = mesh->num_cells;
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -292,7 +292,6 @@ PetscErrorCode TDyGetCentroidArray(TDy tdy,PetscReal **X) {
 PetscErrorCode TDyResetDiscretizationMethod(TDy tdy) {
   PetscErrorCode ierr;
   PetscInt       dim;
-  PetscInt       nrow,ncol,nsubcells;
 
   PetscFunctionBegin;
   PetscValidPointer(tdy,1);
@@ -308,19 +307,12 @@ PetscErrorCode TDyResetDiscretizationMethod(TDy tdy) {
   if (tdy->LtoG  ) { ierr = PetscFree(tdy->LtoG  ); CHKERRQ(ierr); }
   if (tdy->orient) { ierr = PetscFree(tdy->orient); CHKERRQ(ierr); }
   if (tdy->quad  ) { ierr = PetscQuadratureDestroy(&(tdy->quad)); CHKERRQ(ierr); }
+
   // Need call to destroy TDy_Mesh
   switch (dim) {
   case 2:
-    nsubcells = 4;
-    nrow = 2;
-    ncol = 2;
-
     break;
   case 3:
-    nsubcells = 8;
-    nrow = 3;
-    ncol = 3;
-
     break;
   default:
     SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"Unsupported dim in TDyResetDiscretizationMethod");


### PR DESCRIPTION
Three IFunctions for residual computation that were previously separated by 
type of vertex (e.g. internal vertex, boundary vertex that is shared by an internal 
vertex or boundary vertex that is not shared by an internal vertex) are replaced by
a single function.

The two IJacobian functions for internal and boundary vertex shared by an internal
vertex are replaced by a single function.

The IJacobina function for boundary vertex not shared by an internal vertex is commented
out as it is not called from any other function.