### PR TITLE
Adding tools for creating and pushing Docker images

### DIFF
--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -22,10 +22,6 @@ jobs:
         os: [ubuntu-latest] #, macos-latest]
         build-type: [Debug] #, Release]
 
-    # Environment variables
-    env:
-      DEBUG: 1
-
     # Steps for building and running tests.
     steps:
 
@@ -38,7 +34,7 @@ jobs:
 
     - name: Running tests (${{ matrix.build-type }})
       run: |
-        export PETSC_DIR=$PWD/petsc
+        set +e # disable "fast fail" (continue on test failures)
         cd demo/mpfao; make V=1 codecov=1
         cd ../richards; make V=1 codecov=1
         cd ../steady; make V=1 codecov=1
@@ -60,13 +56,13 @@ jobs:
         make test-th
         cd ..
         cat regression_tests/*testlog
-        cat demo/transient/transient-mpfaof90.stdout
-        cat demo/transient/transient-snes-mpfaof90.stdout
-        ls $PETSC_ARCH/obj/src/
 
     - name: Evaluating test coverage
       run: |
         lcov --capture --directory . --output-file coverage.info
         lcov --list coverage.info # debug info
-        bash <(curl -s https://codecov.io/bash  -f coverage.info)
+        curl -s https://codecov.io/bash > .codecov
+        chmod +x .codecov
+        ./.codecov
+        #bash <(curl -s https://codecov.io/bash  -f coverage.info)
 

--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -14,6 +14,7 @@ jobs:
   # This job builds the box model and runs our test suite.
   build:
     runs-on: ${{ matrix.os }}
+    container: coherellc/tdycore-petsc:latest
 
     # A build matrix storing all desired configurations.
     strategy:
@@ -23,54 +24,16 @@ jobs:
 
     # Environment variables
     env:
-      PETSC_ARCH: ${{ matrix.os }}
-      PETSC_GIT_HASH: 03cacdc99d
       DEBUG: 1
 
     # Steps for building and running tests.
     steps:
 
-    - name: Installing compilers and tools (Linux)
-      if: contains(matrix.os, 'ubuntu')
-      run: sudo apt-get install cmake lcov gcc gfortran g++
-
-    - name: Installing compilers and tools (Mac)
-      if: contains(matrix.os, 'macos')
-      run: |
-        brew update
-        brew install git gcc lcov
-
     - name: Checking out repository
       uses: actions/checkout@v2
 
-    - name: Installing PETSc
-      run: |
-        git clone https://gitlab.com/petsc/petsc.git
-        cd petsc
-        git checkout $PETSC_GIT_HASH
-        export PETSC_DIR=$PWD
-        ./configure \
-        --with-cc=gcc \
-        --with-cxx=g++ \
-        --with-fc=gfortran \
-        --CFLAGS='-g -O0' --CXXFLAGS='-g -O0' --FFLAGS='-g -O0 -Wno-unused-function' \
-        --with-clanguage=c \
-        --with-debug=$DEBUG  \
-        --with-shared-libraries=0 \
-        --download-hdf5 \
-        --download-metis \
-        --download-parmetis \
-        --download-exodusii \
-        --download-netcdf \
-        --download-pnetcdf \
-        --download-zlib \
-        --download-fblaslapack \
-        --download-mpich=http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
-        make all
-
     - name: Building TDycore (${{ matrix.build-type }})
       run: |
-        export PETSC_DIR=$PWD/petsc
         make -j codecov=1 V=1
 
     - name: Running tests (${{ matrix.build-type }})

--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -35,11 +35,12 @@ ENV LANG=en_US.UTF-8
 
 WORKDIR /build
 
-#  git reset --hard $PETSC_HASH && \
-ARG PETSC_HASH=48a67072e60
+ARG PETSC_HASH=HEAD
+ENV PETSC_HASH=$PETSC_HASH
 ENV PETSC_DIR=/usr/local/petsc/mpich-int32-real-opt
 RUN git clone --depth=1 --branch=master https://gitlab.com/petsc/petsc && \
   cd petsc && \
+  git reset --hard $PETSC_HASH && \
   OPT='-O2 -march=native -ffp-contract=fast'; \
   PETSC_INSTALL_PREFIX=$PETSC_DIR; unset PETSC_DIR; \
   python3 configure \

--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -1,0 +1,99 @@
+# This Docker file builds PETSc specifically for the TDycore project. It's based
+# loosely off of the jedbrown/petsc image, without building MPICH from source,
+# and with the USER removed (since GitHub Actions only support Docker images
+# with a root user).
+
+FROM ubuntu:20.10
+
+RUN echo Etc/UTC > /etc/timezone && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  autoconf \
+  automake \
+  bash-completion \
+  chrpath \
+  cmake \
+  curl \
+  g++ \
+  gcc \
+  gfortran \
+  git \
+  libmpich-dev \
+  libblis-serial-dev \
+  liblapack-dev \
+  libtool \
+  locales \
+  m4 \
+  make \
+  pkg-config \
+  python3-distutils \
+  zlib1g-dev \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+WORKDIR /build
+
+#  git reset --hard $PETSC_HASH && \
+ARG PETSC_HASH=48a67072e60
+ENV PETSC_DIR=/usr/local/petsc/mpich-int32-real-opt
+RUN git clone --depth=1 --branch=master https://gitlab.com/petsc/petsc && \
+  cd petsc && \
+  OPT='-O2 -march=native -ffp-contract=fast'; \
+  PETSC_INSTALL_PREFIX=$PETSC_DIR; unset PETSC_DIR; \
+  python3 configure \
+    --prefix=$PETSC_INSTALL_PREFIX \
+    --with-cc=mpicc \
+    --with-cxx=mpicxx \
+    --with-fc=mpif90 \
+    --with-cxx-dialect=C++14 \
+    --with-debugging=0 COPTFLAGS="$OPT" CXXOPTFLAGS="$OPT" FOPTFLAGS="$OPT" \
+    --download-ctetgen \
+    --download-exodusii \
+    --download-hdf5 \
+    --download-hypre \
+    --download-med \
+    --download-metis \
+    --download-ml \
+    --download-mumps \
+    --download-netcdf \
+    --download-parmetis \
+    --download-pnetcdf \
+    --download-scalapack \
+    --download-sundials \
+    --download-suitesparse \
+    --download-superlu \
+    --download-superlu_dist \
+    --download-triangle \
+    --with-zlib \
+    && \
+  make -j; \
+  cat configure.log && \
+  make install && \
+  export PETSC_DIR=$PETSC_INSTALL_PREFIX && \
+  unset OPT PETSC_INSTALL_PREFIX && \
+  chrpath --delete \
+    $PETSC_DIR/lib/libhdf5.so \
+    $PETSC_DIR/lib/libmetis.so \
+    $PETSC_DIR/lib/libpnetcdf.so \
+    $PETSC_DIR/lib/libsuperlu.so \
+    $PETSC_DIR/lib/libsuperlu_dist.so \
+    && \
+  chrpath --replace $PETSC_DIR/lib \
+    $PETSC_DIR/lib/libexoIIv2for32.so \
+    $PETSC_DIR/lib/libexodus.so \
+    $PETSC_DIR/lib/libexodus_for.so \
+    $PETSC_DIR/lib/libexodus_for.so \
+    $PETSC_DIR/lib/libhdf5_fortran.so \
+    $PETSC_DIR/lib/libhdf5_hl.so \
+    $PETSC_DIR/lib/libhdf5hl_fortran.so \
+    $PETSC_DIR/lib/libnetcdf.so \
+    $PETSC_DIR/lib/libparmetis.so \
+    $PETSC_DIR/lib/libpetsc.so \
+    && \
+  cd /build && \
+  rm -rf /build/petsc
+
+LABEL maintainer='Jeffrey Johnson <jeff@cohere-llc.com>'
+LABEL description='PETSc built with various libraries for TDycore'

--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -3,6 +3,10 @@
 # and with the USER removed (since GitHub Actions only support Docker images
 # with a root user).
 
+# We use the latest Ubuntu, but we install GCC/GFortran 8 (and build MPICH
+# against it) because versions of GFortran between 8.4 and 10.2 exhibit an
+# internal compiler error when building some of our Fortran assets with code
+# coverage enabled. (See https://github.com/TDycores-Project/TDycore/pull/145)
 FROM ubuntu:20.10
 
 RUN echo Etc/UTC > /etc/timezone && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
@@ -13,12 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   chrpath \
   cmake \
   curl \
-  g++ \
   gcc \
+  g++ \
   gfortran \
   git \
-  libmpich-dev \
-  libblis-serial-dev \
+  lcov \
   liblapack-dev \
   libtool \
   locales \
@@ -38,63 +41,39 @@ WORKDIR /build
 ARG PETSC_HASH=HEAD
 ENV PETSC_HASH=$PETSC_HASH
 ENV PETSC_DIR=/usr/local/petsc/mpich-int32-real-opt
-RUN git clone --depth=1 --branch=master https://gitlab.com/petsc/petsc && \
+RUN git clone --depth=1 --branch=main https://gitlab.com/petsc/petsc && \
   cd petsc && \
   git reset --hard $PETSC_HASH && \
-  OPT='-O2 -march=native -ffp-contract=fast'; \
   PETSC_INSTALL_PREFIX=$PETSC_DIR; unset PETSC_DIR; \
   python3 configure \
     --prefix=$PETSC_INSTALL_PREFIX \
-    --with-cc=mpicc \
-    --with-cxx=mpicxx \
-    --with-fc=mpif90 \
-    --with-cxx-dialect=C++14 \
-    --with-debugging=0 COPTFLAGS="$OPT" CXXOPTFLAGS="$OPT" FOPTFLAGS="$OPT" \
-    --download-ctetgen \
+    --with-cc=gcc \
+    --with-cxx=g++ \
+    --with-fc=gfortran \
+    --CFLAGS='-g -O0' --CXXFLAGS='-g -O0' --FFLAGS='-g -O0 -Wno-unused-function' \
+    --with-clanguage=c \
+    --with-debug=1 \
+    --with-shared-libraries=0 \
     --download-exodusii \
+    --download-fblaslapack \
     --download-hdf5 \
-    --download-hypre \
-    --download-med \
     --download-metis \
-    --download-ml \
-    --download-mumps \
+    --download-mpich=http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz \
     --download-netcdf \
     --download-parmetis \
     --download-pnetcdf \
-    --download-scalapack \
-    --download-sundials \
-    --download-suitesparse \
-    --download-superlu \
-    --download-superlu_dist \
-    --download-triangle \
     --with-zlib \
     && \
-  make -j; \
+  make all -j; \
   cat configure.log && \
   make install && \
   export PETSC_DIR=$PETSC_INSTALL_PREFIX && \
-  unset OPT PETSC_INSTALL_PREFIX && \
-  chrpath --delete \
-    $PETSC_DIR/lib/libhdf5.so \
-    $PETSC_DIR/lib/libmetis.so \
-    $PETSC_DIR/lib/libpnetcdf.so \
-    $PETSC_DIR/lib/libsuperlu.so \
-    $PETSC_DIR/lib/libsuperlu_dist.so \
-    && \
-  chrpath --replace $PETSC_DIR/lib \
-    $PETSC_DIR/lib/libexoIIv2for32.so \
-    $PETSC_DIR/lib/libexodus.so \
-    $PETSC_DIR/lib/libexodus_for.so \
-    $PETSC_DIR/lib/libexodus_for.so \
-    $PETSC_DIR/lib/libhdf5_fortran.so \
-    $PETSC_DIR/lib/libhdf5_hl.so \
-    $PETSC_DIR/lib/libhdf5hl_fortran.so \
-    $PETSC_DIR/lib/libnetcdf.so \
-    $PETSC_DIR/lib/libparmetis.so \
-    $PETSC_DIR/lib/libpetsc.so \
-    && \
+  unset PETSC_INSTALL_PREFIX && \
   cd /build && \
   rm -rf /build/petsc
+
+# Change the default shell to bash.
+SHELL ["/bin/bash", "-c"]
 
 LABEL maintainer='Jeffrey Johnson <jeff@cohere-llc.com>'
 LABEL description='PETSc built with various libraries for TDycore'

--- a/tools/build-petsc-docker-image.sh
+++ b/tools/build-petsc-docker-image.sh
@@ -28,13 +28,16 @@ cd docker-build
 docker build -t $IMAGE_NAME:$TAG --network=host \
   --build-arg PETSC_HASH=$PETSC_HASH \
   .
+STATUS=$?
 cd ..
 rm -rd docker-build
 
-# Tag the image.
-docker image tag $IMAGE_NAME:$TAG $DOCKERHUB_USER/$IMAGE_NAME:$TAG
+if [[ "$STATUS" == "0" ]]; then
+  # Tag the image.
+  docker image tag $IMAGE_NAME:$TAG $DOCKERHUB_USER/$IMAGE_NAME:$TAG
 
-echo "To upload this image to DockerHub, use the following:"
-echo "docker login"
-echo "docker image push $DOCKERHUB_USER/$IMAGE_NAME:$TAG"
-echo "docker logout"
+  echo "To upload this image to DockerHub, use the following:"
+  echo "docker login"
+  echo "docker image push $DOCKERHUB_USER/$IMAGE_NAME:$TAG"
+  echo "docker logout"
+fi

--- a/tools/build-petsc-docker-image.sh
+++ b/tools/build-petsc-docker-image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script builds a Docker image that contains an installation of PETSc
+# configured specifically for TDycore. PETSc is installed in /opt/haero,
+# on top of a recent Ubuntu image. Run it like so:
+#
+# `./build-petsc-docker-image.sh <petsc-hash>`
+#
+# The arguments are:
+# <petsc-hash> - A Git hash identifying the revision of PETSc to build
+#
+# For this script to work, Docker must be installed on your machine.
+PETSC_HASH=$1
+
+if [[ "$1" == "" ]]; then
+  echo "Usage: $0 <petsc-hash>"
+  exit
+fi
+
+DOCKERHUB_USER=coherellc
+IMAGE_NAME=tdycore-petsc
+TAG=$PETSC_HASH
+
+# Build the image locally.
+mkdir -p docker-build
+cp Dockerfile.petsc docker-build/Dockerfile
+cd docker-build
+docker build -t $IMAGE_NAME:$TAG --network=host \
+  --build-arg PETSC_HASH=$PETSC_HASH \
+  .
+cd ..
+rm -rd docker-build
+
+# Tag the image.
+docker image tag $IMAGE_NAME:$TAG $DOCKERHUB_USER/$IMAGE_NAME:$TAG
+
+echo "To upload this image to DockerHub, use the following:"
+echo "docker login"
+echo "docker image push $DOCKERHUB_USER/$IMAGE_NAME:$TAG"
+echo "docker logout"

--- a/tools/build-petsc-docker-image.sh
+++ b/tools/build-petsc-docker-image.sh
@@ -4,22 +4,22 @@
 # configured specifically for TDycore. PETSc is installed in /opt/haero,
 # on top of a recent Ubuntu image. Run it like so:
 #
-# `./build-petsc-docker-image.sh <petsc-hash>`
+# ./build-petsc-docker-image.sh [petsc-hash]
 #
 # The arguments are:
-# <petsc-hash> - A Git hash identifying the revision of PETSc to build
+# [petsc-hash] - A Git hash identifying the revision of PETSc to build. If
+#                omitted, the HEAD of the repository is built.
 #
 # For this script to work, Docker must be installed on your machine.
 PETSC_HASH=$1
 
 if [[ "$1" == "" ]]; then
-  echo "Usage: $0 <petsc-hash>"
-  exit
+  PETSC_HASH=HEAD
 fi
 
 DOCKERHUB_USER=coherellc
 IMAGE_NAME=tdycore-petsc
-TAG=$PETSC_HASH
+TAG=latest
 
 # Build the image locally.
 mkdir -p docker-build


### PR DESCRIPTION
This PR intends to speed up our builds by using a Docker image that is tailor-made for the project. The tools used to generate this docker image live in the `tools/` directory.

We were discussing a workflow that allowed us to automatically generate a Docker image when requested (somehow), but this gets us most of the way. We can further automate it if the tools here aren't convenient enough.

For now I've created a Docker image and stuck it in my own DockerHub account (`coherellc`). It's very easy to change where we store this, and I think we can also use GitHub's Docker registry, though it's very new and still in beta.

Closes #142 