### PR TITLE
Enable testing from top-level makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,11 @@
+# Default target
+all :
+	+@$(MAKE) -f makefile --no-print-directory $@
+
+ifeq ($(firstword $(sort 4.1.99 $(MAKE_VERSION))),4.1.99)
+include gmakefile
+endif
+
+# For any target that doesn't exist in gmakefile, use the legacy makefile (which has the logging features)
+% :
+	+@$(MAKE) -f makefile --no-print-directory $@

--- a/demo/SPE10/makefile
+++ b/demo/SPE10/makefile
@@ -15,6 +15,6 @@ TDYCORE_DIR ?= $(topdir)
 include $(TDYCORE_DIR)/lib/tdycore/conf/variables
 include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 
-steady: steady.o chkopts
+steady: steady.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<

--- a/demo/mpfao/makefile
+++ b/demo/mpfao/makefile
@@ -23,7 +23,7 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 build:
 	@cd ../; make
 
-mpfao: mpfao.o chkopts
+mpfao: mpfao.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 

--- a/demo/steady/makefile
+++ b/demo/steady/makefile
@@ -23,6 +23,6 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 build:
 	@cd ../../; make
 
-steady: steady.o chkopts
+steady: steady.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<

--- a/demo/steadyblock/makefile
+++ b/demo/steadyblock/makefile
@@ -23,6 +23,6 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 build:
 	@cd ../../; make
 
-steadyblock: steadyblock.o chkopts
+steadyblock: steadyblock.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<

--- a/demo/steadyf90/makefile
+++ b/demo/steadyf90/makefile
@@ -23,6 +23,6 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 build:
 	@cd ../; make
 
