### PR TITLE
Fixes parallel MPFA-O run

### DIFF
--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -2603,12 +2603,16 @@ PetscErrorCode FindCellsAboveAndBelowVertices(TDy tdy, PetscInt **cellsAbove, Pe
   PetscFunctionBegin;
 
   TDy_mesh *mesh;
+  TDy_vertex *vertices;
   PetscInt ivertex;
   PetscErrorCode ierr;
 
   mesh = tdy->mesh;
+  vertices = &mesh->vertices;
 
   for (ivertex = 0; ivertex < mesh->num_vertices; ivertex++) {
+
+    if (!vertices->is_local[ivertex]) continue;
 
     if (cellsAbove[ivertex][0] == -1 && cellsBelow[ivertex][0] == -1) {
 

--- a/src/mpfao/tdympfao.c
+++ b/src/mpfao/tdympfao.c
@@ -388,9 +388,8 @@ PetscErrorCode TDyMPFAOInitialize(TDy tdy) {
     ierr = PetscSectionSetFieldComponents(sec, 1, 1); CHKERRQ(ierr);
   }
 
-  ierr = DMPlexGetChart(dm, &pStart, &pEnd); CHKERRQ(ierr);
-  ierr = PetscSectionSetChart(sec,pStart,pEnd); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&pStart,&pEnd); CHKERRQ(ierr);
+  ierr = PetscSectionSetChart(sec,pStart,pEnd); CHKERRQ(ierr);
   for(p=pStart; p<pEnd; p++) {
     ierr = PetscSectionSetFieldDof(sec,p,0,1); CHKERRQ(ierr);
     ierr = PetscSectionSetDof(sec,p,1); CHKERRQ(ierr);

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -134,6 +134,18 @@ PetscErrorCode TDyCreateDM(DM *dm) {
 PetscErrorCode TDyDistributeDM(DM *dm) {
   DM dmDist;
   PetscErrorCode ierr;
+
+  /* Define 1 DOF on cell center of each cell */
+  PetscInt dim;
+  PetscFE fe;
+  ierr = DMGetDimension(*dm, &dim); CHKERRQ(ierr);
+  ierr = PetscFECreateDefault(PETSC_COMM_SELF, dim, 1, PETSC_FALSE, "p_", -1, &fe); CHKERRQ(ierr);
+  ierr = PetscObjectSetName((PetscObject) fe, "p");CHKERRQ(ierr);
+  ierr = DMSetField(*dm, 0, NULL, (PetscObject)fe); CHKERRQ(ierr);
+  ierr = DMCreateDS(*dm); CHKERRQ(ierr);
+  ierr = PetscFEDestroy(&fe); CHKERRQ(ierr);
+  ierr = DMSetUseNatural(*dm, PETSC_TRUE); CHKERRQ(ierr);
+
   ierr = DMPlexDistribute(*dm, 1, NULL, &dmDist); CHKERRQ(ierr);
   if (dmDist) {
     DMDestroy(dm); CHKERRQ(ierr);


### PR DESCRIPTION
- The code that determines cell-ids above/below now skips non-local vertices
- Additionally, `TDyDistributeDM` is modified to use `DMSetUseNatural` before 
  partitioning the domain. This change allows the mapping of natural cells to
  local ids.

Fixes #93