### PR TITLE
Introduced a CMocka unit testing proof of concept

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - .travis/install-petsc.sh
   - export PETSC_DIR=$PWD/petsc; export PETSC_ARCH=petsc-arch
   - make codecov=1 V=1
+  - export CMOCKA_INCLUDE_DIR=/usr/local/include; export CMOCKA_INCLUDE_DIR=/usr/local/lib
   - make unit-test
   - (cd demo; make V=1 codecov=1 )
   - (cd regression_tests; make test-mpfao)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ script:
   - .travis/install-petsc.sh
   - export PETSC_DIR=$PWD/petsc; export PETSC_ARCH=petsc-arch
   - make codecov=1 V=1
-  - export CMOCKA_INCLUDE_DIR=/usr/local/include; export CMOCKA_INCLUDE_DIR=/usr/local/lib
-  - make unit-test
+  - env CMOCKA_INCLUDE_DIR=/usr/local/include CMOCKA_LIBRARY_DIR=/usr/local/lib MPI_NPROC=2 make unit-test
   - (cd demo; make V=1 codecov=1 )
   - (cd regression_tests; make test-mpfao)
   - (cd regression_tests; make test-steady)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ matrix:
 script: 
   - .travis/install-petsc.sh
   - export PETSC_DIR=$PWD/petsc; export PETSC_ARCH=petsc-arch
-  - make codecov=1 V=1 
+  - make codecov=1 V=1
+  - make unit-test
   - (cd demo; make V=1 codecov=1 )
   - (cd regression_tests; make test-mpfao)
   - (cd regression_tests; make test-steady)

--- a/.travis/install-linux-deps.sh
+++ b/.travis/install-linux-deps.sh
@@ -3,4 +3,5 @@ sudo apt-get update -qq
 #sudo apt-get install -y cmake gcc gfortran g++ liblapack-dev libopenmpi-dev openmpi-bin
 sudo apt-get install -y cmake gcc gfortran g++
 sudo apt-get install -y netcdf-bin libnetcdf-dev
+sudo apt-get install -y libcmocka-dev
 

--- a/.travis/install-linux-deps.sh
+++ b/.travis/install-linux-deps.sh
@@ -4,10 +4,6 @@ sudo apt-get update -qq
 sudo apt-get install -y cmake gcc gfortran g++
 sudo apt-get install -y netcdf-bin libnetcdf-dev
 
-# Install and identify the location of the cmocka testing library.
-# (The values of the environment variables below don't matter, because
-#  cmocka files are installed in standard locations.)
+# Install the cmocka testing library.
 sudo apt-get install -y libcmocka-dev
-export CMOCKA_INCLUDE_DIR=/usr/local/include
-export CMOCKA_INCLUDE_DIR=/usr/local/lib
 

--- a/.travis/install-linux-deps.sh
+++ b/.travis/install-linux-deps.sh
@@ -3,5 +3,11 @@ sudo apt-get update -qq
 #sudo apt-get install -y cmake gcc gfortran g++ liblapack-dev libopenmpi-dev openmpi-bin
 sudo apt-get install -y cmake gcc gfortran g++
 sudo apt-get install -y netcdf-bin libnetcdf-dev
+
+# Install and identify the location of the cmocka testing library.
+# (The values of the environment variables below don't matter, because
+#  cmocka files are installed in standard locations.)
 sudo apt-get install -y libcmocka-dev
+export CMOCKA_INCLUDE_DIR=/usr/local/include
+export CMOCKA_INCLUDE_DIR=/usr/local/lib
 

--- a/.travis/install-osx-deps.sh
+++ b/.travis/install-osx-deps.sh
@@ -9,10 +9,8 @@ brew install gcc@7
 #brew install open-mpi
 #brew install netcdf
 
-# Install and identify the location of the cmocka testing library.
+# Install the cmocka testing library.
 brew install cmocka
-export CMOCKA_INCLUDE_DIR=/usr/local/include
-export CMOCKA_LIBRARY_DIR=/usr/local/lib
 
 # Make sure the weird gfortran library links are in place.
 #ln -s /usr/local/lib/gcc/5/libgfortran.dylib /usr/local/lib/libgfortran.dylib

--- a/.travis/install-osx-deps.sh
+++ b/.travis/install-osx-deps.sh
@@ -8,6 +8,7 @@ brew tap homebrew/science
 brew install gcc@7
 #brew install open-mpi
 #brew install netcdf
+brew install cmocka
 
 # Make sure the weird gfortran library links are in place.
 #ln -s /usr/local/lib/gcc/5/libgfortran.dylib /usr/local/lib/libgfortran.dylib

