### PR TITLE
Move TDySetFromOptions prior to DM creation; added flags to check or…

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -102,7 +102,13 @@ int main(int argc, char **argv) {
   PetscErrorCode ierr;
   PetscInt dim = 2, N = 0;
   PetscReal ang = 0;
+
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"SPE Options",""); CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-dim","Problem dimension","",
 			  dim,&dim,NULL); CHKERRQ(ierr);
@@ -136,14 +142,13 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  /* Setup problem parameters */
-  TDy  tdy;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
   ierr = ReadSPE10Permeability(tdy,ang); CHKERRQ(ierr);
   ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
+
+  /* Setup problem parameters */
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate CHKERRQ(ierr);
+  ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -107,7 +107,6 @@ int main(int argc, char **argv) {
   TDy  tdy;
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"SPE Options",""); CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-dim","Problem dimension","",
@@ -142,12 +141,14 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = ReadSPE10Permeability(tdy,ang); CHKERRQ(ierr);
   ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   /* Setup problem parameters */
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -146,8 +146,7 @@ int main(int argc, char **argv) {
   ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   /* Setup problem parameters */
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -230,8 +230,7 @@ int main(int argc, char **argv) {
   // Setup problem parameters
   PetscReal gravity[3];
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
   PetscInt dim;
   ierr = TDyGetDimension(tdy,&dim); CHKERRQ(ierr);
 

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -202,6 +202,12 @@ int main(int argc, char **argv) {
   PetscBool perturb = PETSC_FALSE;
 
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
   CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-problem","Problem number","",problem,&problem,NULL);
@@ -222,10 +228,10 @@ int main(int argc, char **argv) {
   ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
 
   // Setup problem parameters
-  TDy  tdy;
   PetscReal gravity[3];
 
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
   PetscInt dim;
   ierr = TDyGetDimension(tdy,&dim); CHKERRQ(ierr);
 
@@ -268,9 +274,6 @@ int main(int argc, char **argv) {
     ierr = TDySetDirichletFluxFunction(tdy,Velocity3D,NULL); CHKERRQ(ierr);
   }
 
-  ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   // Compute system

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -206,6 +206,14 @@ int main(int argc, char **argv) {
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+
+  /* Create and distribute the mesh */
+  DM dm;
+  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+  if (perturb) {ierr = PerturbInteriorVertices(dm,perturbation); CHKERRQ(ierr);}
+  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+
   ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
@@ -221,16 +229,9 @@ int main(int argc, char **argv) {
                          successful_exit_code,&successful_exit_code,NULL);
    ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
-  /* Create and distribute the mesh */
-  DM dm;
-  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
-  if (perturb) {ierr = PerturbInteriorVertices(dm,perturbation); CHKERRQ(ierr);}
-  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
-
   // Setup problem parameters
   PetscReal gravity[3];
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
   PetscInt dim;
   ierr = TDyGetDimension(tdy,&dim); CHKERRQ(ierr);
 
@@ -273,7 +274,7 @@ int main(int argc, char **argv) {
     ierr = TDySetDirichletFluxFunction(tdy,Velocity3D,NULL); CHKERRQ(ierr);
   }
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   // Compute system
   Mat K;

--- a/demo/richards/richards_driver.c
+++ b/demo/richards/richards_driver.c
@@ -14,6 +14,10 @@ int main(int argc, char **argv) {
   TDyIOFormat format = ExodusFormat; 
 
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+
   ierr = MPI_Comm_rank(PETSC_COMM_WORLD,&rank); CHKERRQ(ierr);
   ierr = MPI_Comm_size(PETSC_COMM_WORLD,&size); CHKERRQ(ierr);
   PetscPrintf(PETSC_COMM_WORLD,"Beginning Richards Driver simulation.\n");
@@ -29,9 +33,9 @@ int main(int argc, char **argv) {
                           CHKERRQ(ierr);
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
-  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
-  ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  // default mode and method must be set prior to TDySetFromOptions()
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = TDyDriverInitializeTDy(tdy); CHKERRQ(ierr);
   if (!rank) tdy->io->io_process = PETSC_TRUE;
   tdy->io->print_intermediate = print_intermediate;

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -629,8 +629,7 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   if(wheeler2006){

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -566,7 +566,6 @@ int main(int argc, char **argv) {
   TDy  tdy;
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options",""); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-dim","Problem dimension","",dim,&dim,NULL); CHKERRQ(ierr);
@@ -629,7 +628,8 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   if(wheeler2006){
@@ -736,7 +736,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -561,7 +561,13 @@ int main(int argc, char **argv) {
   char true_pres_filename[256]="none";
   char forcing_filename[256]="none";
   PetscBool exo = PETSC_FALSE;
+
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options",""); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-dim","Problem dimension","",dim,&dim,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-N","Number of elements in 1D","",N,&N,NULL); CHKERRQ(ierr);
@@ -623,10 +629,10 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  /* Setup problem parameters */
-  TDy  tdy;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
 
+  /* Setup problem parameters */
   if(wheeler2006){
     if(dim != 2){
       SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"-paper wheeler2006 is only for -dim 2 problems");
@@ -731,8 +737,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */

--- a/demo/steadyblock/steadyblock.c
+++ b/demo/steadyblock/steadyblock.c
@@ -97,7 +97,6 @@ int main(int argc, char **argv) {
   TDy  tdy;
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,TPF); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   strcpy(string,"tdycore.in");
 
@@ -144,7 +143,8 @@ int main(int argc, char **argv) {
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   printf("Creating TDycore.\n");
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/steadyblock/steadyblock.c
+++ b/demo/steadyblock/steadyblock.c
@@ -144,8 +144,7 @@ int main(int argc, char **argv) {
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   printf("Creating TDycore.\n");

--- a/demo/steadyblock/steadyblock.c
+++ b/demo/steadyblock/steadyblock.c
@@ -94,6 +94,10 @@ int main(int argc, char **argv) {
   char string[128];
 
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,TPF); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   strcpy(string,"tdycore.in");
 
@@ -140,10 +144,11 @@ int main(int argc, char **argv) {
   if (dmDist) {DMDestroy(&dm); dm = dmDist;}
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+
   /* Setup problem parameters */
   printf("Creating TDycore.\n");
-  TDy  tdy;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   if (dim == 1) {
     ierr = TDySetPermeabilityTensor(tdy,PermeabilityBlock1); CHKERRQ(ierr);
     switch(problem) {
@@ -165,8 +170,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  ierr = TDySetDiscretizationMethod(tdy,TPF); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -19,7 +19,7 @@ contains
     K(1) = 5.d0; K(2) = 1.d0
     K(3) = 1.d0; K(4) = 2.d0
 
-    ierr = 0;
+    ierr = 0
     
   end subroutine PermeabilityFunction
   
@@ -33,12 +33,12 @@ contains
     integer                :: dummy(*)
     PetscErrorCode         :: ierr
 
-    !(*f)  = PetscPowReal(1-x[0],4);
-    !(*f) += PetscPowReal(1-x[1],3)*(1-x[0]);
-    !(*f) += PetscSinReal(1-x[1])*PetscCosReal(1-x[0]);
-    f = (1-x(1))**4.d0 + (1.d0-x(1))*(1.d0-x(2))**3.d0 + cos(1.d0-x(1))*sin(1.d0-x(2));
+    !(*f)  = PetscPowReal(1-x[0],4)
+    !(*f) += PetscPowReal(1-x[1],3)*(1-x[0])
+    !(*f) += PetscSinReal(1-x[1])*PetscCosReal(1-x[0])
+    f = (1-x(1))**4.d0 + (1.d0-x(1))*(1.d0-x(2))**3.d0 + cos(1.d0-x(1))*sin(1.d0-x(2))
 
-    ierr = 0;
+    ierr = 0
 
   end subroutine PressureFunction
 
@@ -57,28 +57,28 @@ contains
     integer   :: dummy2(1)
 
 
-    call PermeabilityFunction(tdy,x,K,dummy2,ierr);
+    call PermeabilityFunction(tdy,x,K,dummy2,ierr)
 
-    !vx  = -4*PetscPowReal(1-x[0],3);
-    !vx += -  PetscPowReal(1-x[1],3);
-    !vx += +PetscSinReal(x[1]-1)*PetscSinReal(x[0]-1);
-    !vy  = -3*PetscPowReal(1-x[1],2)*(1-x[0]);
-    !vy += -PetscCosReal(x[0]-1)*PetscCosReal(x[1]-1);
+    !vx  = -4*PetscPowReal(1-x[0],3)
+    !vx += -  PetscPowReal(1-x[1],3)
+    !vx += +PetscSinReal(x[1]-1)*PetscSinReal(x[0]-1)
+    !vy  = -3*PetscPowReal(1-x[1],2)*(1-x[0])
+    !vy += -PetscCosReal(x[0]-1)*PetscCosReal(x[1]-1)
 
     vx = &
       -4.d0*((1.d0-x(1))**3.d0) &
       -     ((1.d0-x(2))**3.d0) &
-      + sin((x(2)-1.d0)) * sin(x(1)-1.d0);
+      + sin((x(2)-1.d0)) * sin(x(1)-1.d0)
     vy = &
       -3.d0 * ((1.d0-x(2))**2.d0) *(1.d0-x(1)) &
-      - cos(x(1)-1.d0) * cos(x(2)-1.d0);
+      - cos(x(1)-1.d0) * cos(x(2)-1.d0)
 
-    !v[0] = -(K[0]*vx+K[1]*vy);
-    !v[1] = -(K[2]*vx+K[3]*vy);
-    v(1) = -K(1)*vx - K(2)*vy;
-    v(2) = -K(3)*vx - K(4)*vy;
+    !v[0] = -(K[0]*vx+K[1]*vy)
+    !v[1] = -(K[2]*vx+K[3]*vy)
+    v(1) = -K(1)*vx - K(2)*vy
+    v(2) = -K(3)*vx - K(4)*vy
 
-    ierr = 0;
+    ierr = 0
 
   end subroutine VelocityFunction
 
@@ -95,19 +95,19 @@ contains
     PetscReal :: K(4)
     integer   :: dummy2(1)
 
-    call PermeabilityFunction(tdy,x,K,dummy2,ierr);
+    call PermeabilityFunction(tdy,x,K,dummy2,ierr)
     
-    !(*f)  = -K[0]*(12*PetscPowReal(1-x[0],2)+PetscSinReal(x[1]-1)*PetscCosReal(x[0]-1));
-    !(*f) += -K[1]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1));
-    !(*f) += -K[2]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1));
-    !(*f) += -K[3]*(-6*(1-x[0])*(x[1]-1)+PetscSinReal(x[1]-1)*PetscCosReal(x[0]-1));
+    !(*f)  = -K[0]*(12*PetscPowReal(1-x[0],2)+PetscSinReal(x[1]-1)*PetscCosReal(x[0]-1))
+    !(*f) += -K[1]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1))
+    !(*f) += -K[2]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1))
+    !(*f) += -K[3]*(-6*(1-x[0])*(x[1]-1)+PetscSinReal(x[1]-1)*PetscCosReal(x[0]-1))
     f = &
          -K(1)*(12.d0*((1.d0-x(1))**2.d0) + sin(x(2)-1.d0)*cos(x(1)-1.d0)) + &
          -K(2)*( 3.d0*((1.d0-x(2))**2.d0) + sin(x(1)-1.d0)*cos(x(2)-1.d0)) + &
          -K(3)*( 3.d0*((1.d0-x(2))**2.d0) + sin(x(1)-1.d0)*cos(x(2)-1.d0)) + &
-         -K(4)*(-6.d0*(1.d0-x(1))*(x(2)-1.d0) + sin(x(2)-1.d0)*cos(x(1)-1.d0));
+         -K(4)*(-6.d0*(1.d0-x(1))*(x(2)-1.d0) + sin(x(2)-1.d0)*cos(x(1)-1.d0))
 
-    ierr = 0;
+    ierr = 0
 
   end subroutine ForcingFunction
 
@@ -129,7 +129,7 @@ program main
 
   TDy            :: tdy
   DM             :: dm, dmDist
-  PetscInt       :: N, rank, method, successful_exit_code
+  PetscInt       :: N, rank, method, successful_exit_code, mode
   PetscBool      :: flg
   PetscInt       :: dim, faces(3)
   PetscReal      :: lower(3), upper(3)
@@ -140,110 +140,116 @@ program main
   PetscErrorCode :: ierr
 
   call TDyInit(ierr)
-  CHKERRA(ierr);
-  call TDyCreate(tdy, ierr);
-  CHKERRA(ierr);
-  method = MPFA_O;
-  call TDySetDiscretizationMethod(tdy,method, ierr);
-  CHKERRA(ierr);
-  call TDySetFromOptions(tdy, ierr);
-  CHKERRA(ierr);
+  CHKERRA(ierr)
+  call TDyCreate(tdy, ierr)
+  CHKERRA(ierr)
+  method = MPFA_O
+  call TDySetDiscretizationMethod(tdy,method,ierr)
+  CHKERRA(ierr)
+  mode = RICHARDS
+  call TDySetMode(tdy, mode, ierr)
+  CHKERRA(ierr)
 
   N = 8
-  dim = 2;
+  dim = 2
   successful_exit_code= 0
 
-  call PetscOptionsGetInt(PETSC_NULL_OPTIONS,PETSC_NULL_CHARACTER,'-N',N,flg,ierr);
+  call PetscOptionsGetInt(PETSC_NULL_OPTIONS,PETSC_NULL_CHARACTER,'-N',N,&
+                          flg,ierr)
   CHKERRA(ierr)
-  call PetscOptionsGetInt(PETSC_NULL_OPTIONS,PETSC_NULL_CHARACTER,'-successful_exit_code',successful_exit_code,flg,ierr);
+  call PetscOptionsGetInt(PETSC_NULL_OPTIONS,PETSC_NULL_CHARACTER, &
+                          '-successful_exit_code',successful_exit_code,flg,ierr)
   CHKERRA(ierr)
-  call MPI_Comm_rank(PETSC_COMM_WORLD,rank,ierr);
+  call MPI_Comm_rank(PETSC_COMM_WORLD,rank,ierr)
   CHKERRA(ierr)
 
-  faces(:) = N;
-  lower(:) = 0.d0;
-  upper(:) = 1.d0;
+  faces(:) = N
+  lower(:) = 0.d0
+  upper(:) = 1.d0
   
-  call DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, PETSC_FALSE, faces, lower, upper, &
-       PETSC_NULL_INTEGER, PETSC_TRUE, dm, ierr);
-  CHKERRA(ierr);
-  call DMPlexDistribute(dm, 1, PETSC_NULL_SF, dmDist, ierr);
-  CHKERRA(ierr);
-  if (dmDist /= PETSC_NULL_DM) then
-     call DMDestroy(dm, ierr);
-     CHKERRA(ierr);
-     dm = dmDist;
-  end if
-  call DMSetUp(dm,ierr);
+  call DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, PETSC_FALSE, faces, &
+                           lower, upper, PETSC_NULL_INTEGER, PETSC_TRUE, &
+                           dm, ierr)
   CHKERRA(ierr)
-  call DMSetFromOptions(dm, ierr);
-  CHKERRA(ierr);
-  !call DMViewFromOptions(dm,PETSC_NULL_CHARACTER,'-dm_view',ierr); CHKERRA(ierr)
+  call DMPlexDistribute(dm, 1, PETSC_NULL_SF, dmDist, ierr)
+  CHKERRA(ierr)
+  if (dmDist /= PETSC_NULL_DM) then
+     call DMDestroy(dm, ierr)
+  CHKERRA(ierr)
+     dm = dmDist
+  end if
+  call DMSetUp(dm,ierr)
+  CHKERRA(ierr)
+  call DMSetFromOptions(dm, ierr)
+  CHKERRA(ierr)
+  !call DMViewFromOptions(dm,PETSC_NULL_CHARACTER,'-dm_view',ierr)
+  !CHKERRA(ierr)
 
-  call TDySetupDiscretization(dm, tdy, ierr);
-  CHKERRA(ierr);
+  call TDySetDM(tdy, dm, ierr)
+  CHKERRA(ierr)
+  call TDySetFromOptions(tdy, ierr)
+  CHKERRA(ierr)
 
-  call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr);
-  CHKERRA(ierr);
-  call TDySetDirichletValueFunction(tdy,PressureFunction,0,ierr);
-  CHKERRA(ierr);
-  call TDySetForcingFunction(tdy,ForcingFunction,0,ierr);
-  CHKERRA(ierr);
-  call TDySetDirichletFluxFunction(tdy,VelocityFunction,0,ierr);
-  CHKERRA(ierr);
+  call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr)
+  CHKERRA(ierr)
+  call TDySetDirichletValueFunction(tdy,PressureFunction,0,ierr)
+  CHKERRA(ierr)
+  call TDySetForcingFunction(tdy,ForcingFunction,0,ierr)
+  CHKERRA(ierr)
+  call TDySetDirichletFluxFunction(tdy,VelocityFunction,0,ierr)
+  CHKERRA(ierr)
 
-  call TDySetup(tdy, ierr);
-  CHKERRA(ierr);
+  call TDySetupNumericalMethods(tdy, ierr)
+  CHKERRA(ierr)
 
-
-  call DMCreateGlobalVector(dm,U,ierr);
-  CHKERRA(ierr);
-  call DMCreateGlobalVector(dm,F,ierr);
-  CHKERRA(ierr);
-  call DMCreateMatrix      (dm,K,ierr);
-  CHKERRA(ierr);
-  call TDyComputeSystem(tdy,K,F,ierr);
-  CHKERRA(ierr);
+  call DMCreateGlobalVector(dm,U,ierr)
+  CHKERRA(ierr)
+  call DMCreateGlobalVector(dm,F,ierr)
+  CHKERRA(ierr)
+  call DMCreateMatrix      (dm,K,ierr)
+  CHKERRA(ierr)
+  call TDyComputeSystem(tdy,K,F,ierr)
+  CHKERRA(ierr)
 
   !Solve system
-  call KSPCreate(PETSC_COMM_WORLD,ksp,ierr);
-  CHKERRQ(ierr);
+  call KSPCreate(PETSC_COMM_WORLD,ksp,ierr)
+  CHKERRQ(ierr)
 
-  call KSPSetOperators(ksp,K,K,ierr);
-  CHKERRQ(ierr);
-  call KSPSetFromOptions(ksp,ierr);
-  CHKERRQ(ierr);
+  call KSPSetOperators(ksp,K,K,ierr)
+  CHKERRQ(ierr)
+  call KSPSetFromOptions(ksp,ierr)
+  CHKERRQ(ierr)
 
-  call KSPSetUp(ksp,ierr);
-  CHKERRQ(ierr);
+  call KSPSetUp(ksp,ierr)
+  CHKERRQ(ierr)
 
-  call KSPSolve(ksp,F,U,ierr);
-  CHKERRQ(ierr);
+  call KSPSolve(ksp,F,U,ierr)
+  CHKERRQ(ierr)
 
-  call TDyComputeErrorNorms(tdy,U,normp,normv,ierr);
-  CHKERRA(ierr);
+  call TDyComputeErrorNorms(tdy,U,normp,normv,ierr)
+  CHKERRA(ierr)
   write(*,*)normp,normv
 
-  call TDyOutputRegression(tdy,U,ierr);
-  CHKERRA(ierr);
+  call TDyOutputRegression(tdy,U,ierr)
+  CHKERRA(ierr)
 
-  call KSPDestroy(ksp,ierr);
-  CHKERRQ(ierr);
+  call KSPDestroy(ksp,ierr)
+  CHKERRQ(ierr)
 
-  call VecDestroy(U,ierr);
-  CHKERRQ(ierr);
+  call VecDestroy(U,ierr)
+  CHKERRQ(ierr)
 
-  call VecDestroy(F,ierr);
-  CHKERRQ(ierr);
+  call VecDestroy(F,ierr)
+  CHKERRQ(ierr)
 
-  call MatDestroy(K,ierr);
-  CHKERRQ(ierr);
+  call MatDestroy(K,ierr)
+  CHKERRQ(ierr)
 
-  call TDyDestroy(tdy,ierr);
-  CHKERRQ(ierr);
+  call TDyDestroy(tdy,ierr)
+  CHKERRQ(ierr)
 
-  call TDyFinalize(ierr)
-  CHKERRA(ierr);
+  call TDyFinalize(ierr) 
+  CHKERRA(ierr)
 
   call exit(successful_exit_code)
 end

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -180,9 +180,7 @@ program main
   CHKERRA(ierr);
   !call DMViewFromOptions(dm,PETSC_NULL_CHARACTER,'-dm_view',ierr); CHKERRA(ierr)
 
-  call TDySetDM(dm, tdy, ierr);
-  CHKERRA(ierr);
-  call TDyAllocate(tdy, ierr);
+  call TDySetupDiscretization(dm, tdy, ierr);
   CHKERRA(ierr);
 
   call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr);

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -140,6 +140,14 @@ program main
   PetscErrorCode :: ierr
 
   call TDyInit(ierr)
+  CHKERRA(ierr);
+  call TDyCreate(tdy, ierr);
+  CHKERRA(ierr);
+  method = MPFA_O;
+  call TDySetDiscretizationMethod(tdy,method, ierr);
+  CHKERRA(ierr);
+  call TDySetFromOptions(tdy, ierr);
+  CHKERRA(ierr);
 
   N = 8
   dim = 2;
@@ -172,7 +180,9 @@ program main
   CHKERRA(ierr);
   !call DMViewFromOptions(dm,PETSC_NULL_CHARACTER,'-dm_view',ierr); CHKERRA(ierr)
 
-  call TDyCreateWithDM(dm, tdy, ierr);
+  call TDySetDM(dm, tdy, ierr);
+  CHKERRA(ierr);
+  call TDyAllocate(tdy, ierr);
   CHKERRA(ierr);
 
   call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr);
@@ -184,11 +194,6 @@ program main
   call TDySetDirichletFluxFunction(tdy,VelocityFunction,0,ierr);
   CHKERRA(ierr);
 
-  method = MPFA_O;
-  call TDySetDiscretizationMethod(tdy,method, ierr);
-  CHKERRA(ierr);
-  call TDySetFromOptions(tdy, ierr);
-  CHKERRA(ierr);
   call TDySetup(tdy, ierr);
   CHKERRA(ierr);
 

--- a/demo/th/th_driver.c
+++ b/demo/th/th_driver.c
@@ -14,6 +14,10 @@ int main(int argc, char **argv) {
   TDyIOFormat format = PetscViewerASCIIFormat; 
 
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetMode(tdy,TH); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+
   ierr = MPI_Comm_rank(PETSC_COMM_WORLD,&rank); CHKERRQ(ierr);
   ierr = MPI_Comm_size(PETSC_COMM_WORLD,&size); CHKERRQ(ierr);
   PetscPrintf(PETSC_COMM_WORLD,"Beginning TH Driver simulation.\n");
@@ -29,9 +33,9 @@ int main(int argc, char **argv) {
                           CHKERRQ(ierr);
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
-  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
-  ierr = TDySetMode(tdy,TH); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  // default mode and method must be set prior to TDySetFromOptions()
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = TDyDriverInitializeTDy(tdy); CHKERRQ(ierr);
   if (!rank) tdy->io->io_process = PETSC_TRUE;
   tdy->io->print_intermediate = print_intermediate;

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -70,7 +70,6 @@ int main(int argc, char **argv) {
   TDy  tdy;
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
@@ -106,7 +105,8 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   /* Setup initial condition */
   Vec U;

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -106,8 +106,7 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -65,7 +65,13 @@ int main(int argc, char **argv) {
   PetscInt successful_exit_code=0;
   char exofile[256];
   PetscBool exo = PETSC_FALSE;
+
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-N","Number of elements in 1D",
@@ -100,15 +106,15 @@ int main(int argc, char **argv) {
   ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
   ierr = DMViewFromOptions(dm, NULL, "-dm_view"); CHKERRQ(ierr);
 
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+
   /* Setup problem parameters */
-  TDy  tdy;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   ierr = TDySetPermeabilityScalar(tdy,Permeability); CHKERRQ(ierr);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Setup initial condition */

--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -122,8 +122,7 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);

--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -72,7 +72,13 @@ int main(int argc, char **argv) {
   PetscInt successful_exit_code=0;
   char exofile[256];
   PetscBool exo = PETSC_FALSE;
+
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
   //ierr = PetscOptionsInt("-N","Number of elements in 1D",
@@ -116,17 +122,17 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+
   /* Setup problem parameters */
-  TDy  tdy;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   //ierr = TDySetPermeabilityScalar(tdy,Permeability); CHKERRQ(ierr);
   ierr = TDySetPermeabilityFunction(tdy,PermeabilityFunction3D,NULL); CHKERRQ(ierr);
   ierr = TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Setup initial condition */

--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -77,7 +77,6 @@ int main(int argc, char **argv) {
   TDy  tdy;
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
@@ -122,7 +121,8 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   /* Setup initial condition */
   Vec U;

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -74,6 +74,12 @@ implicit none
 
   call TDyInit(ierr);
   CHKERRA(ierr);
+  call TDyCreate(tdy, ierr);
+  CHKERRA(ierr);
+  call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
+  CHKERRA(ierr);
+  call TDySetFromOptions(tdy,ierr);
+  CHKERRA(ierr);
 
   nx = 3; ny = 3; nz = 3;
   dim = 3
@@ -104,10 +110,6 @@ implicit none
   call DMSetFromOptions(dm, ierr);
   CHKERRA(ierr);
 
-  call TDyCreateWithDM(dm, tdy, ierr);
-  CHKERRA(ierr);
-
-
   call DMPlexGetHeightStratum(dm,0,cStart,cEnd,ierr);
   CHKERRA(ierr);
 
@@ -127,6 +129,11 @@ implicit none
     enddo
   enddo
 
+  call TDySetDM(dm, tdy, ierr);
+  CHKERRA(ierr);
+  call TDyAllocate(tdy, ierr);
+  CHKERRA(ierr);
+
   call TDySetPorosityFunction(tdy,PorosityFunction,0,ierr);
   CHKERRA(ierr);
 
@@ -139,11 +146,6 @@ implicit none
   call TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat,ierr);
   CHKERRA(ierr);
 
-  call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
-  CHKERRA(ierr);
-
-  call TDySetFromOptions(tdy,ierr);
-  CHKERRA(ierr);
   call TDySetup(tdy,ierr);
   CHKERRA(ierr);
 

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -129,9 +129,7 @@ implicit none
     enddo
   enddo
 
-  call TDySetDM(dm, tdy, ierr);
-  CHKERRA(ierr);
-  call TDyAllocate(tdy, ierr);
+  call TDySetupDiscretization(dm, tdy, ierr);
   CHKERRA(ierr);
 
   call TDySetPorosityFunction(tdy,PorosityFunction,0,ierr);

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -78,8 +78,6 @@ implicit none
   CHKERRA(ierr);
   call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
   CHKERRA(ierr);
-  call TDySetFromOptions(tdy,ierr);
-  CHKERRA(ierr);
 
   nx = 3; ny = 3; nz = 3;
   dim = 3
@@ -107,9 +105,6 @@ implicit none
   call DMSetUp(dm,ierr);
   CHKERRA(ierr)
 
-  call DMSetFromOptions(dm, ierr);
-  CHKERRA(ierr);
-
   call DMPlexGetHeightStratum(dm,0,cStart,cEnd,ierr);
   CHKERRA(ierr);
 
@@ -129,7 +124,12 @@ implicit none
     enddo
   enddo
 
-  call TDySetupDiscretization(dm, tdy, ierr);
+  call DMSetFromOptions(dm, ierr);
+  CHKERRA(ierr);
+
+  call TDySetDM(tdy, dm, ierr);
+  CHKERRA(ierr);
+  call TDySetFromOptions(tdy,ierr);
   CHKERRA(ierr);
 
   call TDySetPorosityFunction(tdy,PorosityFunction,0,ierr);
@@ -144,7 +144,7 @@ implicit none
   call TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat,ierr);
   CHKERRA(ierr);
 
-  call TDySetup(tdy,ierr);
+  call TDySetupNumericalMethods(tdy,ierr);
   CHKERRA(ierr);
 
   ! Set initial condition

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -237,9 +237,7 @@ implicit none
     enddo
   enddo
 
-  call TDySetDM(dm, tdy, ierr);
-  CHKERRA(ierr);
-  call TDyAllocate(tdy,ierr);
+  call TDySetupDiscretization(dm, tdy, ierr);
   CHKERRA(ierr);
 
   if (pflotran_consistent) then

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -139,6 +139,12 @@ implicit none
 
   call TDyInit(ierr);
   CHKERRA(ierr);
+  call TDyCreate(tdy, ierr);
+  CHKERRA(ierr);
+  call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
+  CHKERRA(ierr);
+  call TDySetFromOptions(tdy,ierr);
+  CHKERRA(ierr);
 
   nx = 1; ny = 1; nz = 15;
   dim = 3
@@ -199,8 +205,6 @@ implicit none
   call DMSetFromOptions(dm, ierr);
   CHKERRA(ierr);
 
-  call TDyCreateWithDM(dm, tdy, ierr);
-  CHKERRA(ierr);
 
   call TDySetWaterDensityType(tdy,WATER_DENSITY_EXPONENTIAL,ierr);
   CHKERRA(ierr)
@@ -232,6 +236,11 @@ implicit none
       blockPerm((c-1)*dim*dim+j) = perm(j)
     enddo
   enddo
+
+  call TDySetDM(dm, tdy, ierr);
+  CHKERRA(ierr);
+  call TDyAllocate(tdy,ierr);
+  CHKERRA(ierr);
 
   if (pflotran_consistent) then
      call TDySetPorosityFunction(tdy,PorosityFunctionPFLOTRAN,0,ierr);
@@ -268,11 +277,6 @@ implicit none
 
   end if
 
-  call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
-  CHKERRA(ierr);
-
-  call TDySetFromOptions(tdy,ierr);
-  CHKERRA(ierr);
   call TDySetup(tdy,ierr);
   CHKERRA(ierr);
 

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -143,8 +143,6 @@ implicit none
   CHKERRA(ierr);
   call TDySetDiscretizationMethod(tdy,MPFA_O,ierr);
   CHKERRA(ierr);
-  call TDySetFromOptions(tdy,ierr);
-  CHKERRA(ierr);
 
   nx = 1; ny = 1; nz = 15;
   dim = 3
@@ -237,7 +235,9 @@ implicit none
     enddo
   enddo
 
-  call TDySetupDiscretization(dm, tdy, ierr);
+  call TDySetDM(tdy, dm, ierr);
+  CHKERRA(ierr);
+  call TDySetFromOptions(tdy,ierr);
   CHKERRA(ierr);
 
   if (pflotran_consistent) then
@@ -275,7 +275,7 @@ implicit none
 
   end if
 
-  call TDySetup(tdy,ierr);
+  call TDySetupNumericalMethods(tdy,ierr);
   CHKERRA(ierr);
 
   call TDyCreateVectors(tdy,ierr); CHKERRA(ierr)

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -176,8 +176,7 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -131,7 +131,6 @@ int main(int argc, char **argv) {
   TDyMode mode = TH;
   ierr = TDySetMode(tdy,mode); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
@@ -176,7 +175,8 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
+  ierr = TDySetDM(tdy,dm); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
   //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
   //ierr = TDySetTemperatureDirichletValueFunction(tdy,Temperature,NULL); CHKERRQ(ierr);
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   PetscSection   sec;
   PetscInt num_fields;

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -124,7 +124,15 @@ int main(int argc, char **argv) {
   PetscInt successful_exit_code=0;
   char exofile[256];
   PetscBool exo = PETSC_FALSE;
+
   ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  TDy  tdy;
+  ierr = TDyCreate(&tdy); CHKERRQ(ierr);
+  TDyMode mode = TH;
+  ierr = TDySetMode(tdy,mode); CHKERRQ(ierr);
+  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
 			   "Transient Options",""); CHKERRQ(ierr);
   //ierr = PetscOptionsInt("-N","Number of elements in 1D",
@@ -168,11 +176,10 @@ int main(int argc, char **argv) {
     residualSat[c] = 0.115;
   }
 
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+
   /* Setup problem parameters */
-  TDy  tdy;
-  TDyMode mode = TH;
-  ierr = TDyCreateWithDM(dm,&tdy); CHKERRQ(ierr);
-  ierr = TDySetMode(tdy,mode); CHKERRQ(ierr);
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   ierr = TDySetSpecificHeatCapacity(tdy,SpecificHeatCapacity); CHKERRQ(ierr);
   ierr = TDySetRockDensity(tdy,RockDensity); CHKERRQ(ierr);
@@ -184,8 +191,7 @@ int main(int argc, char **argv) {
   ierr = TDySetEnergyForcingFunction(tdy,EnergyForcing,NULL); CHKERRQ(ierr);
   //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
   //ierr = TDySetTemperatureDirichletValueFunction(tdy,Temperature,NULL); CHKERRQ(ierr);
-  ierr = TDySetDiscretizationMethod(tdy,MPFA_O); CHKERRQ(ierr);
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
   ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   PetscSection   sec;

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -36,6 +36,7 @@ struct _p_TDy {
   DM dm;
 
   TDyTimeIntegrator ti;
+  TDySetupFlags setupflags;
   TDyIO io;
   PetscBool init_with_random_field;
 

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -78,7 +78,7 @@ PETSC_EXTERN PetscErrorCode TDyInitNoArguments(void);
 PETSC_EXTERN PetscErrorCode TDyFinalize(void);
 
 PETSC_EXTERN PetscErrorCode TDyCreate(TDy *tdy);
-PETSC_EXTERN PetscErrorCode TDySetDM(DM dm,TDy tdy);
+PETSC_EXTERN PetscErrorCode TDySetupDiscretization(DM dm,TDy tdy);
 PETSC_EXTERN PetscErrorCode TDyAllocate(TDy tdy);
 PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy tdy,PetscViewer viewer);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -48,6 +48,13 @@ typedef enum {
   TDyTS
 } TDyTimeIntegrationMethod;
 
+typedef enum {
+  TDyCreated=0x0,
+  TDyParametersInitialized=0x1,
+  TDyOptionsSet=0x2,
+  TDySetupFinished=0x4,
+} TDySetupFlags;
+
 PETSC_EXTERN const char *const TDyModes[];
 
 typedef void (*SpatialFunction)(PetscReal *x,PetscReal *f); /* returns f(x) */
@@ -71,7 +78,8 @@ PETSC_EXTERN PetscErrorCode TDyInitNoArguments(void);
 PETSC_EXTERN PetscErrorCode TDyFinalize(void);
 
 PETSC_EXTERN PetscErrorCode TDyCreate(TDy *tdy);
-PETSC_EXTERN PetscErrorCode TDyCreateWithDM(DM dm,TDy *tdy);
+PETSC_EXTERN PetscErrorCode TDySetDM(DM dm,TDy tdy);
+PETSC_EXTERN PetscErrorCode TDyAllocate(TDy tdy);
 PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy tdy,PetscViewer viewer);
 

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -78,8 +78,12 @@ PETSC_EXTERN PetscErrorCode TDyInitNoArguments(void);
 PETSC_EXTERN PetscErrorCode TDyFinalize(void);
 
 PETSC_EXTERN PetscErrorCode TDyCreate(TDy *tdy);
-PETSC_EXTERN PetscErrorCode TDySetupDiscretization(DM dm,TDy tdy);
-PETSC_EXTERN PetscErrorCode TDyAllocate(TDy tdy);
+PETSC_EXTERN PetscErrorCode TDySetMode(TDy tdy, TDyMode mode);
+PETSC_EXTERN PetscErrorCode TDySetDiscretizationMethod(TDy tdy,
+                                                       TDyMethod method);
+PETSC_EXTERN PetscErrorCode TDySetDM(TDy tdy,DM dm);
+PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy tdy);
+PETSC_EXTERN PetscErrorCode TDySetupNumericalMethods(TDy tdy);
 PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy tdy,PetscViewer viewer);
 
@@ -131,12 +135,6 @@ PETSC_EXTERN PetscErrorCode TDySetDirichletFlux    (TDy tdy,SpatialFunction f);
 
 PETSC_EXTERN PetscErrorCode TDyResetDiscretizationMethod(TDy tdy);
 
-PETSC_EXTERN PetscErrorCode TDySetDiscretizationMethod(TDy tdy,
-    TDyMethod method);
-PETSC_EXTERN PetscErrorCode TDySetupDiscretizationMethod(TDy tdy);
-PETSC_EXTERN PetscErrorCode TDySetMode(TDy tdy, TDyMode mode);
-PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy tdy);
-PETSC_EXTERN PetscErrorCode TDySetup(TDy tdy);
 PETSC_EXTERN PetscErrorCode TDySetQuadratureType(TDy tdy,
     TDyQuadratureType qtype);
 PETSC_EXTERN PetscErrorCode TDySetWaterDensityType(TDy,TDyWaterDensityType);

--- a/src/f90-mod/tdycoremod.F90
+++ b/src/f90-mod/tdycoremod.F90
@@ -16,13 +16,20 @@ module tdycore
      end subroutine TDyFinalize
   end interface
   interface
-     subroutine TDyCreate(a,b,z)
+     subroutine TDyCreate(a,z)
+       use tdycoredef
+       TDy a
+       integer z
+     end subroutine TDyCreate
+  end interface
+  interface
+     subroutine TDySetDM(a,b,z)
        use petscdm
        use tdycoredef
        DM a
        TDy b
        integer z
-     end subroutine TDyCreate
+     end subroutine TDySetDM
   end interface
   interface
      subroutine TDySetDiscretizationMethod(a,b,z)
@@ -45,6 +52,13 @@ module tdycore
        TDy a
        integer z
      end subroutine TDySetFromOptions
+  end interface
+  interface
+     subroutine TDyAllocate(a,z)
+       use tdycoredef
+       TDy a
+       integer z
+     end subroutine TDyAllocate
   end interface
   interface
      subroutine TDySetup(a,z)

--- a/src/f90-mod/tdycoremod.F90
+++ b/src/f90-mod/tdycoremod.F90
@@ -23,13 +23,12 @@ module tdycore
      end subroutine TDyCreate
   end interface
   interface
-     subroutine TDySetupDiscretization(a,b,z)
-       use petscdm
+     subroutine TDySetMode(a,b,z)
        use tdycoredef
-       DM a
-       TDy b
+       TDy a
+       PetscInt b
        integer z
-     end subroutine TDySetupDiscretization
+     end subroutine TDySetMode
   end interface
   interface
      subroutine TDySetDiscretizationMethod(a,b,z)
@@ -40,11 +39,13 @@ module tdycore
      end subroutine TDySetDiscretizationMethod
   end interface
   interface
-     subroutine TDySetupDiscretizationMethod(a,z)
+     subroutine TDySetDM(a,b,z)
+       use petscdm
        use tdycoredef
        TDy a
+       DM b
        integer z
-     end subroutine TDySetupDiscretizationMethod
+     end subroutine TDySetDM
   end interface
   interface
      subroutine TDySetFromOptions(a,z)
@@ -54,18 +55,11 @@ module tdycore
      end subroutine TDySetFromOptions
   end interface
   interface
-     subroutine TDyAllocate(a,z)
+     subroutine TDySetupNumericalMethods(a,z)
        use tdycoredef
        TDy a
        integer z
-     end subroutine TDyAllocate
-  end interface
-  interface
-     subroutine TDySetup(a,z)
-       use tdycoredef
-       TDy a
-       integer z
-     end subroutine TDySetup
+     end subroutine TDySetupNumericalMethods
   end interface
   interface
      subroutine TDyComputeSystem(a,b,c,z)

--- a/src/f90-mod/tdycoremod.F90
+++ b/src/f90-mod/tdycoremod.F90
@@ -23,13 +23,13 @@ module tdycore
      end subroutine TDyCreate
   end interface
   interface
-     subroutine TDySetDM(a,b,z)
+     subroutine TDySetupDiscretization(a,b,z)
        use petscdm
        use tdycoredef
        DM a
        TDy b
        integer z
-     end subroutine TDySetDM
+     end subroutine TDySetupDiscretization
   end interface
   interface
      subroutine TDySetDiscretizationMethod(a,b,z)

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -6,18 +6,15 @@
 
 #define PetscToPointer(a) (*(PetscFortranAddr *)(a))
 
-#include "tdycore.h"
-
 #ifdef PETSC_HAVE_FORTRAN_CAPS
 #define tdyinitnoarguments_                         TDYINITNOARGUMENTS
 #define tdyfinalize_                                TDYFINALIZE
 #define tdycreate_                                  TDYCREATE
-#define tdycreatesetupdiscretization_               TDYSETUPDISCRETIZATION
+#define tdycreatesetdm_                             TDYSETDM
+#define tdysetmode_                                 TDYSETMODE
 #define tdysetdiscretizationmethod_                 TDYSETDISCRETIZATIONMETHOD
-#define tdyallocate_                                TDYALLOCATE
-#define tdysetup_                                   TDYSETUP
 #define tdysetfromoptions_                          TDYSETFROMOPTIONS
-#define tdysetupdiscretizationmethod_               TDYSETUPDISCRETIZATIONMETHOD
+#define tdysetupnumericalmethods_                   TDYSETUPNUMERICALMETHODS
 #define tdysetwaterdensitytype_                     TDYSETWATERDENSITYTYPE
 #define tdysetmpfaogmatrixmethod_                   TDYSETMPFAOGMATRIXMETHOD
 #define tdysetmpfaoboundaryconditiontype_           TDYSETMPFAOGBOUNDARYCONDITIONTYPE
@@ -70,12 +67,11 @@
 #define tdyinitnoarguments_                         tdyinitnoarguments
 #define tdyfinalize_                                tdyfinalize
 #define tdycreate_                                  tdycreate
-#define tdysetupdiscretization_                     tdysetdiscretization
+#define tdysetdm_                                   tdysetdm
+#define tdysetmode_                                 tdysetmode
 #define tdysetdiscretizationmethod_                 tdysetdiscretizationmethod
-#define tdyallocate_                                tdyallocate
-#define tdysetup_                                   tdysetup
 #define tdysetfromoptions_                          tdysetfromoptions
-#define tdysetupdiscretizationmethod_               tdysetupdiscretizationmethod
+#define tdysetupnumericalmethods_                   tdysetupnumericalmethods
 #define tdysetwaterdensitytype_                     tdysetwaterdensitytype
 #define tdysetmpfaogmatrixmethod_                   tdysetmpfaogmatrixmethod
 #define tdysetmpfaoboundaryconditiontype_           tdysetmpfaoboundaryconditiontype
@@ -170,8 +166,17 @@ PETSC_EXTERN void  tdycreate_(TDy *_tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdysetupdiscretization_(DM dm,TDy *_tdy, int *__ierr){
-*__ierr = TDySetupDiscretization((DM)PetscToPointer((dm)), *_tdy);
+PETSC_EXTERN void  tdysetmode_(TDy _tdy, PetscInt *mode, int *__ierr){
+*__ierr = TDySetMode((TDy)PetscToPointer((_tdy)), *mode);
+}
+#if defined(__cplusplus)
+}
+#endif
+#if defined(__cplusplus)
+extern "C" {
+#endif
+PETSC_EXTERN void  tdysetdiscretizationmethod_(TDy _tdy, PetscInt *method, int *__ierr){
+*__ierr = TDySetDiscretizationMethod((TDy)PetscToPointer((_tdy)), *method);
 }
 #if defined(__cplusplus)
 }
@@ -180,18 +185,8 @@ PETSC_EXTERN void  tdysetupdiscretization_(DM dm,TDy *_tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdysetdiscretizationmethod_(TDy tdy, PetscInt *method, int *__ierr){
-*__ierr = TDySetDiscretizationMethod((TDy)PetscToPointer((tdy)), *method);
-}
-#if defined(__cplusplus)
-}
-#endif
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
-PETSC_EXTERN void  tdysetupdiscretizationmethod_(TDy tdy, int *__ierr){
-*__ierr = TDySetupDiscretizationMethod((TDy)PetscToPointer((tdy)));
+PETSC_EXTERN void  tdysetdm_(TDy _tdy, DM dm, int *__ierr){
+*__ierr = TDySetDM((TDy)PetscToPointer((_tdy)), (DM)PetscToPointer((dm)));
 }
 #if defined(__cplusplus)
 }
@@ -210,18 +205,8 @@ PETSC_EXTERN void  tdysetfromoptions_(TDy tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdyallocate_(TDy tdy, int *__ierr){
-*__ierr = TDyAllocate((TDy)PetscToPointer((tdy)));
-}
-#if defined(__cplusplus)
-}
-#endif
-
-#if defined(__cplusplus)
-extern "C" {
-#endif
-PETSC_EXTERN void  tdysetup_(TDy tdy, int *__ierr){
-*__ierr = TDySetup((TDy)PetscToPointer((tdy)));
+PETSC_EXTERN void  tdysetupnumericalmethods_(TDy _tdy, int *__ierr){
+*__ierr = TDySetupNumericalMethods((TDy)PetscToPointer((_tdy)));
 }
 #if defined(__cplusplus)
 }

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -12,8 +12,9 @@
 #define tdyinitnoarguments_                         TDYINITNOARGUMENTS
 #define tdyfinalize_                                TDYFINALIZE
 #define tdycreate_                                  TDYCREATE
-#define tdycreatewithdm_                            TDYCREATEWITHDM
+#define tdycreatesetdm_                             TDYSETDM
 #define tdysetdiscretizationmethod_                 TDYSETDISCRETIZATIONMETHOD
+#define tdyallocate_                                TDYALLOCATE
 #define tdysetup_                                   TDYSETUP
 #define tdysetfromoptions_                          TDYSETFROMOPTIONS
 #define tdysetupdiscretizationmethod_               TDYSETUPDISCRETIZATIONMETHOD
@@ -69,8 +70,9 @@
 #define tdyinitnoarguments_                         tdyinitnoarguments
 #define tdyfinalize_                                tdyfinalize
 #define tdycreate_                                  tdycreate
-#define tdycreatewithdm_                            tdycreatewithdm
+#define tdysetdm_                                   tdysetdm
 #define tdysetdiscretizationmethod_                 tdysetdiscretizationmethod
+#define tdyallocate_                                tdyallocate
 #define tdysetup_                                   tdysetup
 #define tdysetfromoptions_                          tdysetfromoptions
 #define tdysetupdiscretizationmethod_               tdysetupdiscretizationmethod
@@ -168,8 +170,8 @@ PETSC_EXTERN void  tdycreate_(TDy *_tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdycreatewithdm_(DM dm,TDy *_tdy, int *__ierr){
-*__ierr = TDyCreateWithDM((DM)PetscToPointer((dm)), _tdy);
+PETSC_EXTERN void  tdysetdm_(DM dm,TDy *_tdy, int *__ierr){
+*__ierr = TDySetDM((DM)PetscToPointer((dm)), *_tdy);
 }
 #if defined(__cplusplus)
 }
@@ -200,6 +202,16 @@ extern "C" {
 #endif
 PETSC_EXTERN void  tdysetfromoptions_(TDy tdy, int *__ierr){
 *__ierr = TDySetFromOptions((TDy)PetscToPointer((tdy)));
+}
+#if defined(__cplusplus)
+}
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+PETSC_EXTERN void  tdyallocate_(TDy tdy, int *__ierr){
+*__ierr = TDyAllocate((TDy)PetscToPointer((tdy)));
 }
 #if defined(__cplusplus)
 }

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -12,7 +12,7 @@
 #define tdyinitnoarguments_                         TDYINITNOARGUMENTS
 #define tdyfinalize_                                TDYFINALIZE
 #define tdycreate_                                  TDYCREATE
-#define tdycreatesetdm_                             TDYSETDM
+#define tdycreatesetupdiscretization_               TDYSETUPDISCRETIZATION
 #define tdysetdiscretizationmethod_                 TDYSETDISCRETIZATIONMETHOD
 #define tdyallocate_                                TDYALLOCATE
 #define tdysetup_                                   TDYSETUP
@@ -70,7 +70,7 @@
 #define tdyinitnoarguments_                         tdyinitnoarguments
 #define tdyfinalize_                                tdyfinalize
 #define tdycreate_                                  tdycreate
-#define tdysetdm_                                   tdysetdm
+#define tdysetupdiscretization_                     tdysetdiscretization
 #define tdysetdiscretizationmethod_                 tdysetdiscretizationmethod
 #define tdyallocate_                                tdyallocate
 #define tdysetup_                                   tdysetup
@@ -170,8 +170,8 @@ PETSC_EXTERN void  tdycreate_(TDy *_tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdysetdm_(DM dm,TDy *_tdy, int *__ierr){
-*__ierr = TDySetDM((DM)PetscToPointer((dm)), *_tdy);
+PETSC_EXTERN void  tdysetupdiscretization_(DM dm,TDy *_tdy, int *__ierr){
+*__ierr = TDySetupDiscretization((DM)PetscToPointer((dm)), *_tdy);
 }
 #if defined(__cplusplus)
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -640,7 +640,8 @@ PetscErrorCode TDySetupNumericalMethods(TDy tdy) {
   TDyEnterProfilingStage("TDycore Setup");
   ierr = TDySetupDiscretizationScheme(tdy); CHKERRQ(ierr); 
   if (tdy->regression_testing) {
-    // should this be moved to TDyCreateGrid?
+    /* must come after Sections are set up in 
+       TDySetupDiscretizationScheme->XXXInitialize */
     ierr = TDyRegressionInitialize(tdy); CHKERRQ(ierr);
   }
   if (tdy->output_mesh) {

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -230,61 +230,23 @@ PetscErrorCode TDyCreate(TDy *_tdy) {
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetupDiscretization(DM dm,TDy tdy) {
-  PetscInt       d,dim,p,pStart,pEnd,vStart,vEnd,eStart,eEnd,offset,nc;
-  Vec            coordinates;
-  PetscSection   coordSection;
-  PetscScalar   *coords;
+PetscErrorCode TDySetDM(TDy tdy, DM dm) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  if ((tdy->setupflags & TDyOptionsSet) == 0) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetDM()");
-  }
-
   if (!dm) {
     SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"A DM must be created prior to TDySetDM()");
   }
   tdy->dm = dm;
-  /* compute/store plex geometry */
-  PetscLogEvent t1 = TDyGetTimer("ComputePlexGeometry");
-  TDyStartTimer(t1);
-  ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
-  ierr = DMPlexGetChart(tdy->dm,&pStart,&pEnd); CHKERRQ(ierr);
-  ierr = DMPlexGetDepthStratum(tdy->dm,0,&vStart,&vEnd); CHKERRQ(ierr);
-  ierr = DMPlexGetDepthStratum(tdy->dm,1,&eStart,&eEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc(    (pEnd-pStart)*sizeof(PetscReal),&(tdy->V));
-  CHKERRQ(ierr);
-  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),&(tdy->X));
-  CHKERRQ(ierr);
-  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),&(tdy->N));
-  CHKERRQ(ierr);
-  ierr = DMGetCoordinateSection(tdy->dm, &coordSection); CHKERRQ(ierr);
-  ierr = DMGetCoordinatesLocal (tdy->dm, &coordinates); CHKERRQ(ierr);
-  ierr = VecGetArray(coordinates,&coords); CHKERRQ(ierr);
-  for(p=pStart; p<pEnd; p++) {
-    if((p >= vStart) && (p < vEnd)) {
-      ierr = PetscSectionGetOffset(coordSection,p,&offset); CHKERRQ(ierr);
-      for(d=0; d<dim; d++) tdy->X[p*dim+d] = coords[offset+d];
-    } else {
-      if((dim == 3) && (p >= eStart) && (p < eEnd)) continue;
-      ierr = DMPlexComputeCellGeometryFVM(tdy->dm,p,&(tdy->V[p]),
-                                          &(tdy->X[p*dim]),
-                                          &(tdy->N[p*dim])); CHKERRQ(ierr);
-    }
-  }
-  ierr = VecRestoreArray(coordinates,&coords); CHKERRQ(ierr);
-  TDyStopTimer(t1);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDyAllocate(TDy tdy) {
+PetscErrorCode TDyMalloc(TDy tdy) {
   PetscInt       dim,c,cStart,cEnd,eStart,eEnd,nc;
   PetscErrorCode ierr;
   PetscFunctionBegin;
 
   if (!tdy->dm) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"tdy->dm must be set priot to TDyAllocate()");
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"tdy->dm must be set prior to TDyMalloc()");
   }
 
   /* allocate space for a full tensor perm for each cell */
@@ -360,6 +322,57 @@ PetscErrorCode TDyAllocate(TDy tdy) {
     tdy->dvis_dT[c] = 0.0;
   }
   tdy->gravity[dim-1] = -9.81;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDyCreateGrid(TDy tdy) {
+  PetscInt       d,dim,p,pStart,pEnd,vStart,vEnd,eStart,eEnd,offset,nc;
+  Vec            coordinates;
+  PetscSection   coordSection;
+  PetscScalar   *coords;
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  if ((tdy->setupflags & TDyOptionsSet) == 0) {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"Options must be set prior to TDyCreateGrid()");
+  }
+
+  if (!tdy->dm) {
+    DM dm;
+    ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+    ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
+    tdy->dm = dm;
+  }
+
+  /* compute/store plex geometry */
+  PetscLogEvent t1 = TDyGetTimer("ComputePlexGeometry");
+  TDyStartTimer(t1);
+  ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
+  ierr = DMPlexGetChart(tdy->dm,&pStart,&pEnd); CHKERRQ(ierr);
+  ierr = DMPlexGetDepthStratum(tdy->dm,0,&vStart,&vEnd); CHKERRQ(ierr);
+  ierr = DMPlexGetDepthStratum(tdy->dm,1,&eStart,&eEnd); CHKERRQ(ierr);
+  ierr = PetscMalloc(    (pEnd-pStart)*sizeof(PetscReal),&(tdy->V));
+  CHKERRQ(ierr);
+  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),&(tdy->X));
+  CHKERRQ(ierr);
+  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),&(tdy->N));
+  CHKERRQ(ierr);
+  ierr = DMGetCoordinateSection(tdy->dm, &coordSection); CHKERRQ(ierr);
+  ierr = DMGetCoordinatesLocal (tdy->dm, &coordinates); CHKERRQ(ierr);
+  ierr = VecGetArray(coordinates,&coords); CHKERRQ(ierr);
+  for(p=pStart; p<pEnd; p++) {
+    if((p >= vStart) && (p < vEnd)) {
+      ierr = PetscSectionGetOffset(coordSection,p,&offset); CHKERRQ(ierr);
+      for(d=0; d<dim; d++) tdy->X[p*dim+d] = coords[offset+d];
+    } else {
+      if((dim == 3) && (p >= eStart) && (p < eEnd)) continue;
+      ierr = DMPlexComputeCellGeometryFVM(tdy->dm,p,&(tdy->V[p]),
+                                          &(tdy->X[p*dim]),
+                                          &(tdy->N[p*dim])); CHKERRQ(ierr);
+    }
+  }
+  ierr = VecRestoreArray(coordinates,&coords); CHKERRQ(ierr);
+  TDyStopTimer(t1);
+  ierr = TDyMalloc(tdy); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -512,7 +525,7 @@ PetscErrorCode TDyView(TDy tdy,PetscViewer viewer) {
 }
 
 PetscErrorCode TDySetFromOptions(TDy tdy) {
-  // must preceed TDySetup() as it sets options used in TDySetup()
+  // must preceed TDySetupNumericalMethods() as it sets options used in TDySetupNumericalMethods()
   PetscErrorCode ierr;
   PetscBool flg;
   TDyMethod method = WY;
@@ -523,7 +536,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   TDyMPFAOBoundaryConditionType bctype = MPFAO_DIRICHLET_BC;
   PetscFunctionBegin;
   if ((tdy->setupflags & TDySetupFinished) != 0) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetup()");
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
   }
   PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
   ierr = PetscObjectOptionsBegin((PetscObject)tdy); CHKERRQ(ierr);
@@ -580,43 +593,13 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
 
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
   tdy->setupflags |= TDyOptionsSet;
+
+  ierr = TDyCreateGrid(tdy); CHKERRQ(ierr);
+
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetup(TDy tdy) {
-  /* must follow TDySetFromOptions() is it relies upon options set by 
-     TDySetFromOptions */
-  PetscErrorCode ierr;
-  PetscFunctionBegin;
-  if ((tdy->setupflags & TDyOptionsSet) == 0) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetup()");
-  }
-  TDY_START_FUNCTION_TIMER()
-  TDyEnterProfilingStage("TDycore Setup");
-  ierr = TDySetupDiscretizationMethod(tdy); CHKERRQ(ierr); 
-  if (tdy->regression_testing) {
-    ierr = TDyRegressionInitialize(tdy); CHKERRQ(ierr);
-  }
-  if (tdy->output_mesh) {
-    if (tdy->method != MPFA_O) {
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
-              "-tdy_output_mesh only supported for MPFA-O method");
-    }
-    ierr = TDyOutputMesh(tdy); CHKERRQ(ierr);
-  }
-  TDyExitProfilingStage("TDycore Setup");
-  tdy->setupflags |= TDySetupFinished;
-  TDY_STOP_FUNCTION_TIMER()
-  PetscFunctionReturn(0);
-}
-
-PetscErrorCode TDySetDiscretizationMethod(TDy tdy,TDyMethod method) {
-  PetscFunctionBegin;
-  tdy->method = method;
-  PetscFunctionReturn(0);
-}
-
-PetscErrorCode TDySetupDiscretizationMethod(TDy tdy) {
+PetscErrorCode TDySetupDiscretizationScheme(TDy tdy) {
   MPI_Comm       comm;
   PetscErrorCode ierr;
   PetscValidPointer(tdy,1);
@@ -642,6 +625,40 @@ PetscErrorCode TDySetupDiscretizationMethod(TDy tdy) {
     ierr = TDyWYInitialize(tdy); CHKERRQ(ierr);
     break;
   }
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySetupNumericalMethods(TDy tdy) {
+  /* must follow TDySetFromOptions() is it relies upon options set by 
+     TDySetFromOptions */
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  if ((tdy->setupflags & TDyOptionsSet) == 0) {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
+  }
+  TDY_START_FUNCTION_TIMER()
+  TDyEnterProfilingStage("TDycore Setup");
+  ierr = TDySetupDiscretizationScheme(tdy); CHKERRQ(ierr); 
+  if (tdy->regression_testing) {
+    // should this be moved to TDyCreateGrid?
+    ierr = TDyRegressionInitialize(tdy); CHKERRQ(ierr);
+  }
+  if (tdy->output_mesh) {
+    if (tdy->method != MPFA_O) {
+      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
+              "-tdy_output_mesh only supported for MPFA-O method");
+    }
+    ierr = TDyOutputMesh(tdy); CHKERRQ(ierr);
+  }
+  TDyExitProfilingStage("TDycore Setup");
+  tdy->setupflags |= TDySetupFinished;
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySetDiscretizationMethod(TDy tdy,TDyMethod method) {
+  PetscFunctionBegin;
+  tdy->method = method;
   PetscFunctionReturn(0);
 }
 

--- a/src/tdydm.c
+++ b/src/tdydm.c
@@ -132,7 +132,6 @@ PetscErrorCode TDyCreateDM(DM *dm) {
                                 dm); CHKERRQ(ierr);
   }
 
-
   PetscFunctionReturn(0);
 }
 

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -1,4 +1,5 @@
 #include <private/tdycoreimpl.h>
