### PR TITLE
Documentation is now published to GitHub Pages

### DIFF
--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -37,8 +37,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        #        git clone https://github.com/TDycore/TDycore.git --branch github_pages --single-branch github_pages
-        git checkout github_pages
+        git clone https://github.com/TDycores-Project/TDycore.git --branch github_pages --single-branch github_pages
         cp -r doc/sphinx/build/html/* docs/
         cd docs
         git add .

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -37,7 +37,8 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git clone https://github.com/TDycore/TDycore.git --branch github_pages --single-branch github_pages
+        #        git clone https://github.com/TDycore/TDycore.git --branch github_pages --single-branch github_pages
+        git checkout github_pages
         cp -r doc/sphinx/build/html/* docs/
         cd docs
         git add .

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -48,6 +48,6 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         branch: github_pages
-        directory: github_pages
+        directory: docs
         github_token: ${{ secrets.GITHUB_TOKEN }}
     # ===============================

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -6,7 +6,7 @@ name: auto_publish_docs
 on:
   push:
     branches:
-      - jeff-cohere/publish-docs # change to master when ready
+      - master
 
 jobs:
   build:

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -42,7 +42,7 @@ jobs:
         cd docs
         touch .nojekyll
         git add .
-        git commit -m "Update documentation" -a || true
+        git commit -m "Updated documentation" -a || true
         # The above command will fail if no changes were present, so we ignore
         # that.
     - name: Push changes

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         pre-build-command: "pip install -r requirements.txt"
         build-command: "make doc-html"
-        docs-folder: "doc/sphinx/source"
+        docs-folder: "doc/sphinx"
     ## Great extra actions to compose with:
     ## Create an artifact of the html output.
     #- uses: actions/upload-artifact@v1

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -1,0 +1,52 @@
+# This action build and publishes the Sphinx documentation for TDycore to a
+# GitHub Pages site.
+name: auto_publish_docs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        pre-build-command: "pip install -r requirements.txt"
+        build-command: "make doc-html"
+        docs-folder: "doc/sphinx"
+    ## Great extra actions to compose with:
+    ## Create an artifact of the html output.
+    #- uses: actions/upload-artifact@v1
+    #  with:
+    #    name: DocumentationHTML
+    #    path: docs/_build/html/
+    ## Create an artifact out of the previously built pdf.
+    #- uses: actions/upload-artifact@v1
+    #  with:
+    #    name: Documentation
+    #    path: docs2/_build/latex/pdfexample.pdf
+    # Publish built docs to gh-pages branch.
+    # ===============================
+    - name: Commit documentation changes
+      run: |
+        git clone https://github.com/ammaraskar/TDycore-site.git --branch gh-pages --single-branch gh-pages
+        cp -r doc/sphinx/build/html/* gh-pages/
+        cd gh-pages
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Update documentation" -a || true
+        # The above command will fail if no changes were present, so we ignore
+        # that.
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    # ===============================

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -37,7 +37,8 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git clone https://github.com/TDycores-Project/TDycore.git --branch github_pages --single-branch github_pages
+        #git clone https://github.com/TDycores-Project/TDycore.git --branch github_pages --single-branch github_pages
+        git checkout github_pages
         cp -r doc/sphinx/build/html/* docs/
         cd docs
         git add .

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -35,11 +35,11 @@ jobs:
     # ===============================
     - name: Commit documentation changes
       run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
         git clone https://github.com/TDycore/TDycore.git --branch github_pages --single-branch github_pages
         cp -r doc/sphinx/build/html/* docs/
         cd docs
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
         git add .
         git commit -m "Update documentation" -a || true
         # The above command will fail if no changes were present, so we ignore

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         pre-build-command: "pip install -r requirements.txt"
-        build-command: "make doc-html"
+        build-command: "make html"
         docs-folder: "doc/sphinx"
     ## Great extra actions to compose with:
     ## Create an artifact of the html output.

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -6,7 +6,7 @@ name: auto_publish_docs
 on:
   push:
     branches:
-      - jeff-cohere/publish_docs # change to master when ready
+      - jeff-cohere/publish-docs # change to master when ready
 
 jobs:
   build:

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -1,11 +1,12 @@
-# This action build and publishes the Sphinx documentation for TDycore to a
-# GitHub Pages site.
+# This action build and publishes the Sphinx documentation for TDycore to its
+# GitHub Pages site. Adapted from
+# https://github.com/ammaraskar/sphinx-action-test/blob/master/.github/workflows/default.yml
 name: auto_publish_docs
 
 on:
   push:
     branches:
-      - master
+      - jeff-cohere/publish_docs # change to master when ready
 
 jobs:
   build:
@@ -18,25 +19,25 @@ jobs:
       with:
         pre-build-command: "pip install -r requirements.txt"
         build-command: "make doc-html"
-        docs-folder: "doc/sphinx"
+        docs-folder: "doc/sphinx/source"
     ## Great extra actions to compose with:
     ## Create an artifact of the html output.
     #- uses: actions/upload-artifact@v1
     #  with:
     #    name: DocumentationHTML
-    #    path: docs/_build/html/
+    #    path: doc/sphinx/build/html/
     ## Create an artifact out of the previously built pdf.
     #- uses: actions/upload-artifact@v1
     #  with:
     #    name: Documentation
-    #    path: docs2/_build/latex/pdfexample.pdf
-    # Publish built docs to gh-pages branch.
+    #    path: doc/sphinx/build/latex/pdfexample.pdf
+    # Publish built docs to github_pages branch.
     # ===============================
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/ammaraskar/TDycore-site.git --branch gh-pages --single-branch gh-pages
-        cp -r doc/sphinx/build/html/* gh-pages/
-        cd gh-pages
+        git clone https://github.com/TDycore/TDycore.git --branch github_pages --single-branch github_pages
+        cp -r doc/sphinx/build/html/* docs/
+        cd docs
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add .
@@ -46,7 +47,7 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        branch: gh-pages
-        directory: gh-pages
+        branch: github_pages
+        directory: github_pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
     # ===============================

--- a/.github/workflows/auto_publish_docs.yml
+++ b/.github/workflows/auto_publish_docs.yml
@@ -37,10 +37,10 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        #git clone https://github.com/TDycores-Project/TDycore.git --branch github_pages --single-branch github_pages
         git checkout github_pages
         cp -r doc/sphinx/build/html/* docs/
         cd docs
+        touch .nojekyll
         git add .
         git commit -m "Update documentation" -a || true
         # The above command will fail if no changes were present, so we ignore

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -159,7 +159,7 @@ katex_options = r'''{
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'TYdcoredoc'
+htmlhelp_basename = 'TDycoredoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/doc/sphinx/source/development.rst
+++ b/doc/sphinx/source/development.rst
@@ -24,8 +24,8 @@ TDycore-based program:::
 
     PetscErrorCode TDyFinalize(void);
 
-Use this instead of ``MPI_Finalize`` or ``PetscFinalize``. This ensures that all
-TDycore subsystems properly free their resources.
+Use this function instead of ``MPI_Finalize`` or ``PetscFinalize``. This ensures
+that all TDycore subsystems properly free their resources.
 
 Fortran 90 Interface
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This adds a GitHub Action that builds the documentation for TDycore and sticks it into the `docs/` directory of the `github_pages` branch. We've pointed GitHub Pages at this location, and you can find the generated site here:

https://tdycores-project.github.io/TDycore/

Documentation is published whenever a PR is merged into the `master` branch.

Whenever it makes sense, we can point `tdycore.org` to this location. Thanks, Jed, for pointing out the GitHub Action that makes this easy.

Closes #129 