--- a/.travis/install-osx-deps.sh
+++ b/.travis/install-osx-deps.sh
@@ -8,7 +8,11 @@ brew tap homebrew/science
 brew install gcc@7
 #brew install open-mpi
 #brew install netcdf
+
+# Install and identify the location of the cmocka testing library.
 brew install cmocka
+export CMOCKA_INCLUDE_DIR=/usr/local/include
+export CMOCKA_LIBRARY_DIR=/usr/local/lib
 
 # Make sure the weird gfortran library links are in place.
 #ln -s /usr/local/lib/gcc/5/libgfortran.dylib /usr/local/lib/libgfortran.dylib

--- a/gmakefile
+++ b/gmakefile
@@ -160,13 +160,6 @@ $(UTEST.c:%.c=%.o) : %.o : %.c
 $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -L$(CMOCKA_LIBRARY_DIR) -o $@ $^ -lcmocka-static $(TDYCORE_LIB) $(LIBS)
 
-# Make a list of all the unit test exes.
-utestname = $(basename $(1))
-#utestname = utest-$(subst _,-,$(basename $(notdir $(1))))
-ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
-
-$(ALLUNITTESTS) : % : $$(UTEST_EXE)
-
 unit-test : % : $(UTEST.c:%.c=%)
 	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
 

--- a/gmakefile
+++ b/gmakefile
@@ -42,6 +42,14 @@ else                   # Show the full command line
   quiet = $($1)
 endif
 