+#include <tdydm.h>
 #include <tdydriver.h>
 #include <tdypermeability.h>
 #include <tdyporosity.h>
@@ -13,9 +14,15 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
   TDyEnterProfilingStage("TDycore Setup");
   TDY_START_FUNCTION_TIMER()
   PetscReal gravity[3] = {0.,0.,0.};
+  DM dm;
   TS ts;
   SNES snes;
   SNESLineSearch linesearch;
+
+  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
+  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
+  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
+  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
 
   PetscInt dim;
   ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
@@ -25,8 +32,6 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
   gravity[dim-1] = 9.8068;
   ierr = TDySetGravityVector(tdy,gravity);
 
-  // default mode and method must be set prior to TDySetFromOptions()
-  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
   switch(tdy->method) {
     case TPF:
     case MPFA_O:

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -21,8 +21,7 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
 
   ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
   ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
-  ierr = TDySetDM(dm,tdy); CHKERRQ(ierr);
-  ierr = TDyAllocate(tdy); CHKERRQ(ierr);
+  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
 
   PetscInt dim;
   ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -19,10 +19,6 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
   SNES snes;
   SNESLineSearch linesearch;
 
-  ierr = TDyCreateDM(&dm); CHKERRQ(ierr);
-  ierr = TDyDistributeDM(&dm); CHKERRQ(ierr);
-  ierr = TDySetupDiscretization(dm,tdy); CHKERRQ(ierr);
-
   PetscInt dim;
   ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
   if (dim != 3) {
@@ -55,7 +51,7 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
     ierr = TDySetSpecificHeatCapacity(tdy,TDySpecificHeatCapacityFunctionDefault); CHKERRQ(ierr);
   }
 
-  ierr = TDySetup(tdy); CHKERRQ(ierr);
+  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
   ierr = TDyTimeIntegratorCreate(&tdy->ti); CHKERRQ(ierr);
   ierr = TDyCreateVectors(tdy); CHKERRQ(ierr);


### PR DESCRIPTION
This pull request enforces creating and initializing members of TDycore in a specific order.  The TDycore object is now created without mallocing memory for the parameter arrays.  These arrays are allocated after TDySetFromOptions() has been called and the DM is created.  TDySetup() will not proceed unless TDySetFromOptions has been called.  A bitwise operation using tdy->setupflags enforces this order of operations.

Fixes #106  and #107 