### PR TITLE
Allows code to compile without ExodusII

### DIFF
--- a/demo/transient/transient_snes_mpfaof90.cfg
+++ b/demo/transient/transient_snes_mpfaof90.cfg
@@ -1,8 +1,7 @@
 [suites]
 standard=transient-snes-mpfaof90
-	transient-snes-mpfaof90-transect-neumann
-	transient-snes-mpfaof90-region
-
+standard_exodus= transient-snes-mpfaof90-transect-neumann
+                 transient-snes-mpfaof90-region
 #standard_parallel=
 
 [default-test-criteria]

--- a/regression_tests/makefile
+++ b/regression_tests/makefile
@@ -29,6 +29,11 @@ ifneq ($(strip $(MPIEXEC)),)
 	TEST_OPTIONS += --mpiexec "$(MPIEXEC)"
 endif
 
+SUITES = --suite standard standard_parallel
+ifneq ($(strip $(EXODUSII_LIB)),)
+SUITES += standard_exodus standard_parallel_exodus
+endif
+
 #
 # standard tests that are run to verify executable is built correctly
 #
@@ -37,61 +42,61 @@ test : test-mpfao test-steadyf90 test-steady test-transient test-transient-mpfao
 
 test-steady :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/steady/steady $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/steady/steady.cfg \
 		--logfile_prefix steady
 
 test-transient :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/transient/transient $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/transient/transient.cfg \
 		--logfile_prefix transient
 
 test-transient-mpfao :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/transient/transient_mpfao $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/transient/transient_mpfao.cfg \
 		--logfile_prefix transient_mpfao
 
 test-transient-mpfaof90 :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/transient/transient_mpfaof90 $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/transient/transient_mpfaof90.cfg \
 		--logfile_prefix transient_mpfaof90
 
 test-transient-snes-mpfaof90 :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/transient/transient_snes_mpfaof90 $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+                $(SUITES) \
 		--config-files ../demo/transient/transient_snes_mpfaof90.cfg \
 		--logfile_prefix transient_snes_mpfaof90
 
 test-transient-th-mpfao :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/transient/transient_th_mpfao $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/transient/transient_th_mpfao.cfg \
 		--logfile_prefix transient_th_mpfao
 
 test-mpfao :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/mpfao/mpfao $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/mpfao/mpfao.cfg \
 		--logfile_prefix mpfao
 
 test-steadyf90 :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/steadyf90/steadyf90 $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/steadyf90/steadyf90.cfg \
 		--logfile_prefix steadyf90
 
 test-richards :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/richards/richards_driver $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/richards/richards.cfg \
 		--logfile_prefix richards
 
 test-th :
 	$(PYTHON) $(TEST_MANAGER) -e ../demo/th/th_driver $(TEST_OPTIONS) \
-		--suite standard standard_parallel \
+		$(SUITES) \
 		--config-files ../demo/th/th.cfg \
 		--logfile_prefix th
 

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -1,7 +1,9 @@
 #include <private/tdycoreimpl.h>
 #include <private/tdyioimpl.h>
 #include <tdyio.h>
+#if defined(PETSC_HAVE_EXODUSII)
 #include "exodusII.h"
+#endif
 #include <petsc/private/dmpleximpl.h>
 
 PetscErrorCode TDyIOCreate(TDyIO *_io) {
@@ -69,6 +71,7 @@ PetscErrorCode TdyIOInitializeExodus(char *ofilename, char *zonalVarNames[], DM 
   PetscErrorCode ierr;
   int exoid = -1;
   
+#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
 
@@ -80,6 +83,9 @@ PetscErrorCode TdyIOInitializeExodus(char *ofilename, char *zonalVarNames[], DM 
   ierr = ex_put_variable_param(exoid, EX_ELEM_BLOCK, num_vars);CHKERRQ(ierr);
   ierr = ex_put_variable_names(exoid,EX_ELEM_BLOCK, num_vars, zonalVarNames);CHKERRQ(ierr);
   ierr = ex_close(exoid);CHKERRQ(ierr);
+#else
+  SETERRQ(PETSC_COMM_SELF,PETSC_ERR_SUP, "PETSc not compiled with Exodus II support.");
+#endif
 
   PetscFunctionReturn(0);
 }
@@ -90,6 +96,7 @@ PetscErrorCode TdyIOAddExodusTime(char *ofilename, PetscReal time, TDyIO io){
   PetscErrorCode ierr;
   int exoid = -1;
   
+#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
   
@@ -98,6 +105,7 @@ PetscErrorCode TdyIOAddExodusTime(char *ofilename, PetscReal time, TDyIO io){
   if (exoid < 0) SETERRQ1(PETSC_COMM_SELF, PETSC_ERR_FILE_UNEXPECTED, "Unable to open exodus file %\n", ofilename);
   ierr = ex_put_time(exoid,io->num_times,&time);CHKERRQ(ierr);
   ierr = ex_close(exoid);CHKERRQ(ierr);
+#endif
 
   PetscFunctionReturn(0);
 }
@@ -108,6 +116,7 @@ PetscErrorCode TdyIOWriteExodusVar(char *ofilename, Vec U, TDyIO io){
   float version;
   int exoid = -1;
   
+#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
 
@@ -115,6 +124,7 @@ PetscErrorCode TdyIOWriteExodusVar(char *ofilename, Vec U, TDyIO io){
   if (exoid < 0) SETERRQ1(PETSC_COMM_SELF, PETSC_ERR_FILE_UNEXPECTED, "Unable to open exodus file %\n", ofilename);
   ierr = VecViewPlex_ExodusII_Zonal_Internal(U, exoid, io->num_times);CHKERRQ(ierr);       
   ierr = ex_close(exoid);CHKERRQ(ierr);
+#endif
 
   PetscFunctionReturn(0);
 }

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -67,11 +67,11 @@ PetscErrorCode TDyIOWriteVec(TDy tdy){
 }
 
 PetscErrorCode TdyIOInitializeExodus(char *ofilename, char *zonalVarNames[], DM dm, int num_vars){
+#if defined(PETSC_HAVE_EXODUSII)
   int CPU_word_size, IO_word_size;
   PetscErrorCode ierr;
   int exoid = -1;
   
-#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
 
@@ -91,12 +91,12 @@ PetscErrorCode TdyIOInitializeExodus(char *ofilename, char *zonalVarNames[], DM 
 }
 
 PetscErrorCode TdyIOAddExodusTime(char *ofilename, PetscReal time, TDyIO io){
+#if defined(PETSC_HAVE_EXODUSII)
   int CPU_word_size, IO_word_size;
   float version;
   PetscErrorCode ierr;
   int exoid = -1;
   
-#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
   
@@ -111,12 +111,12 @@ PetscErrorCode TdyIOAddExodusTime(char *ofilename, PetscReal time, TDyIO io){
 }
   
 PetscErrorCode TdyIOWriteExodusVar(char *ofilename, Vec U, TDyIO io){ 
+#if defined(PETSC_HAVE_EXODUSII)
   int CPU_word_size, IO_word_size;
   PetscErrorCode ierr;
   float version;
   int exoid = -1;
   
-#if defined(PETSC_HAVE_EXODUSII)
   CPU_word_size = sizeof(PetscReal);
   IO_word_size  = sizeof(PetscReal);
 


### PR DESCRIPTION
Added preprocessing to avoid ExodusII code when PETSc is not configured with it.
added condition in regression test makefile to skip ExodusII tests

Fixes #125 