+# Set paths for CMocka-based unit tests.
+ifneq ($(CMOCKA_INCLUDE_DIR),)
+	ifneq ($(CMOCKA_LIBRARY_DIR),)
+		CFLAGS += "-I$(CMOCKA_INCLUDE_DIR)"
+		LDLAGS += "-L$(CMOCKA_LIBRARY_DIR) -lcmocka-static"
+	endif
+endif
+
 pcc = $(if $(findstring CONLY,$(PETSC_LANGUAGE)),CC,CXX)
 COMPILE.c = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
 COMPILE.cxx = $(call quiet,CXX) $(CXX_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(CXX_DEPFLAGS) -c
@@ -142,7 +150,24 @@ $(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(dem
 $(ALLTESTS) : test-% : $$(DEMO_EXE)
 	+@$(MAKE) -C regression_tests $@
 
-test : $(ALLTESTS)
+UTEST.c = \
+	src/tests/test_tdyinit.c \
+
+ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call testname,$(path)))
+# Set target-specific variables for each test
+define target_specific_utest_exe
+  $(call testname,$(1)) : UTEST_EXE = $(basename $(1))
+endef
+$(foreach utest_src,$(UTEST.c),$(eval $(call target_specific_utest_exe,$(utest_src))))
+
+$(ALLUNITTESTS) : test-% : $$(UTEST_EXE)
+	+@if [ $(CMOCKA_INCLUDE_DIR) != "" ] && [ $(CMOCKA_LIBRARY_DIR) != ""]; then \
+	+@$@ \
+	fi
+
+unit-test : $(ALLUNITTESTS)
+
+test : unit-test $(ALLTESTS)
 
 # make print VAR=the-variable
 print : ; @echo $($(VAR))

--- a/gmakefile
+++ b/gmakefile
@@ -42,14 +42,6 @@ else                   # Show the full command line
   quiet = $($1)
 endif
 
-# Set paths for CMocka-based unit tests.
-ifneq ($(CMOCKA_INCLUDE_DIR),)
-	ifneq ($(CMOCKA_LIBRARY_DIR),)
-		CFLAGS += "-I$(CMOCKA_INCLUDE_DIR)"
-		LDLAGS += "-L$(CMOCKA_LIBRARY_DIR) -lcmocka-static"
-	endif
-endif
-
 pcc = $(if $(findstring CONLY,$(PETSC_LANGUAGE)),CC,CXX)
 COMPILE.c = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
 COMPILE.cxx = $(call quiet,CXX) $(CXX_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(CXX_DEPFLAGS) -c
@@ -150,22 +142,31 @@ $(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(dem
 $(ALLTESTS) : test-% : $$(DEMO_EXE)
 	+@$(MAKE) -C regression_tests $@
 
+ifdef CMOCKA_INCLUDE_DIR # Begin unit tests
+
+# Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
 
-ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call testname,$(path)))
-# Set target-specific variables for each test
-define target_specific_utest_exe
-  $(call testname,$(1)) : UTEST_EXE = $(basename $(1))
-endef
-$(foreach utest_src,$(UTEST.c),$(eval $(call target_specific_utest_exe,$(utest_src))))
+# Compile the unit tests
+$(UTEST.c:%.c=%.o) : %.o : %.c
+	$(COMPILE.c) -I$(CMOCKA_INCLUDE_DIR) $(abspath $<) -o $@
 
-$(ALLUNITTESTS) : test-% : $$(UTEST_EXE)
-	+@if [ $(CMOCKA_INCLUDE_DIR) != "" ] && [ $(CMOCKA_LIBRARY_DIR) != ""]; then \
-	+@$@ \
-	fi
+# Link the unit tests into executables
+$(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
+	$(call quiet,CLINKER) -L$(CMOCKA_LIBRARY_DIR) -o $@ $^ -lcmocka-static $(TDYCORE_LIB) $(LIBS)
 
-unit-test : $(ALLUNITTESTS)
+# Make a list of all the unit test exes.
+utestname = $(basename $(1))
+#utestname = utest-$(subst _,-,$(basename $(notdir $(1))))
+ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
+
+$(ALLUNITTESTS) : % : $$(UTEST_EXE)
+
+unit-test : % : $(UTEST.c:%.c=%)
+	+@find src -name "test_*" -executable -exec {} \;
+
+endif  # ifdef CMOCKA_INCLUDE_DIR
 
 test : unit-test $(ALLTESTS)
 

--- a/gmakefile
+++ b/gmakefile
@@ -144,6 +144,10 @@ $(ALLTESTS) : test-% : $$(DEMO_EXE)
 
 ifdef CMOCKA_INCLUDE_DIR # Begin unit tests
 
+ifndef MPI_NPROC
+MPI_NPROC=1
+endif
+
 # Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
@@ -164,7 +168,7 @@ ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
 $(ALLUNITTESTS) : % : $$(UTEST_EXE)
 
 unit-test : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec {} \;
+	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
 
 endif  # ifdef CMOCKA_INCLUDE_DIR
 

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -1,0 +1,77 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include <tdycore.h>
+
+// This unit test suite tests the initialization and finalization of the
+// TDycore library.
+
+// Globals for holding command line arguments.
+static int argc_;
+static char **argv_;
+
+// Test whether TDyInit works and initializes MPI properly.
+static void TestTDyInit(void **state)
+{
+  int mpi_initialized;
+  MPI_Initialized(&mpi_initialized);
+  assert_false(mpi_initialized);
+  TDyInit(argc_, argv_);
+  MPI_Initialized(&mpi_initialized);
+  assert_true(mpi_initialized);
+}
+
+// Test whether the PETSC_COMM_WORLD communicator behaves properly within cmocka.
+static void TestPetscCommWorld(void **state)
+{
+  int num_procs;
+  MPI_Comm_size(PETSC_COMM_WORLD, &num_procs);
+  assert_true(num_procs >= 1);
+
+  int rank;
+  MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+  assert_true(rank >= 0);
+  assert_true(rank < num_procs);
+}
+
+// Test whether MPI performs as expected within CMocka's environment.
+static void TestMPIAllreduce(void **state)
+{
+  // Let's see if we can properly sum over all ranks.
+  int num_procs;
+  MPI_Comm_size(PETSC_COMM_WORLD, &num_procs);
+
+  int one = 1;
+  int sum;
+
+  MPI_Allreduce(&one, &sum, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
+  assert_int_equal(num_procs, sum);
+}
+
+// Test whether TDyFinalize works as expected.
+static void TestTDyFinalize(void **state)
+{
+  int mpi_initialized;
+  MPI_Initialized(&mpi_initialized);
+  assert_true(mpi_initialized);
+  TDyFinalize();
+}
+
+int main(int argc, char* argv[])
+{
+  // Stash command line arguments.
+  argc_ = argc;
+  argv_ = argv;
+
+  const struct CMUnitTest tests[] =
+  {
+    cmocka_unit_test(TestTDyInit),
+    cmocka_unit_test(TestPetscCommWorld),
+    cmocka_unit_test(TestMPIAllreduce),
+    cmocka_unit_test(TestTDyFinalize),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This little guy allows us to use a pre-installed CMocka library whose location is defined by the CMOCKA_INCLUDE_DIR and CMOCKA_LIBRARY_DIR environment variables. See `gmakefile` for details. If either of these environment variables is not defined, unit tests are deactivated.

Briefly, you can just type

```
make unit-test
```

to build and run the unit tests only. They're also included in the `test` target.

As you can see in the unit test (`src/tests/test_tdyinit.c`), I've placed some simple checks that MPI does in fact work within CMocka. To run the unit tests with a specific number of processes, you can use (e.g.)

```
env MPI_NPROC=4 make unit-test
```

This is just a starting point. I'd love to hear thoughts on how we make this easier to use.

Closes #138