### PR TITLE
Refactors creation of DM

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
 
   /* Setup problem parameters */
   TDy  tdy;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
   ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
   ierr = ReadSPE10Permeability(tdy,ang); CHKERRQ(ierr);
@@ -167,7 +167,6 @@ int main(int argc, char **argv) {
   ierr = VecDestroy(&F); CHKERRQ(ierr);
   ierr = MatDestroy(&K); CHKERRQ(ierr);
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);
   return(0);
 }

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -1,4 +1,5 @@
 #include "tdycore.h"
+#include "tdydm.h"
 
 PetscReal alpha = 1;
 
@@ -192,61 +193,38 @@ PetscErrorCode PerturbInteriorVertices(DM dm,PetscReal h) {
 int main(int argc, char **argv) {
   /* Initialize */
   PetscErrorCode ierr;
-  PetscInt N = 8, dim = 2, problem = 3;
+  PetscInt problem = 3;
   PetscInt successful_exit_code=0;
+  PetscReal perturbation = 0.;
   PetscBool perturb = PETSC_FALSE;
-  char      mesh_filename[PETSC_MAX_PATH_LEN];
 
   ierr = PetscInitialize(&argc,&argv,(char *)0,0); CHKERRQ(ierr);
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
   CHKERRQ(ierr);
-  ierr = PetscOptionsInt ("-dim","Problem dimension","",dim,&dim,NULL);
-  CHKERRQ(ierr);
-  ierr = PetscOptionsInt ("-N","Number of elements in 1D","",N,&N,NULL);
-  CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-problem","Problem number","",problem,&problem,NULL);
   CHKERRQ(ierr);
-  ierr = PetscOptionsBool("-perturb","Perturb interior vertices","",perturb,
-                          &perturb,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-perturb","Perturb interior vertices","",
+                          perturbation,&perturbation,&perturb); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-alpha","Permeability scaling","",alpha,&alpha,NULL);
   CHKERRQ(ierr);
-  ierr = PetscOptionsInt("-successful_exit_code","Code passed on successful completion","",
+  ierr = PetscOptionsInt("-successful_exit_code",
+                         "Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
-  ierr = PetscOptionsString("-mesh_filename", "The mesh file", "", mesh_filename, mesh_filename, PETSC_MAX_PATH_LEN, NULL); CHKERRQ(ierr);
-
    ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
   /* Create and distribute the mesh */
-  DM dm, dmDist = NULL;
-  size_t len;
-
-  ierr = PetscStrlen(mesh_filename, &len); CHKERRQ(ierr);
-  if (!len){
-    const PetscInt  faces[3] = {N,N,N  };
-    const PetscReal lower[3] = {0.0,0.0,0.0};
-    const PetscReal upper[3] = {1.0,1.0,1.0};
-
-    ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD,dim,PETSC_FALSE,faces,lower,upper,
-                               NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
-    if (perturb) {
-      ierr = PerturbInteriorVertices(dm,1./N); CHKERRQ(ierr);
-    } else {
-      ierr = PerturbInteriorVertices(dm,0.); CHKERRQ(ierr);
-    }
-  } else {
-    ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, mesh_filename, PETSC_TRUE, &dm); CHKERRQ(ierr);
-  }
-
-  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
-  if (dmDist) {DMDestroy(&dm); dm = dmDist;}
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
+  DM dm;
+  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+  if (perturb) {ierr = PerturbInteriorVertices(dm,perturbation); CHKERRQ(ierr);}
+  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
 
   // Setup problem parameters
   TDy  tdy;
   PetscReal gravity[3];
 
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
+  PetscInt dim;
+  ierr = TDyGetDimension(tdy,&dim); CHKERRQ(ierr);
 
   gravity[0] = 0.0; gravity[1] = 0.0; gravity[2] = 0.0;
   ierr = TDySetGravityVector(tdy,gravity);

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -296,7 +296,6 @@ int main(int argc, char **argv) {
   ierr = VecDestroy(&F); CHKERRQ(ierr);
   ierr = MatDestroy(&K); CHKERRQ(ierr);
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm);CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);
 
   return(successful_exit_code);

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -625,7 +625,7 @@ int main(int argc, char **argv) {
 
   /* Setup problem parameters */
   TDy  tdy;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
 
   if(wheeler2006){
     if(dim != 2){
@@ -802,7 +802,6 @@ int main(int argc, char **argv) {
   ierr = VecDestroy(&F); CHKERRQ(ierr);
   ierr = MatDestroy(&K); CHKERRQ(ierr);
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);
 
   return(successful_exit_code);

--- a/demo/steadyblock/steadyblock.c
+++ b/demo/steadyblock/steadyblock.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   /* Setup problem parameters */
   printf("Creating TDycore.\n");
   TDy  tdy;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   if (dim == 1) {
     ierr = TDySetPermeabilityTensor(tdy,PermeabilityBlock1); CHKERRQ(ierr);
     switch(problem) {
@@ -224,7 +224,6 @@ int main(int argc, char **argv) {
   ierr = VecDestroy(&F); CHKERRQ(ierr);
   ierr = MatDestroy(&K); CHKERRQ(ierr);
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);
 
   printf("Done.\n");

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -172,7 +172,7 @@ program main
   CHKERRA(ierr);
   !call DMViewFromOptions(dm,PETSC_NULL_CHARACTER,'-dm_view',ierr); CHKERRA(ierr)
 
-  call TDyCreate(dm, tdy, ierr);
+  call TDyCreateWithDM(dm, tdy, ierr);
   CHKERRA(ierr);
 
   call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr);
@@ -235,9 +235,6 @@ program main
   CHKERRQ(ierr);
 
   call TDyDestroy(tdy,ierr);
-  CHKERRQ(ierr);
-
-  call DMDestroy(dm,ierr);
   CHKERRQ(ierr);
 
   call PetscFinalize(ierr)

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
 
   /* Setup problem parameters */
   TDy  tdy;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   ierr = TDySetPermeabilityScalar(tdy,Permeability); CHKERRQ(ierr);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
@@ -134,7 +134,6 @@ int main(int argc, char **argv) {
 
   /* Cleanup */
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);
   return(successful_exit_code);
 }

--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
 
   /* Setup problem parameters */
   TDy  tdy;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   //ierr = TDySetPermeabilityScalar(tdy,Permeability); CHKERRQ(ierr);
   ierr = TDySetPermeabilityFunction(tdy,PermeabilityFunction3D,NULL); CHKERRQ(ierr);
@@ -211,7 +211,6 @@ int main(int argc, char **argv) {
 
   /* Cleanup */
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFree(mass_p); CHKERRQ(ierr);
   ierr = PetscFree(pres_p); CHKERRQ(ierr);
   ierr = PetscFinalize(); CHKERRQ(ierr);

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -104,7 +104,7 @@ implicit none
   call DMSetFromOptions(dm, ierr);
   CHKERRA(ierr);
 
-  call TDyCreate(dm, tdy, ierr);
+  call TDyCreateWithDM(dm, tdy, ierr);
   CHKERRA(ierr);
 
 
@@ -214,9 +214,6 @@ implicit none
   CHKERRA(ierr);
 
   call TDyDestroy(tdy,ierr);
-  CHKERRA(ierr);
-
-  call DMDestroy(dm,ierr);
   CHKERRA(ierr);
 
   call PetscFinalize(ierr);

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -124,7 +124,7 @@ implicit none
   call DMSetFromOptions(dm, ierr);
   CHKERRA(ierr);
 
-  call TDyCreate(dm, tdy, ierr);
+  call TDyCreateWithDM(dm, tdy, ierr);
   CHKERRA(ierr);
 
   call TDySetWaterDensityType(tdy,WATER_DENSITY_EXPONENTIAL,ierr);
@@ -250,9 +250,6 @@ implicit none
   CHKERRA(ierr);
 
   call TDyDestroy(tdy,ierr);
-  CHKERRA(ierr);
-
-  call DMDestroy(dm,ierr);
   CHKERRA(ierr);
 
   call PetscFinalize(ierr);

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
   /* Setup problem parameters */
   TDy  tdy;
   TDyMode mode = TH;
-  ierr = TDyCreate(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetMode(tdy,mode); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   ierr = TDySetSpecificHeatCapacity(tdy,SpecificHeatCapacity); CHKERRQ(ierr);
@@ -306,7 +306,6 @@ int main(int argc, char **argv) {
 
   /* Cleanup */
   ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
-  ierr = DMDestroy(&dm); CHKERRQ(ierr);
   ierr = PetscFree(mass_p); CHKERRQ(ierr);
   ierr = PetscFree(pres_p); CHKERRQ(ierr);
   ierr = PetscPrintf(MPI_COMM_SELF,"Done!\n");CHKERRQ(ierr);

--- a/include/private/tdydmimpl.h
+++ b/include/private/tdydmimpl.h
@@ -1,0 +1,9 @@
+#if !defined(TDYDMIMPL_H)
+#define TDYDMIMPL_H
+
+#include <petsc.h>
+
+PETSC_EXTERN PetscErrorCode TDyCreateDM(DM*);
+
+#endif
+

--- a/include/private/tdydmimpl.h
+++ b/include/private/tdydmimpl.h
@@ -1,9 +1,0 @@
-#if !defined(TDYDMIMPL_H)
-#define TDYDMIMPL_H
-
-#include <petsc.h>
-
-PETSC_EXTERN PetscErrorCode TDyCreateDM(DM*);
-
-#endif
-

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -48,7 +48,8 @@ PETSC_EXTERN PetscLogEvent TDy_ComputeSystem;
 
 /* ---------------------------------------------------------------- */
 
-PETSC_EXTERN PetscErrorCode TDyCreate(DM dm,TDy *tdy);
+PETSC_EXTERN PetscErrorCode TDyCreate(TDy *tdy);
+PETSC_EXTERN PetscErrorCode TDyCreateWithDM(DM dm,TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy tdy,PetscViewer viewer);
 PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy tdy);

--- a/include/tdydm.h
+++ b/include/tdydm.h
@@ -1,0 +1,10 @@
+#if !defined(TDYDM_H)
+#define TDYDM_H
+
+#include <petsc.h>
+
+PETSC_EXTERN PetscErrorCode TDyCreateDM(DM*);
+PETSC_EXTERN PetscErrorCode TDyDistributeDM(DM*);
+
+#endif
+

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -10,6 +10,7 @@
 
 #ifdef PETSC_HAVE_FORTRAN_CAPS
 #define tdycreate_                                  TDYCREATE
+#define tdycreatewithdm_                            TDYCREATEWITHDM
 #define tdysetdiscretizationmethod_                 TDYSETDISCRETIZATIONMETHOD
 #define tdysetup_                                   TDYSETUP
 #define tdysetwaterdensitytype_                     TDYWATERDENSITYTYPE
@@ -59,6 +60,7 @@
 #define tdydestroy_                                 TDYDESTROY
 #elif !defined(PETSC_HAVE_FORTRAN_UNDERSCORE) && !defined(FORTRANDOUBLEUNDERSCORE)
 #define tdycreate_                                  tdycreate
+#define tdycreatewithdm_                            tdycreatewithdm
 #define tdysetdiscretizationmethod_                 tdysetdiscretizationmethod
 #define tdysetup_                                   tdysetup
 #define tdysetwaterdensitytype_                     tdysetwaterdensitytype
@@ -122,8 +124,18 @@ static struct {
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdycreate_(DM dm,TDy *_tdy, int *__ierr){
-*__ierr = TDyCreate((DM)PetscToPointer((dm)), _tdy);
+PETSC_EXTERN void  tdycreate_(TDy *_tdy, int *__ierr){
+*__ierr = TDyCreate(_tdy);
+}
+#if defined(__cplusplus)
+}
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+PETSC_EXTERN void  tdycreatewithdm_(DM dm,TDy *_tdy, int *__ierr){
+*__ierr = TDyCreateWithDM((DM)PetscToPointer((dm)), _tdy);
 }
 #if defined(__cplusplus)
 }

--- a/src/interface/ftn/tdydmf.c
+++ b/src/interface/ftn/tdydmf.c
@@ -1,0 +1,38 @@
+#include "petscsys.h"
+#include "petscfix.h"
+#include "petsc/private/fortranimpl.h"
+#include <tdydm.h>
+#include <petsc/private/f90impl.h>
+
+#define PetscToPointer(a) (*(PetscFortranAddr *)(a))
+
+#include "tdycore.h"
+
+#ifdef PETSC_HAVE_FORTRAN_CAPS
+#define tdycreatedm_                                TDYCREATEDM
+#define tdydistributedm_                            TDYDISTRIBUTEDM
+#elif !defined(PETSC_HAVE_FORTRAN_UNDERSCORE) && !defined(FORTRANDOUBLEUNDERSCORE)
+#define tdycreatedm_                                tdycreatedm
+#define tdydistributedm_                            tdydistributedm
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+PETSC_EXTERN void  tdycreatedm_(DM *dm,int *__ierr){
+*__ierr = TDyCreateDM(dm);
+}
+#if defined(__cplusplus)
+}
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+PETSC_EXTERN void  tdydistributedm_(DM *dm,int *__ierr){
+*__ierr = TDyDistributeDM(dm);
+}
+#if defined(__cplusplus)
+}
+#endif
+

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -5,6 +5,7 @@
 #include <private/tdympfaoimpl.h>
 #include <private/tdyeosimpl.h>
 #include <private/tdympfao3Dutilsimpl.h>
+#include <private/tdydmimpl.h>
 
 const char *const TDyMethods[] = {
   "TPF",
@@ -80,7 +81,15 @@ PetscErrorCode TDyInitializePackage(void) {
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDyCreate(DM dm,TDy *_tdy) {
+PetscErrorCode TDyCreate(TDy *_tdy) {
+  PetscErrorCode ierr;
+  DM             dm;
+  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+  ierr = TDyCreateWithDM(dm,_tdy); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDyCreateWithDM(DM dm,TDy *_tdy) {
   TDy            tdy;
   PetscInt       d,dim,p,pStart,pEnd,vStart,vEnd,c,cStart,cEnd,eStart,eEnd,offset,
                  nc;
@@ -264,6 +273,7 @@ PetscErrorCode TDyDestroy(TDy *_tdy) {
   ierr = PetscFree(tdy->Cr); CHKERRQ(ierr);
   ierr = PetscFree(tdy->rhor); CHKERRQ(ierr);
   ierr = PetscFree(tdy->dvis_dT); CHKERRQ(ierr);
+  ierr = DMDestroy(&tdy->dm); CHKERRQ(ierr);
   ierr = PetscFree(tdy); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -5,7 +5,7 @@
 #include <private/tdympfaoimpl.h>
 #include <private/tdyeosimpl.h>
 #include <private/tdympfao3Dutilsimpl.h>
-#include <private/tdydmimpl.h>
+#include <tdydm.h>
 
 const char *const TDyMethods[] = {
   "TPF",
@@ -85,6 +85,7 @@ PetscErrorCode TDyCreate(TDy *_tdy) {
   PetscErrorCode ierr;
   DM             dm;
   ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
   ierr = TDyCreateWithDM(dm,_tdy); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -1,0 +1,130 @@
+#include <private/tdydmimpl.h>
+
+PetscErrorCode TDyCreateDM(DM *_dm) {
+  PetscErrorCode ierr;
+  DM             dm;
+  PetscInt       dim = 2;
+  PetscReal      lower_bound_x = 0., lower_bound_y = lower_bound_x, 
+                 lower_bound_z = lower_bound_x;
+  PetscReal      upper_bound_x = 1., upper_bound_y = upper_bound_x, 
+                 upper_bound_z = upper_bound_x;
+  PetscInt       Nx = -999, Ny = -999, Nz = -999;
+  PetscBool      found;
+  PetscBool      perturb;
+  char           mesh_filename[PETSC_MAX_PATH_LEN];
+
+  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"DM Options","");
+                           CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-dim","Problem dimension","",dim,&dim,NULL);
+                         CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-N","Number of elements in 1D","",Nx,&Nx,&found);
+                         CHKERRQ(ierr);
+  if (found) {Ny = Nx; Nz = Nx;}
+  ierr = PetscOptionsInt("-Nx","Number of elements in X","",Nx,&Nx,NULL);
+                         CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-Ny","Number of elements in Y","",Ny,&Ny,NULL);
+                         CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-Nz","Number of elements in Z","",Nz,&Nz,NULL);
+                         CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-lower_bound","Lower bound","",lower_bound_x,
+                          &lower_bound_x,&found); CHKERRQ(ierr);
+  if (found) {lower_bound_y = lower_bound_x; lower_bound_z = lower_bound_x;}
+  ierr = PetscOptionsReal("-lower_bound_x","Lower bound in X","",lower_bound_x,
+                          &lower_bound_x,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-lower_bound_y","Lower bound in Y","",lower_bound_y,
+                          &lower_bound_y,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-lower_bound_z","Lower bound in Z","",lower_bound_z,
+                          &lower_bound_z,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-upper_bound","Upper bound","",upper_bound_x,
+                          &upper_bound_x,&found); CHKERRQ(ierr);
+  if (found) {upper_bound_y = upper_bound_x; upper_bound_z = upper_bound_x;}
+  ierr = PetscOptionsReal("-upper_bound_x","Upper bound in X","",upper_bound_x,
+                          &upper_bound_x,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-upper_bound_y","Upper bound in Y","",upper_bound_y,
+                          &upper_bound_y,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsReal("-upper_bound_z","Upper bound in Z","",upper_bound_z,
+                          &upper_bound_z,NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsString("-mesh_filename", "The mesh file", "",
+                            mesh_filename, mesh_filename, PETSC_MAX_PATH_LEN,
+                            NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+
+  size_t len;
+  ierr = PetscStrlen(mesh_filename, &len); CHKERRQ(ierr);
+  if (!len){
+    if (dim == 1) {
+      printf("ERROR: Only two or three dimensions currently supported.\n");
+      exit(0);
+      int i = 0;
+      if (Nx > 0) i++;
+      if (Ny > 0) i++;
+      if (Nz > 0) i++;
+      if (i > 1) {
+        printf("ERROR: Number of grid cells must be defined in only one ");
+        printf("dimension for a 1D problem:");
+        if (Nx > 0) printf(" %d",Nx); else printf(" ?");
+        if (Ny > 0) printf(" %d",Ny); else printf(" ?");
+        if (Nz > 0) printf(" %d\n",Nz); else printf(" ?\n");
+        exit(0);
+      }
+      if (Nx > 0) {Ny = 1; Nz = 1;}
+      else if (Ny > 0) {Nx = 1; Nz = 1;}
+      else if (Nz > 0) {Nx = 1; Ny = 1;}
+      else {Nx = 8; Ny = 1; Nz = 1;}
+    } else if (dim == 2) {
+      if (!((Nx > 0 && Ny > 0) || 
+            (Nx > 0 && Nz > 0) || 
+            (Ny > 0 && Nz > 0) ||
+            (Nx > 0 && Ny < 0 && Nz < 0) ||
+            (Nx < 0 && Ny < 0 && Nz < 0))) {
+        printf("ERROR: Number of grid cells must be defined in one (-N #) ");
+        printf("or two dimensions for a 2D problem:");
+        if (Nx > 0) printf(" %d",Nx); else printf(" ?");
+        if (Ny > 0) printf(" %d",Ny); else printf(" ?");
+        if (Nz > 0) printf(" %d\n",Nz); else printf(" ?\n");
+        exit(0);
+      }
+      if (Nx > 0 && Ny > 0) Nz = 1;
+      else if (Nx > 0 && Nz > 0) Ny = 1;
+      else if (Ny > 0 && Nz > 0) Nx = 1;
+      else {Nx = 8; Ny = Nx; Nz = 1;}
+    }
+    else if (dim == 3) {
+      if ((Nx < 0 && (Ny > 0 || Nz > 0)) || 
+          (Nx > 0 && ((Ny > 0 && Nz < 0) || (Ny < 0 && Nz > 0)))) {
+        printf("ERROR: Number of grid cells must be defined in one (-N #) ");
+        printf("or three dimensions for a 3D problem:");
+        if (Nx > 0) printf(" %d",Nx); else printf(" ?");
+        if (Ny > 0) printf(" %d",Ny); else printf(" ?");
+        if (Nz > 0) printf(" %d\n",Nz); else printf(" ?\n");
+        exit(0);
+      }
+      if (Nx < 0) Nx = 8;
+      if (Ny < 0) Ny = Nx;
+      if (Nz < 0) Nz = Nx;
+    }
+    const PetscInt  faces[3] = {Nx,Ny,Nz};
+    const PetscReal lower[3] = {lower_bound_x,lower_bound_y,lower_bound_z};
+    const PetscReal upper[3] = {upper_bound_x,upper_bound_y,upper_bound_z};
+    //printf("%d %d %d\n",faces[0],faces[1],faces[2]);
+    //printf("%f %f %f\n",lower[0],lower[1],lower[2]);
+    //printf("%f %f %f\n",upper[0],upper[1],upper[2]);
+
+    ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, PETSC_FALSE, faces,
+                               lower, upper, NULL, PETSC_TRUE, &dm);
+    CHKERRQ(ierr);
+  } else {
+    ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, mesh_filename, PETSC_TRUE,
+                                &dm); CHKERRQ(ierr);
+  }
+
+  DM dmDist;
+  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
+  if (dmDist) {DMDestroy(&dm); dm = dmDist;}
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
+  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
+  *_dm = dm;
+
+  PetscFunctionReturn(0);
+}
+

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -1,8 +1,7 @@
 #include <tdydm.h>
 
-PetscErrorCode TDyCreateDM(DM *_dm) {
+PetscErrorCode TDyCreateDM(DM *dm) {
   PetscErrorCode ierr;
-  DM             dm;
   PetscInt       dim = 2;
   PetscReal      lower_bound_x = 0., lower_bound_y = lower_bound_x, 
                  lower_bound_z = lower_bound_x;
@@ -111,29 +110,26 @@ PetscErrorCode TDyCreateDM(DM *_dm) {
     //printf("%f %f %f\n",upper[0],upper[1],upper[2]);
 
     ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, PETSC_FALSE, faces,
-                               lower, upper, NULL, PETSC_TRUE, &dm);
+                               lower, upper, NULL, PETSC_TRUE, dm);
     CHKERRQ(ierr);
   } else {
     ierr = DMPlexCreateFromFile(PETSC_COMM_WORLD, mesh_filename, PETSC_TRUE,
-                                &dm); CHKERRQ(ierr);
+                                dm); CHKERRQ(ierr);
   }
 
 
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDyDistributeDM(DM *_dm) {
-  DM             dm;
-  PetscErrorCode ierr;
-
+PetscErrorCode TDyDistributeDM(DM *dm) {
   DM dmDist;
-  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist); CHKERRQ(ierr);
+  PetscErrorCode ierr;
+  ierr = DMPlexDistribute(*dm, 1, NULL, &dmDist); CHKERRQ(ierr);
   if (dmDist) {
-    DMDestroy(&dm); CHKERRQ(ierr);
-    dm = dmDist;
+    DMDestroy(dm); CHKERRQ(ierr);
+    *dm = dmDist;
   }
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
-  *_dm = dm;
+  ierr = DMSetFromOptions(*dm); CHKERRQ(ierr);
+  ierr = DMViewFromOptions(*dm, NULL, "-dm_view"); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -1,4 +1,4 @@
-#include <private/tdydmimpl.h>
+#include <tdydm.h>
 
 PetscErrorCode TDyCreateDM(DM *_dm) {
   PetscErrorCode ierr;
@@ -118,13 +118,22 @@ PetscErrorCode TDyCreateDM(DM *_dm) {
                                 &dm); CHKERRQ(ierr);
   }
 
-  DM dmDist;
-  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
-  if (dmDist) {DMDestroy(&dm); dm = dmDist;}
-  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
-  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
-  *_dm = dm;
 
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDyDistributeDM(DM *_dm) {
+  DM             dm;
+  PetscErrorCode ierr;
+
+  DM dmDist;
+  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist); CHKERRQ(ierr);
+  if (dmDist) {
+    DMDestroy(&dm); CHKERRQ(ierr);
+    dm = dmDist;
+  }
+  ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
+  ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
+  *_dm = dm;
+  PetscFunctionReturn(0);
+}

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -9,7 +9,6 @@ PetscErrorCode TDyCreateDM(DM *dm) {
                  upper_bound_z = upper_bound_x;
   PetscInt       Nx = -999, Ny = -999, Nz = -999;
   PetscBool      found;
-  PetscBool      perturb;
   char           mesh_filename[PETSC_MAX_PATH_LEN];
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"DM Options","");


### PR DESCRIPTION
The TDy library can create a default DM if none is specified.
One can continue to create TDy by explicitly specifying a DM.