-steadyf90: steadyf90.o chkopts
+steadyf90: steadyf90.o
 	$(FLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -1,4 +1,4 @@
-module f90module
+module steadyf90mod
 
   use tdycore
 #include <petsc/finclude/petsc.h>
@@ -111,7 +111,7 @@ contains
 
   end subroutine ForcingFunction
 
-end module f90module
+end module steadyf90mod
 
 program main
 
@@ -123,7 +123,7 @@ program main
   use petscvec
   use petscdm
   use petscksp
-  use f90module
+  use steadyf90mod
 
   implicit none
 

--- a/demo/transient/makefile
+++ b/demo/transient/makefile
@@ -23,23 +23,23 @@ include $(TDYCORE_DIR)/lib/tdycore/conf/rules
 build:
 	@cd ../; make
 
-transient: transient.o chkopts
+transient: transient.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 
-transient_mpfao: transient_mpfao.o chkopts
+transient_mpfao: transient_mpfao.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 
-transient_th_mpfao: transient_th_mpfao.o chkopts
+transient_th_mpfao: transient_th_mpfao.o
 	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 
-transient_mpfaof90: transient_mpfaof90.o chkopts
+transient_mpfaof90: transient_mpfaof90.o
 	$(FLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 
-transient_snes_mpfaof90: transient_snes_mpfaof90.o chkopts
+transient_snes_mpfaof90: transient_snes_mpfaof90.o
 	$(FLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
 	$(RM) -f $<
 

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -1,4 +1,4 @@
-module f90module
+module mpfaof90mod
 
   use tdycore
 #include <petsc/finclude/petsc.h>
@@ -39,7 +39,7 @@ contains
       ierr = 0
   end subroutine PermeabilityFunction
 
-end module f90module
+end module mpfaof90mod
 
 program main
 
@@ -52,7 +52,7 @@ program main
   use petscdm
   use petscksp
   use petscts
-  use f90module
+  use mpfaof90mod
 
 implicit none
 

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -1,4 +1,4 @@
-module f90module
+module snes_mpfaof90mod
 
   use tdycore
 #include <petsc/finclude/petsc.h>
@@ -39,7 +39,7 @@ contains
       ierr = 0
   end subroutine PermeabilityFunction
 
-end module f90module
+end module snes_mpfaof90mod
 
 program main
 
@@ -52,7 +52,7 @@ program main
   use petscdm
   use petscksp
   use petscsnes
-  use f90module
+  use snes_mpfaof90mod
 
 implicit none
 

--- a/gmakefile
+++ b/gmakefile
@@ -44,7 +44,7 @@ else                   # Show the full command line
 endif
 
 pcc = $(if $(findstring CONLY,$(PETSC_LANGUAGE)),CC,CXX)
-COMPILE.cc = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
+COMPILE.c = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
 COMPILE.cxx = $(call quiet,CXX) $(CXX_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(CXX_DEPFLAGS) -c
 ifneq ($(FC_MODULE_OUTPUT_FLAG),)
 COMPILE.fc = $(call quiet,FC) $(FC_FLAGS) $(FFLAGS) $(FCPPFLAGS) $(FC_DEPFLAGS) $(FC_MODULE_OUTPUT_FLAG)$(MODDIR) -c
@@ -81,7 +81,7 @@ else
 endif
 
 $(OBJDIR)/%.o : %.c | $$(@D)/.DIR
-	$(COMPILE.cc) $(abspath $<) -o $@
+	$(COMPILE.c) $(abspath $<) -o $@
 
 $(OBJDIR)/%.o : %.cxx | $$(@D)/.DIR
 	$(COMPILE.cxx) $(abspath $<) -o $@

--- a/gmakefile
+++ b/gmakefile
@@ -107,7 +107,8 @@ $(TEST.c:%.c=%.o) : %.o : %.c
 $(TEST.c:%.c=%) : demo/% : demo/%.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -o $@ $^ $(TDYCORE_LIB) $(LIBS)
 
-$(TEST.F90:%.F90=%.o) : %.o : %.F90 | $$(@D)/.DIR $(MODDIR)/.DIR
+$(TEST.F90:%.F90=%.o) : MODDIR = $(PETSC_ARCH)/obj/demo-modules
+$(TEST.F90:%.F90=%.o) : %.o : %.F90 $(libtdycore) | $$(@D)/.DIR $$(MODDIR)/.DIR
 	$(COMPILE.fc) $(abspath $<) -o $(if $(FCMOD),$(abspath $@),$@)
 
 $(TEST.F90:%.F90=%) : demo/% : demo/%.o $$^ $(libtdycore)

--- a/gmakefile
+++ b/gmakefile
@@ -88,6 +88,31 @@ $(OBJDIR)/%.o : %.cxx | $$(@D)/.DIR
 $(OBJDIR)/%.o : %.F90 | $$(@D)/.DIR $(MODDIR)/.DIR
 	$(COMPILE.fc) $(abspath $<) -o $(if $(FCMOD),$(abspath $@),$@)
 
+TEST.c = \
+	demo/steady/steady.c \
+	demo/transient/transient.c \
+	demo/transient/transient_mpfao.c \
+	demo/mpfao/mpfao.c \
+#	demo/transient/transient_th_mpfao.c \
+
+TEST.F90 = \
+	demo/steadyf90/steadyf90.F90 \
+	demo/transient/transient_mpfaof90.F90 \
+	demo/transient/transient_snes_mpfaof90.F90
+
+# Demo executables
+$(TEST.c:%.c=%.o) : %.o : %.c
+	$(COMPILE.c) $(abspath $<) -o $@
+
+$(TEST.c:%.c=%) : demo/% : demo/%.o $$^ $(libtdycore)
+	$(call quiet,CLINKER) -o $@ $^ $(TDYCORE_LIB) $(LIBS)
+
+$(TEST.F90:%.F90=%.o) : %.o : %.F90 | $$(@D)/.DIR $(MODDIR)/.DIR
+	$(COMPILE.fc) $(abspath $<) -o $(if $(FCMOD),$(abspath $@),$@)
+
+$(TEST.F90:%.F90=%) : demo/% : demo/%.o $$^ $(libtdycore)
+	$(call quiet,FLINKER) -o $@ $^ $(TDYCORE_LIB) $(LIBS)
+
 # Hack: manual dependencies on object files
 tdycore.mod.o:= $(OBJDIR)/src/tdycore.o
 srcs-tdycore.F90.o = $(srcs-tdycore.F90:%.F90=$(OBJDIR)/%.o)
@@ -104,6 +129,19 @@ $(filter-out $(tdycore.mod.o),$(srcs-tdycore.F90.o)): | $(tdycore.mod.o)
 
 clean:
 	@$(RM) -r $(OBJDIR) $(LIBDIR)/libtdycore.* $(MODDIR)/tdycore.mod
+
+testname = test-$(subst _,-,$(basename $(notdir $(1))))
+ALLTESTS = $(foreach path,$(TEST.c) $(TEST.F90),$(call testname,$(path)))
+# Set target-specific variables for each test
+define target_specific_var
+  $(call testname,$(1)) : DEMO_EXE = $(basename $(1))
+endef
+$(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(demo_src))))
+
+$(ALLTESTS) : test-% : $$(DEMO_EXE)
+	+@$(MAKE) -C regression_tests $@
+
+test : $(ALLTESTS)
 
 # make print VAR=the-variable
 print : ; @echo $($(VAR))

--- a/gmakefile
+++ b/gmakefile
@@ -2,7 +2,6 @@
 
 TDYCORE_DIR ?= $(CURDIR)
 include ./lib/tdycore/conf/variables
--include makefile.in
 
 OBJDIR := $(PETSC_ARCH)/obj
 MODDIR := $(PETSC_ARCH)/include

--- a/makefile
+++ b/makefile
@@ -15,8 +15,6 @@ FPPFLAGS = ${MYFLAGS}
 
 TDYCORE_DIR ?= $(CURDIR)
 include ${TDYCORE_DIR}/lib/tdycore/conf/variables
-include ${TDYCORE_DIR}/lib/tdycore/conf/rules
-include ${TDYCORE_DIR}/lib/tdycore/conf/test
 
 all:
 	@if [ "${MAKE_IS_GNUMAKE}" != "" ]; then \

--- a/regression_tests/Makefile
+++ b/regression_tests/Makefile
@@ -7,8 +7,6 @@
 # command line with: make PYTHON=python3.3 test
 
 include ${PETSC_DIR}/lib/petsc/conf/variables
-include ${PETSC_DIR}/lib/petsc/conf/rules
-
 
 TEST_MANAGER = regression_tests.py
 

--- a/regression_tests/regression_tests.py
+++ b/regression_tests/regression_tests.py
@@ -1800,6 +1800,14 @@ def check_options(options):
         raise RuntimeError("ERROR: can not create new tests and update gold "
                            "regression files at the same time.")
 
+def get_test_info_file(dir):
+    """
+    Create a unique temporary test-info file path.
+    """
+    import tempfile
+    fd, path = tempfile.mkstemp(dir=dir, prefix="tmp-executable-regression-test-info.", suffix=".txt")
+    os.close(fd)
+    return path
 
 def check_for_executable(options):
     """
@@ -1846,7 +1854,7 @@ def check_for_mpiexec(options, testlog):
         # try to log some info about mpiexec
         print("MPI information :", file=testlog)
         print("-----------------", file=testlog)
-        tempfile = "{0}/tmp-executable-regression-test-info.txt".format(os.getcwd())
+        tempfile = get_test_info_file(os.getcwd())
         command = shlex.split(mpiexec) + ["--version"]
         append_command_to_log(command, testlog, tempfile)
         print("\n\n", file=testlog)
@@ -1980,7 +1988,7 @@ def setup_testlog(txtwrap,logfile_prefix):
 
     git_found = which('git')
 
-    tempfile = "{0}/tmp-executable-regression-test-info.txt".format(test_dir)
+    tempfile = get_test_info_file(test_dir)
 
     print("\nRepository status :", file=testlog)
     print("----------------------------", file=testlog)


### PR DESCRIPTION
You can now run

    make -j4 test

to run the full test suite in parallel, rebuilding library and demos as needed. Or

    make -j4 test-steady

to run any single test, also rebuilding (in parallel) anything that's needed. Use `make print-ALLTESTS` to list all options.

We could remove pretty much all the other makefiles, but I've left them intact for now. We could also place the compiled demos into `PETSC_ARCH`, which I've also skipped to avoid disrupting a workflow that moves into the demo directory.