### PR TITLE
Updates the code to use refactored mesh functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.o
 *.vtk
 *.DIR
+.DS_Store

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -4,3 +4,7 @@
 *.regression
 *.stdout*
 *.regression.old
+*.txt
+*.h5
+*.xmf
+*.csv

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -250,5 +250,15 @@ PETSC_EXTERN PetscErrorCode TDyMeshGetFaceNormal(TDyMesh*, PetscInt, TDyVector*)
 PETSC_EXTERN PetscErrorCode TDyMeshGetFaceArea(TDyMesh*, PetscInt, PetscReal*);
 
 PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellFaces(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellIsFaceUp(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellFaceUnknownIdxs(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellFaceFluxIdxs(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellFaceAreas(TDyMesh*, PetscInt, PetscReal**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellVertices(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellNuVectors(TDyMesh*, PetscInt, TDyVector**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellNuStarVectors(TDyMesh*, PetscInt, TDyVector**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellVariableContinutiyCoordinates(TDyMesh*, PetscInt, TDyCoordinate**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellFaceCentroids(TDyMesh*, PetscInt, TDyCoordinate**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetSubcellVerticesCoordinates(TDyMesh*, PetscInt, TDyCoordinate**, PetscInt*);
 
 #endif

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -239,6 +239,7 @@ PETSC_EXTERN PetscErrorCode TDyMeshGetCellVolume(TDyMesh*, PetscInt, PetscReal*)
 PETSC_EXTERN PetscErrorCode TDyMeshGetVertexInternalCells(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetVertexSubcells(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetVertexFaces(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetVertexSubfaces(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetVertexBoundaryFaces(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 
 PETSC_EXTERN PetscErrorCode TDyMeshGetFaceCells(TDyMesh*, PetscInt, PetscInt**, PetscInt*);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -231,6 +231,7 @@ PETSC_EXTERN PetscErrorCode TDyMeshCreateFromDM(DM, TDyMesh*);
 PETSC_EXTERN PetscErrorCode TDyMeshDestroy(TDyMesh*);
 
 PETSC_EXTERN PetscErrorCode TDyMeshGetCellVertices(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
+PETSC_EXTERN PetscErrorCode TDyMeshGetCellEdges(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetCellFaces(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetCellNeighbors(TDyMesh*, PetscInt, PetscInt**, PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyMeshGetCellCentroid(TDyMesh*, PetscInt, TDyCoordinate*);

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -1392,7 +1392,7 @@ PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
     PetscInt *subface_ids, num_subfaces;
     ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
-    num_faces = vertices->num_faces[ivertex];
+    //num_faces = vertices->num_faces[ivertex];
 
     PetscInt face_ids_sorted[num_faces];
     PetscInt subface_ids_sorted[num_faces];
@@ -1807,7 +1807,7 @@ PetscErrorCode SetupUpwindFacesForSubcell(TDyMesh *mesh, TDyVertex *vertices, Pe
 
   // Compute number of fluxes through internal faces
   PetscInt nflux_in = 0;
-  for (PetscInt iface=0; iface<vertices->num_faces[ivertex]; iface++) {
+  for (PetscInt iface=0; iface<vertex_num_faces; iface++) {
     PetscInt faceID = vertex_face_ids[iface];
     if (faces->is_internal[faceID]) nflux_in++;
   }
@@ -1830,7 +1830,7 @@ PetscErrorCode SetupUpwindFacesForSubcell(TDyMesh *mesh, TDyVertex *vertices, Pe
     ierr = TDyMeshGetSubcellFaceUnknownIdxs(mesh, subcell_id, &subcell_face_unknown_idx, &subcell_num_faces); CHKERRQ(ierr);
 
     // Loop over all faces of the subcell
-    for (PetscInt iface=0;iface<subcells->num_faces[subcell_id];iface++) {
+    for (PetscInt iface=0;iface<subcell_num_faces;iface++) {
 
       PetscInt face_id = subcell_face_ids[iface];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
@@ -1894,7 +1894,7 @@ PetscErrorCode SetupUpwindFacesForSubcell(TDyMesh *mesh, TDyVertex *vertices, Pe
     ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &subcell_face_ids, &subcell_num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetSubcellIsFaceUp(mesh, subcell_id, &subcell_is_face_up, &subcell_num_faces); CHKERRQ(ierr);
 
-    for (PetscInt iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
+    for (PetscInt iface=0; iface<subcell_num_faces; iface++) {
 
       PetscInt faceID = subcell_face_ids[iface];
       if (faces->is_internal[faceID]) continue;
@@ -1932,7 +1932,7 @@ PetscErrorCode SetupUpwindFacesForSubcell(TDyMesh *mesh, TDyVertex *vertices, Pe
     // - Similary, the index of the flux through the faces of a
     //   subcell are identifed. The internal fluxes are first,
     //   followed by upwind boundary and downwind boundary faces.
-    for (PetscInt iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
+    for (PetscInt iface=0; iface<subcell_num_faces; iface++) {
       PetscInt face_id = subcell_face_ids[iface];
 
       PetscInt idx_flux = subcell_face_unknown_idx[iface];
@@ -2007,7 +2007,7 @@ PetscInt VertexIdWithSameXYInACell(TDy tdy, PetscInt icell, PetscInt ivertex) {
   PetscInt *vertex_ids, num_vertices;
   ierr = TDyMeshGetCellVertices(mesh, icell, &vertex_ids, &num_vertices); CHKERRQ(ierr);
 
-  for (PetscInt iv=0; iv<cells->num_vertices[icell]; iv++) {
+  for (PetscInt iv=0; iv<num_vertices; iv++) {
 
     PetscInt ivertex_2 = vertex_ids[iv];
 
@@ -2047,7 +2047,7 @@ PetscBool IsCellAboveTheVertex(TDy tdy, PetscInt icell, PetscInt ivertex) {
   PetscInt *vertex_ids, num_vertices;
   ierr = TDyMeshGetCellVertices(mesh, icell, &vertex_ids, &num_vertices); CHKERRQ(ierr);
 
-  for (PetscInt iv=0; iv<cells->num_vertices[icell]; iv++) {
+  for (PetscInt iv=0; iv<num_vertices; iv++) {
 
     PetscInt ivertex_2 = vertex_ids[iv];
 
@@ -2123,7 +2123,7 @@ PetscErrorCode DetermineCellsAboveAndBelow(TDy tdy, PetscInt ivertex, PetscInt *
       ierr = TDyMeshGetCellVertices(mesh, cellID, &vertex_ids, &num_vertices); CHKERRQ(ierr);
 
       // Find the vertex that is above/below ivertex
-      for (PetscInt iv=0; iv<cells->num_vertices[cellID]; iv++) {
+      for (PetscInt iv=0; iv<num_vertices; iv++) {
         ivertexAbvBlw[level] = vertex_ids[iv];
         if (ivertex != ivertexAbvBlw[level]) {
           if (VerticesHaveSameXYCoords(tdy, ivertex, ivertexAbvBlw[level])) {
@@ -2141,7 +2141,7 @@ PetscErrorCode DetermineCellsAboveAndBelow(TDy tdy, PetscInt ivertex, PetscInt *
       ierr = TDyMeshGetCellFaces(mesh, cellID, &face_ids, &num_faces); CHKERRQ(ierr);
 
       PetscInt faceCount = 0;
-      for (PetscInt iface=0; iface<cells->num_faces[cellID]; iface++) {
+      for (PetscInt iface=0; iface<num_faces; iface++) {
         PetscInt faceID = face_ids[iface];
         PetscInt fOffsetVert = faces->vertex_offset[faceID];
 
@@ -2231,8 +2231,8 @@ PetscBool AreCellsNeighbors(TDy tdy, PetscInt cell_id_1, PetscInt cell_id_2) {
   ierr = TDyMeshGetCellFaces(mesh, cell_id_2, &face_ids_2, &num_faces_2); CHKERRQ(ierr);
 
   PetscBool are_neighbors = PETSC_FALSE;
-  for (PetscInt ii=0; ii<cells->num_faces[cell_id_1]; ii++) {
-    for (PetscInt jj=0; jj<cells->num_faces[cell_id_2]; jj++) {
+  for (PetscInt ii=0; ii<num_faces_1; ii++) {
+    for (PetscInt jj=0; jj<num_faces_2; jj++) {
       if (face_ids_1[ii] == face_ids_2[jj] ) {
         are_neighbors = PETSC_TRUE;
         break;
@@ -2297,7 +2297,7 @@ PetscInt IDofFaceSharedByTwoCellsForACommonVertex(TDy tdy, PetscInt ivertex, Pet
 
   PetscInt face_id;
   PetscBool found;
-  for (PetscInt iface=0; iface<vertices->num_faces[ivertex]; iface++) {
+  for (PetscInt iface=0; iface<num_faces; iface++) {
     face_id = face_ids[iface];
 
     found = PETSC_FALSE;

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -857,7 +857,10 @@ PetscErrorCode ConvertCellsToCompressedFormat(TDy tdy) {
 }
 
 /* -------------------------------------------------------------------------- */
-
+/// Converts all member variables of a TDyVertex struct in compressed format
+///
+/// @param [inout] tdy A TDy struct
+/// @returns 0 on success, or a non-zero error code on failure
 PetscErrorCode ConvertVerticesToCompressedFormat(TDy tdy) {
 
   PetscFunctionBegin;

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -781,32 +781,30 @@ PetscErrorCode ConvertMeshElementToCompressedFormat(TDy tdy, PetscInt num_elemen
 
   PetscInt count = 0, new_offset = 0;
 
-  count = *subelement_num[0];
+  count = (*subelement_num)[0];
   for (PetscInt ielem=1; ielem<num_element; ielem++) {
 
-    new_offset += *subelement_num[ielem-1];
-    PetscInt old_offset = *subelement_offset[ielem];
+    new_offset += (*subelement_num)[ielem-1];
+    PetscInt old_offset = (*subelement_offset)[ielem];
 
-    *subelement_offset[ielem] = new_offset;
+    for (PetscInt isubelem=0; isubelem<(*subelement_num)[ielem]; isubelem++){
 
-    for (PetscInt isubelem=0; isubelem<*subelement_num[ielem]; isubelem++){
-
-      *subelement_id[new_offset + isubelem] = *subelement_id[old_offset + isubelem];
+      (*subelement_id)[new_offset + isubelem] = (*subelement_id)[old_offset + isubelem];
       count++;
 
     }
     if (update_offset) {
-      *subelement_offset[ielem] = new_offset;
+      (*subelement_offset)[ielem] = new_offset;
     }
   }
 
   if (update_offset) {
-    new_offset += *subelement_num[num_element];
-    *subelement_offset[num_element+1] = new_offset;
+    new_offset += (*subelement_num)[num_element];
+    (*subelement_offset)[num_element+1] = new_offset;
   }
 
   for (PetscInt ii = count; ii < default_offset_size*num_element; ii++) {
-    *subelement_id[ii] = -1;
+    (*subelement_id)[ii] = -1;
   }
 
   PetscFunctionReturn(0);
@@ -847,14 +845,6 @@ PetscErrorCode ConvertVerticesToCompressedFormat(TDy tdy) {
   update_offset = 1;
   ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nfaces_per_vertex, update_offset,
     &vertices->num_faces, &vertices->face_offset, &vertices->subface_ids); CHKERRQ(ierr);
-
-  for (PetscInt ivertex=1; ivertex<num_vertices; ivertex++) {
-    printf("ivertex = %d; num_faces = %d\n",ivertex, vertices->num_faces[ivertex]);
-    for (PetscInt ioffset=vertices->face_offset[ivertex]; ioffset<vertices->face_offset[ivertex+1]; ioffset++){
-      printf("  [%03d] %03d \n",ioffset, vertices->face_ids[ioffset]);
-    }
-
-  }
 
   PetscFunctionReturn(0);
 }

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -3631,6 +3631,7 @@ PetscErrorCode TDyBuildMesh(TDy tdy) {
 
   case 3:
     ierr = ConvertVerticesToCompressedFormat(tdy); CHKERRQ(ierr);
+    ierr = ConvertSubcellsToCompressedFormat(tdy); CHKERRQ(ierr);
     ierr = UpdateFaceOrderAroundAVertex3DMesh(tdy); CHKERRQ(ierr);
     ierr = UpdateCellOrientationAroundAFace3DMesh(  tdy); CHKERRQ(ierr);
     break;

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -970,13 +970,12 @@ PetscErrorCode UpdateCellOrientationAroundAVertex2DMesh(TDy tdy) {
 }
 
 /* -------------------------------------------------------------------------- */
-
+/// For each vertex, reorder faces and subfaces such that all internal faces/subfaces
+/// are listed first followed by boundary faces
+///
+/// @param [inout] tdy A TDy struct
+/// @returns 0 on success, or a non-zero error code on failure
 PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
-
-  /*
-    For a vertex, save face ids such that all internal faces
-    are listed first followed by boundary faces.
-  */
 
   PetscFunctionBegin;
 
@@ -991,13 +990,15 @@ PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
 
   for (PetscInt ivertex=0; ivertex<v_end-v_start; ivertex++) {
 
-    PetscInt face_ids_sorted[vertices->num_faces[ivertex]];
-    PetscInt subface_ids_sorted[vertices->num_faces[ivertex]];
+    PetscInt num_faces = vertices->num_faces[ivertex];
+    PetscInt face_ids_sorted[num_faces];
+    PetscInt subface_ids_sorted[num_faces];
     PetscInt vOffsetFace = vertices->face_offset[ivertex];
     PetscInt count=0;
 
     // First find all internal faces (i.e. face shared by two cells)
-    for (PetscInt iface=0;iface<vertices->num_faces[ivertex];iface++) {
+    // and the corresponding subface
+    for (PetscInt iface=0;iface<num_faces;iface++) {
       PetscInt face_id = vertices->face_ids[vOffsetFace + iface];
       PetscInt subface_id = vertices->subface_ids[vOffsetFace + iface];
       if (faces->num_cells[face_id]==2) {
@@ -1008,7 +1009,8 @@ PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
     }
 
     // Now find all boundary faces (i.e. face shared by a single cell)
-    for (PetscInt iface=0;iface<vertices->num_faces[ivertex];iface++) {
+    // and the corresponding subfaces
+    for (PetscInt iface=0;iface<num_faces;iface++) {
       PetscInt face_id = vertices->face_ids[vOffsetFace+iface];
       PetscInt subface_id = vertices->subface_ids[vOffsetFace+iface];
       if (faces->num_cells[face_id]==1) {
@@ -1018,8 +1020,8 @@ PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
       }
     }
 
-    // Save the sorted faces
-    for (PetscInt iface=0;iface<vertices->num_faces[ivertex];iface++) {
+    // Save the sorted faces/subfaces
+    for (PetscInt iface=0;iface<num_faces;iface++) {
       vertices->face_ids[vOffsetFace+iface] = face_ids_sorted[iface];
       vertices->subface_ids[vOffsetFace+iface] = subface_ids_sorted[iface];
     }

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -831,7 +831,12 @@ PetscErrorCode ConvertVerticesToCompressedFormat(TDy tdy) {
 
   PetscInt update_offset;
 
-  /* Convert face_id */
+  /* Convert edge_ids */
+  update_offset = 1;
+  ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nedges_per_vertex, update_offset,
+    &vertices->num_edges, &vertices->edge_offset, &vertices->edge_ids); CHKERRQ(ierr);
+
+  /* Convert face_ids */
 
   // Note: face_id and subface_id use the same offset (vertices->face_offset)
   //       So, the offsets are not updated when updating face_ids.
@@ -841,10 +846,26 @@ PetscErrorCode ConvertVerticesToCompressedFormat(TDy tdy) {
   ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nfaces_per_vertex, update_offset,
     &vertices->num_faces, &vertices->face_offset, &vertices->face_ids); CHKERRQ(ierr);
 
-  /* Convert subface_id */
+  /* Convert subface_ids */
   update_offset = 1;
   ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nfaces_per_vertex, update_offset,
     &vertices->num_faces, &vertices->face_offset, &vertices->subface_ids); CHKERRQ(ierr);
+
+
+  /* Convert internal_cell_ids */
+  update_offset = 1;
+  ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, ncells_per_vertex, update_offset,
+    &vertices->num_internal_cells, &vertices->internal_cell_offset, &vertices->internal_cell_ids); CHKERRQ(ierr);
+
+  /* Convert subcell_ids */
+  update_offset = 1;
+  ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nfaces_per_vertex, update_offset,
+    &vertices->num_internal_cells, &vertices->subcell_offset, &vertices->subcell_ids); CHKERRQ(ierr);
+
+  /* Convert boundary_face_ids */
+  update_offset = 1;
+  ierr = ConvertMeshElementToCompressedFormat(tdy, num_vertices, nfaces_per_vertex, update_offset,
+    &vertices->num_boundary_faces, &vertices->boundary_face_offset, &vertices->boundary_face_ids); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
 }

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -772,7 +772,16 @@ PetscErrorCode SaveMeshConnectivityInfo(TDy tdy) {
 }
 
 /* -------------------------------------------------------------------------- */
-
+/// Converts an integer datatype of TDy mesh element in compressed format
+///
+/// @param [in] tdy                  A TDy struct
+/// @param [in] num_elements         Number of elements
+/// @param [in] default_offset_size  Default offset size for elements
+/// @param [in] update_offset        Determines if subelement_offset should be updated
+/// @param [inout] subelement_num    Number of subelements for a given element
+/// @param [inout] subelement_offset Offset of subelements for a given element
+/// @param [inout] subelement_id     Subelement ids
+/// @returns 0                       on success, or a non-zero error code on failure
 PetscErrorCode ConvertMeshElementToCompressedFormatIntegerValues(TDy tdy, PetscInt num_element, PetscInt default_offset_size, PetscInt update_offset,
   PetscInt **subelement_num, PetscInt **subelement_offset, PetscInt **subelement_id) {
 
@@ -810,7 +819,16 @@ PetscErrorCode ConvertMeshElementToCompressedFormatIntegerValues(TDy tdy, PetscI
 }
 
 /* -------------------------------------------------------------------------- */
-
+/// Converts TDyVector datatype of TDy mesh element in compressed format
+///
+/// @param [in] tdy                  A TDy struct
+/// @param [in] num_elements         Number of elements
+/// @param [in] default_offset_size  Default offset size for elements
+/// @param [in] update_offset        Determines if subelement_offset should be updated
+/// @param [inout] subelement_num    Number of subelements for a given element
+/// @param [inout] subelement_offset Offset of subelements for a given element
+/// @param [inout] subelement_id     Subelement ids
+/// @returns 0                       on success, or a non-zero error code on failure
 PetscErrorCode ConvertMeshElementToCompressedFormatTDyVectorValues(TDy tdy, PetscInt num_element, PetscInt default_offset_size, PetscInt update_offset,
   PetscInt **subelement_num, PetscInt **subelement_offset, TDyVector **subelement_value) {
 
@@ -856,7 +874,16 @@ PetscErrorCode ConvertMeshElementToCompressedFormatTDyVectorValues(TDy tdy, Pets
   PetscFunctionReturn(0);
 }
 /* -------------------------------------------------------------------------- */
-
+/// Converts TDyCoordinate datatype of TDy mesh element in compressed format
+///
+/// @param [in] tdy                  A TDy struct
+/// @param [in] num_elements         Number of elements
+/// @param [in] default_offset_size  Default offset size for elements
+/// @param [in] update_offset        Determines if subelement_offset should be updated
+/// @param [inout] subelement_num    Number of subelements for a given element
+/// @param [inout] subelement_offset Offset of subelements for a given element
+/// @param [inout] subelement_id     Subelement ids
+/// @returns 0                       on success, or a non-zero error code on failure
 PetscErrorCode ConvertMeshElementToCompressedFormatTDyCoordinateValues(TDy tdy, PetscInt num_element, PetscInt default_offset_size, PetscInt update_offset,
   PetscInt **subelement_num, PetscInt **subelement_offset, TDyCoordinate **subelement_value) {
 
@@ -903,7 +930,16 @@ PetscErrorCode ConvertMeshElementToCompressedFormatTDyCoordinateValues(TDy tdy, 
 }
 
 /* -------------------------------------------------------------------------- */
-
+/// Converts a real datatype of TDy mesh element in compressed format
+///
+/// @param [in] tdy                  A TDy struct
+/// @param [in] num_elements         Number of elements
+/// @param [in] default_offset_size  Default offset size for elements
+/// @param [in] update_offset        Determines if subelement_offset should be updated
+/// @param [inout] subelement_num    Number of subelements for a given element
+/// @param [inout] subelement_offset Offset of subelements for a given element
+/// @param [inout] subelement_id     Subelement ids
+/// @returns 0                       on success, or a non-zero error code on failure
 PetscErrorCode ConvertMeshElementToCompressedFormatRealValues(TDy tdy, PetscInt num_element, PetscInt default_offset_size, PetscInt update_offset,
   PetscInt **subelement_num, PetscInt **subelement_offset, PetscReal **subelement_value) {
 

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -1063,6 +1063,7 @@ PetscErrorCode ConvertSubcellsToCompressedFormat(TDy tdy) {
   ierr = ConvertMeshElementToCompressedFormatTDyCoordinateValues(tdy, num_subcells_per_cell, num_nu_vectors, update_offset,
     &subcells->num_nu_vectors, &subcells->nu_vector_offset, &subcells->face_centroid); CHKERRQ(ierr);
 
+  /* Change variables that have subelement size of 'num_vertices'*/
   update_offset = 1;
   ierr = ConvertMeshElementToCompressedFormatTDyCoordinateValues(tdy, num_subcells_per_cell, num_vertices, update_offset,
     &subcells->num_vertices, &subcells->vertex_offset, &subcells->vertices_coordinates); CHKERRQ(ierr);

--- a/src/mesh/tdycoremeshutils.c
+++ b/src/mesh/tdycoremeshutils.c
@@ -959,9 +959,11 @@ PetscErrorCode TDyPrintSubcellInfo(TDy tdy, PetscInt icell, PetscInt isubcell) {
   TDyMesh *mesh = tdy->mesh;
   TDyCell *cells = &mesh->cells;
   TDySubcell *subcells = &mesh->subcells;
+  PetscErrorCode ierr;
 
   PetscInt subcell_id = icell*cells->num_subcells[icell] + isubcell;
-  PetscInt sOffsetFace = subcells->face_offset[subcell_id];
+  PetscInt *face_ids, num_faces;
+  ierr = TDyMeshGetSubcellFaces(mesh, isubcell, &face_ids, &num_faces); CHKERRQ(ierr);
 
   printf("Subcell_id = %02d is %d-th subcell of cell_id = %d; ",subcell_id, isubcell, icell);
   printf(" No. faces = %d; ",subcells->num_faces[subcell_id]);
@@ -969,7 +971,7 @@ PetscErrorCode TDyPrintSubcellInfo(TDy tdy, PetscInt icell, PetscInt isubcell) {
   PetscInt iface;
   printf(" Face Ids: ");
   for (iface = 0; iface<subcells->num_faces[subcell_id]; iface++) {
-    printf("  %02d ",subcells->face_ids[sOffsetFace + iface]);
+    printf("  %02d ",face_ids[iface]);
   }
   printf("\n");
 

--- a/src/mesh/tdymesh.c
+++ b/src/mesh/tdymesh.c
@@ -284,3 +284,183 @@ PetscErrorCode TDyMeshGetSubcellFaces(TDyMesh *mesh,
   return 0;
 }
 
+/// Given a mesh and a subcell index, retrieve an array of associated is_face_up
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of is_face_up array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellIsFaceUp(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      PetscInt **is_face_up,
+                                      PetscInt *num_faces) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *is_face_up = &mesh->subcells.face_ids[offset];
+  *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated face_unknown_idx
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of face_unkown_idx array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellFaceUnknownIdxs(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      PetscInt **face_unknown_idx,
+                                      PetscInt *num_faces) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *face_unknown_idx = &mesh->subcells.face_unknown_idx[offset];
+  *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated face_flux_idx
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of face_flux_idx array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellFaceFluxIdxs(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      PetscInt **face_flux_idx,
+                                      PetscInt *num_faces) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *face_flux_idx = &mesh->subcells.face_flux_idx[offset];
+  *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated face areas
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of face areas array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellFaceAreas(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      PetscReal **face_area,
+                                      PetscInt *num_faces) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *face_area = &mesh->subcells.face_area[offset];
+  *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated vertices
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of vertices array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellVertices(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      PetscInt **vertices,
+                                      PetscInt *num_faces) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *vertices = &mesh->subcells.vertex_ids[offset];
+  *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated nu_vectors
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of nu_vectors array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellNuVectors(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      TDyVector **nu_vectors,
+                                      PetscInt *num_nu_vectors) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *nu_vectors = &mesh->subcells.nu_vector[offset];
+  *num_nu_vectors = mesh->subcells.nu_vector_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated nu_star_vectors
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of nu_star_vectors array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellNuStarVectors(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      TDyVector **nu_star_vectors,
+                                      PetscInt *num_nu_star_vectors) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *nu_star_vectors = &mesh->subcells.nu_star_vector[offset];
+  *num_nu_star_vectors = mesh->subcells.nu_vector_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated variable_continuity_coordinates
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of variable_continuity_coordinates array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellVariableContinutiyCoordinates(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      TDyCoordinate **variable_continuity_coordinates,
+                                      PetscInt *num_variable_continuity_coordinates) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *variable_continuity_coordinates = &mesh->subcells.variable_continuity_coordinates[offset];
+  *num_variable_continuity_coordinates = mesh->subcells.nu_vector_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated face_centroid
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of face_centroid array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellFaceCentroids(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      TDyCoordinate **face_centroids,
+                                      PetscInt *num_face_centroids) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *face_centroids = &mesh->subcells.variable_continuity_coordinates[offset];
+  *num_face_centroids = mesh->subcells.nu_vector_offset[subcell+1] - offset;
+  return 0;
+}
+
+/// Given a mesh and a subcell index, retrieve an array of associated vertices_coordinates
+/// array and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] subcell The index of a subcell within the mesh
+/// @param [out] is_face_up Stores a pointer to an array of vertices_coordinates array attached to
+///                         the given subcell
+/// @param [out] num_faces Stores the number of faces attached to the
+///                        given subcell
+PetscErrorCode TDyMeshGetSubcellVerticesCoordinates(TDyMesh *mesh,
+                                      PetscInt subcell,
+                                      TDyCoordinate **vertices_coordinates,
+                                      PetscInt *num_vertices_coordinates) {
+  PetscInt offset = mesh->subcells.face_offset[subcell];
+  *vertices_coordinates = &mesh->subcells.vertices_coordinates[offset];
+  *num_vertices_coordinates = mesh->subcells.nu_vector_offset[subcell+1] - offset;
+  return 0;
+}
+

--- a/src/mesh/tdymesh.c
+++ b/src/mesh/tdymesh.c
@@ -297,7 +297,7 @@ PetscErrorCode TDyMeshGetSubcellIsFaceUp(TDyMesh *mesh,
                                       PetscInt **is_face_up,
                                       PetscInt *num_faces) {
   PetscInt offset = mesh->subcells.face_offset[subcell];
-  *is_face_up = &mesh->subcells.face_ids[offset];
+  *is_face_up = &mesh->subcells.is_face_up[offset];
   *num_faces = mesh->subcells.face_offset[subcell+1] - offset;
   return 0;
 }

--- a/src/mesh/tdymesh.c
+++ b/src/mesh/tdymesh.c
@@ -144,6 +144,24 @@ PetscErrorCode TDyMeshGetVertexFaces(TDyMesh *mesh,
   return 0;
 }
 
+/// Given a mesh and a vertex index, retrieve an array of associated subface
+/// indices and their number.
+/// @param [in] mesh A mesh object
+/// @param [in] vertex The index of a vertex within the mesh
+/// @param [out] subfaces Stores a pointer to an array of faces attached to
+///                    the given vertex
+/// @param [out] num_subfaces Stores the number of faces attached to the given
+///                        vertex
+PetscErrorCode TDyMeshGetVertexSubfaces(TDyMesh *mesh,
+                                     PetscInt vertex,
+                                     PetscInt **subfaces,
+                                     PetscInt *num_subfaces) {
+  PetscInt offset = mesh->vertices.face_offset[vertex];
+  *subfaces = &mesh->vertices.subface_ids[offset];
+  *num_subfaces = mesh->vertices.face_offset[vertex+1] - offset;
+  return 0;
+}
+
 /// Given a mesh and a vertex index, retrieve an array of associated boundary
 ////face indices and their number.
 /// @param [in] mesh A mesh object

--- a/src/mesh/tdymesh.c
+++ b/src/mesh/tdymesh.c
@@ -16,6 +16,23 @@ PetscErrorCode TDyMeshDestroy(TDyMesh *mesh) {
   return 0;
 }
 
+/// Given a mesh and a cell index, retrieve an array of cell edge indices, and
+/// their number.
+/// @param [in] mesh A mesh object
+/// @param [in] cell The index of a cell within the mesh
+/// @param [out] edges Stores a pointer to an array of edges for the
+///                    given cell
+/// @param [out] num_edges Stores the number of edges for the given cell
+PetscErrorCode TDyMeshGetCellEdges(TDyMesh *mesh,
+                                      PetscInt cell,
+                                      PetscInt **edges,
+                                      PetscInt *num_edges) {
+  PetscInt offset = mesh->cells.edge_offset[cell];
+  *edges = &mesh->cells.edge_ids[offset];
+  *num_edges = mesh->cells.edge_offset[cell+1] - offset;
+  return 0;
+}
+
 /// Given a mesh and a cell index, retrieve an array of cell vertex indices, and
 /// their number.
 /// @param [in] mesh A mesh object

--- a/src/mpfao/2D/tdympfao2D.c
+++ b/src/mpfao/2D/tdympfao2D.c
@@ -70,10 +70,12 @@ PetscErrorCode TDyComputeGMatrixFor2DMesh(TDy tdy) {
 
     num_subcells = cells->num_subcells[icell];
 
+    PetscInt *vertex_ids, num_vertices;
+    ierr = TDyMeshGetCellVertices(mesh, icell, &vertex_ids, &num_vertices); CHKERRQ(ierr);
+
     for (isubcell=0; isubcell<num_subcells; isubcell++) {
 
-      PetscInt cOffsetVertex = cells->vertex_offset[icell];
-      PetscInt ivertex = cells->vertex_ids[cOffsetVertex + isubcell];
+      PetscInt ivertex = vertex_ids[isubcell];
       PetscInt subcell_id = icell*cells->num_subcells[icell]+isubcell;
 
       // determine ids of up & down edges
@@ -1219,9 +1221,11 @@ PetscReal TDyMPFAOVelocityNorm_2DMesh(TDy tdy) {
 
     if (!cells->is_local[icell]) continue;
 
+    PetscInt *edge_ids, num_edges;
+    ierr = TDyMeshGetCellEdges(mesh, icell, &edge_ids, &num_edges); CHKERRQ(ierr);
+
     for (iedge=0; iedge<cells->num_edges[icell]; iedge++) {
-      PetscInt cOffsetEdge = cells->edge_offset[icell];
-      edge_id = cells->edge_ids[cOffsetEdge + iedge];
+      edge_id = edge_ids[iedge];
 
       ierr = (*tdy->ops->computedirichletflux)(tdy, &(tdy->X[(edge_id + fStart)*dim]), vel, tdy->dirichletfluxctx);CHKERRQ(ierr);
       vel_normal = vel[0]*edges->normal[edge_id].V[0] + vel[1]*edges->normal[edge_id].V[1];

--- a/src/mpfao/2D/tdympfao2D.c
+++ b/src/mpfao/2D/tdympfao2D.c
@@ -1224,7 +1224,7 @@ PetscReal TDyMPFAOVelocityNorm_2DMesh(TDy tdy) {
     PetscInt *edge_ids, num_edges;
     ierr = TDyMeshGetCellEdges(mesh, icell, &edge_ids, &num_edges); CHKERRQ(ierr);
 
-    for (iedge=0; iedge<cells->num_edges[icell]; iedge++) {
+    for (iedge=0; iedge<num_edges; iedge++) {
       edge_id = edge_ids[iedge];
 
       ierr = (*tdy->ops->computedirichletflux)(tdy, &(tdy->X[(edge_id + fStart)*dim]), vel, tdy->dirichletfluxctx);CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_core.c
+++ b/src/mpfao/3D/tdympfao3D_core.c
@@ -89,7 +89,7 @@ PetscErrorCode TDyComputeGMatrixFor3DMesh(TDy tdy) {
       ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &subcell_face_ids, &subcell_num_faces); CHKERRQ(ierr);
       ierr = TDyMeshGetSubcellFaceAreas(mesh, subcell_id, &subcell_face_areas, &subcell_num_faces); CHKERRQ(ierr);
 
-      for (PetscInt ii=0;ii<subcells->num_faces[subcell_id];ii++) {
+      for (PetscInt ii=0;ii<subcell_num_faces;ii++) {
 
         PetscReal area;
         PetscReal normal[3];
@@ -100,7 +100,7 @@ PetscErrorCode TDyComputeGMatrixFor3DMesh(TDy tdy) {
 
         ierr = TDyFace_GetNormal(faces, face_id, dim, &normal[0]); CHKERRQ(ierr);
 
-        for (PetscInt jj=0;jj<subcells->num_faces[subcell_id];jj++) {
+        for (PetscInt jj=0;jj<subcell_num_faces;jj++) {
           PetscReal nu[dim];
 
           switch (tdy->mpfao_gmatrix_method){
@@ -296,7 +296,7 @@ PetscErrorCode ComputeCandFmatrix(TDy tdy, PetscInt ivertex, PetscInt varID,
     idx_interface_p2 = face_unknown_idx[2];
 
     PetscInt idx_flux, iface;
-    for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
+    for (iface=0; iface<subcell_num_faces; iface++) {
 
       PetscBool upwind_entries = (is_face_up[iface] == 1);
 
@@ -358,7 +358,7 @@ PetscErrorCode DetermineNumberOfUpAndDownBoundaryFaces(TDy tdy, PetscInt ivertex
     ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &face_ids, &num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetSubcellIsFaceUp(mesh, subcell_id, &is_face_up, &num_faces); CHKERRQ(ierr);
 
-    for (PetscInt iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
+    for (PetscInt iface=0; iface<num_faces; iface++) {
 
       PetscInt faceID = face_ids[iface];
       if (faces->is_internal[faceID]) continue;
@@ -763,7 +763,7 @@ PetscErrorCode ComputeTransmissibilityMatrix_ForNonCornerVertex(TDy tdy,
       PetscInt *subcell_face_ids, num_faces;
       ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &subcell_face_ids, &num_faces); CHKERRQ(ierr);
 
-      for (PetscInt iface=0;iface<subcells->num_faces[subcell_id];iface++) {
+      for (PetscInt iface=0;iface<num_faces;iface++) {
 
         PetscInt face_id = subcell_face_ids[iface];
 
@@ -907,7 +907,7 @@ PetscErrorCode ComputeTransmissibilityMatrix_ForBoundaryVertex_NotSharedWithInte
     ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &subcell_face_ids, &subcell_num_faces); CHKERRQ(ierr);
 
     PetscInt iface;
-    for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
+    for (iface=0; iface<subcell_num_faces; iface++) {
 
       PetscInt face_id = subcell_face_ids[iface];
       PetscInt *face_cell_ids, num_cell_ids;
@@ -938,7 +938,7 @@ PetscErrorCode ComputeTransmissibilityMatrix_ForBoundaryVertex_NotSharedWithInte
     // Determine the subface ID of 'face_id' that includes 'ivertex'
     PetscInt *vertex_ids, num_vertices;
     ierr = TDyMeshGetFaceVertices(mesh, face_id, &vertex_ids, &num_vertices); CHKERRQ(ierr);
-    for (PetscInt ii=0; ii<faces->num_vertices[face_id]; ii++){
+    for (PetscInt ii=0; ii<num_vertices; ii++){
       if (ivertex == vertex_ids[ii]) {
         subface_id = ii;
         break;

--- a/src/mpfao/3D/tdympfao3D_steady.c
+++ b/src/mpfao/3D/tdympfao3D_steady.c
@@ -38,15 +38,18 @@ PetscErrorCode TDyMPFAOComputeSystem_InternalVertices_3DMesh(TDy tdy,Mat K,Vec F
   for (ivertex=0; ivertex<mesh->num_vertices; ivertex++) {
 
     vertex_id = ivertex;
-    PetscInt vOffsetFace = vertices->face_offset[ivertex];
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
+
 
     if (vertices->num_boundary_faces[ivertex] == 0) {
       PetscInt nflux_in = vertices->num_faces[ivertex];
 
       for (irow=0; irow<nflux_in; irow++) {
 
-        PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+        PetscInt face_id = face_ids[irow];
         PetscInt fOffsetCell = faces->cell_offset[face_id];
 
         cell_id_up = faces->cell_ids[fOffsetCell + 0];
@@ -140,7 +143,9 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
     PetscInt vOffsetSubcell = vertices->subcell_offset[ivertex];
-    PetscInt vOffsetFace    = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
 
     npcen    = vertices->num_internal_cells[ivertex];
     npitf_bc = vertices->num_boundary_faces[ivertex];
@@ -183,7 +188,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
 
     for (irow=0; irow<nflux_in; irow++){
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       cell_id_up = faces->cell_ids[fOffsetCell + 0];
@@ -231,7 +236,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
 
       //row = cell_ids_from_to[irow][0];
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow + nflux_in];
+      PetscInt face_id = face_ids[irow + nflux_in];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       cell_id_up = faces->cell_ids[fOffsetCell + 0];

--- a/src/mpfao/3D/tdympfao3D_steady.c
+++ b/src/mpfao/3D/tdympfao3D_steady.c
@@ -14,7 +14,6 @@ PetscErrorCode TDyMPFAOComputeSystem_InternalVertices_3DMesh(TDy tdy,Mat K,Vec F
   TDyMesh       *mesh = tdy->mesh;
   TDyCell       *cells = &mesh->cells;
   TDyVertex     *vertices = &mesh->vertices;
-  TDyFace       *faces = &mesh->faces;
   PetscInt       ivertex, cell_id_up, cell_id_dn;
   PetscInt       irow, icol, row, col, vertex_id;
   PetscReal      value;
@@ -50,10 +49,11 @@ PetscErrorCode TDyMPFAOComputeSystem_InternalVertices_3DMesh(TDy tdy,Mat K,Vec F
       for (irow=0; irow<nflux_in; irow++) {
 
         PetscInt face_id = face_ids[irow];
-        PetscInt fOffsetCell = faces->cell_offset[face_id];
+        PetscInt *cell_ids, num_cells;
+        ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-        cell_id_up = faces->cell_ids[fOffsetCell + 0];
-        cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+        cell_id_up = cell_ids[0];
+        cell_id_dn = cell_ids[1];
 
         for (icol=0; icol<vertices->num_internal_cells[ivertex]; icol++) {
           col   = vertices->internal_cell_ids[vOffsetCell + icol];
@@ -175,9 +175,11 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
       for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
 
         PetscInt face_id = face_ids[iface];
-        PetscInt fOffsetCell = faces->cell_offset[face_id];
-        cell_id_up = faces->cell_ids[fOffsetCell + 0];
-        cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+        PetscInt *cell_ids, num_cells;
+        ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
+
+        cell_id_up = cell_ids[0];
+        cell_id_dn = cell_ids[1];
 
         if (faces->is_internal[face_id] == 0) {
           PetscInt f;
@@ -191,10 +193,11 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
     for (irow=0; irow<nflux_in; irow++){
 
       PetscInt face_id = face_ids[irow];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
 
       if (cells->is_local[cell_id_up]) {
         row   = cells->global_id[cell_id_up];
@@ -239,10 +242,11 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
       //row = cell_ids_from_to[irow][0];
 
       PetscInt face_id = face_ids[irow + nflux_in];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
 
       if (cell_id_up>-1 && cells->is_local[cell_id_up]) {
 
@@ -360,9 +364,10 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
       PetscInt face_id = face_ids[iface];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      row = faces->cell_ids[fOffsetCell + 0];
+      row = cell_ids[0];
       if (row>-1) sign = -1.0;
       else        sign = +1.0;
 
@@ -381,11 +386,12 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
       PetscInt face_id = face_ids[iface];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      row = faces->cell_ids[fOffsetCell + 0];
-      PetscInt cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      PetscInt cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      row = cell_ids[0];
+      PetscInt cell_id_up = cell_ids[0];
+      PetscInt cell_id_dn = cell_ids[1];
 
       if (cell_id_up>-1 && cells->is_local[cell_id_up]) {
         row   = cells->global_id[cell_id_up];

--- a/src/mpfao/3D/tdympfao3D_steady.c
+++ b/src/mpfao/3D/tdympfao3D_steady.c
@@ -167,12 +167,14 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
       isubcell = vertices->subcell_ids[vOffsetSubcell + irow];
 
       PetscInt subcell_id = icell*cells->num_subcells[icell]+isubcell;
-      PetscInt sOffsetFace = subcells->face_offset[subcell_id];
+
+      PetscInt *face_ids, num_faces;
+      ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &face_ids, &num_faces); CHKERRQ(ierr);
 
       PetscInt iface;
       for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
 
-        PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
+        PetscInt face_id = face_ids[iface];
         PetscInt fOffsetCell = faces->cell_offset[face_id];
         cell_id_up = faces->cell_ids[fOffsetCell + 0];
         cell_id_dn = faces->cell_ids[fOffsetCell + 1];
@@ -339,12 +341,14 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
     isubcell = vertices->subcell_ids[vOffsetSubcell + 0];
 
     PetscInt subcell_id = icell*cells->num_subcells[icell]+isubcell;
-    PetscInt sOffsetFace = subcells->face_offset[subcell_id];
+
+    PetscInt *face_ids, num_faces;
+    ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &face_ids, &num_faces); CHKERRQ(ierr);
 
     numBoundary = 0;
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
-      PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
+      PetscInt face_id = face_ids[iface];
 
       PetscInt f;
       f = faces->id[face_id] + fStart;
@@ -355,7 +359,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
 
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
-      PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
+      PetscInt face_id = face_ids[iface];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       row = faces->cell_ids[fOffsetCell + 0];
@@ -376,7 +380,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
     // For fluxes through boundary edges, only add contribution to the vector
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
-      PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
+      PetscInt face_id = face_ids[iface];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       row = faces->cell_ids[fOffsetCell + 0];

--- a/src/mpfao/3D/tdympfao3D_th_ts.c
+++ b/src/mpfao/3D/tdympfao3D_th_ts.c
@@ -50,7 +50,11 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh_TH(Vec Ul, Vec R, void *ctx) {
   for (ivertex=0; ivertex<mesh->num_vertices; ivertex++) {
 
     if (!vertices->is_local[ivertex]) continue;
-    PetscInt vOffsetFace = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    PetscInt *subface_ids, num_subfaces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
+    ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 
     npitf_bc = vertices->num_boundary_faces[ivertex];
     nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
@@ -60,8 +64,8 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh_TH(Vec Ul, Vec R, void *ctx) {
     // Compute = T*P
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
       PetscInt num_subfaces = 4;
 
       if (!faces->is_local[face_id]) continue;
@@ -345,7 +349,11 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh_TH(Vec Ul, Mat A, void *ctx) {
     if (vertices->num_boundary_faces[ivertex] > 0 && vertices->num_internal_cells[ivertex] < 2) continue;
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
-    PetscInt vOffsetFace    = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    PetscInt *subface_ids, num_subfaces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
+    ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 
     npitf_bc = vertices->num_boundary_faces[ivertex];
     nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
@@ -356,8 +364,8 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh_TH(Vec Ul, Mat A, void *ctx) {
     // Compute = T*P
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
       PetscInt num_subfaces = 4;
 
       if (!faces->is_local[face_id]) continue;
@@ -386,7 +394,7 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh_TH(Vec Ul, Mat A, void *ctx) {
     //
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       cell_id_up = faces->cell_ids[fOffsetCell + 0];

--- a/src/mpfao/3D/tdympfao3D_th_ts.c
+++ b/src/mpfao/3D/tdympfao3D_th_ts.c
@@ -83,10 +83,11 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh_TH(Vec Ul, Vec R, void *ctx) {
     //      (kr/mu)_{ij,upwind} = (kr/mu)_{i} if velocity is from i to j
     //                          = (kr/mu)_{j} otherwise
     //      T includes product of K and A_{ij}
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
       
       if (TtimesP[irow] < 0.0) { // up ---> dn
          // Is the cell_id_up an internal or boundary cell?
@@ -395,10 +396,11 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh_TH(Vec Ul, Mat A, void *ctx) {
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {
       
       PetscInt face_id = face_ids[irow];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
 
       dukvr_dPup = 0.0;
       dukvr_dPdn = 0.0;

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -65,9 +65,10 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec Ul, Vec R, void *ctx) {
        //                          = (kr/mu)_{j} otherwise
        //      T includes product of K and A_{ij}
 
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
-      PetscInt cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      PetscInt cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
+      PetscInt cell_id_up = cell_ids[0];
+      PetscInt cell_id_dn = cell_ids[1];
 
       PetscReal den_aveg = 0.0;
       if (cell_id_up>=0) {
@@ -298,10 +299,11 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
 
       PetscInt face_id = face_ids[irow];
       PetscInt subface_id = subface_ids[irow];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-      PetscInt cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      PetscInt cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      PetscInt cell_id_up = cell_ids[0];
+      PetscInt cell_id_dn = cell_ids[1];
 
       // If using neumann bc (which is currently no-flux), then skip the face
       if ( tdy->mpfao_bc_type == MPFAO_NEUMANN_BC  && (cell_id_up<0 || cell_id_dn <0))  continue;

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -36,8 +36,11 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec Ul, Vec R, void *ctx) {
   for (PetscInt ivertex=0; ivertex<mesh->num_vertices; ivertex++) {
 
     if (!vertices->is_local[ivertex]) continue;
-    //if (vertices->num_boundary_faces[ivertex] != 0) continue;
-    PetscInt vOffsetFace = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    PetscInt *subface_ids, num_subfaces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
+    ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 
     PetscInt npitf_bc = vertices->num_boundary_faces[ivertex];
     PetscInt nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
@@ -46,8 +49,8 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec Ul, Vec R, void *ctx) {
     PetscScalar TtimesP[nflux_in + npitf_bc];
     for (PetscInt irow=0; irow<nflux_in + npitf_bc; irow++) {
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
       PetscInt num_subfaces = 4;
 
       if (!faces->is_local[face_id]) continue;
@@ -254,7 +257,11 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
     PetscInt vertex_id = ivertex;
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
-    PetscInt vOffsetFace    = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    PetscInt *subface_ids, num_subfaces;
+    ierr = TDyMeshGetVertexFaces(mesh, vertex_id, &face_ids, &num_faces); CHKERRQ(ierr);
+    ierr = TDyMeshGetVertexSubfaces(mesh, vertex_id, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 
     PetscInt npitf_bc = vertices->num_boundary_faces[ivertex];
     PetscInt nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
@@ -263,8 +270,8 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
     PetscScalar TtimesP[nflux_in + npitf_bc];
     for (PetscInt irow=0; irow < nflux_in + npitf_bc; irow++) {
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
       PetscInt num_subfaces = 4;
 
       if (!faces->is_local[face_id]) continue;
@@ -289,8 +296,8 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
     //
     for (PetscInt irow=0; irow<nflux_in + npitf_bc; irow++) {
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
-      PetscInt subface_id = vertices->subface_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       PetscInt cell_id_up = faces->cell_ids[fOffsetCell + 0];

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -66,7 +66,7 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec Ul, Vec R, void *ctx) {
        //      T includes product of K and A_{ij}
 
       PetscInt *cell_ids, num_cells;
-      ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
       PetscInt cell_id_up = cell_ids[0];
       PetscInt cell_id_dn = cell_ids[1];
 
@@ -300,7 +300,7 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
       PetscInt face_id = face_ids[irow];
       PetscInt subface_id = subface_ids[irow];
       PetscInt *cell_ids, num_cells;
-      ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
       PetscInt cell_id_up = cell_ids[0];
       PetscInt cell_id_dn = cell_ids[1];

--- a/src/mpfao/3D/tdympfao3D_ts.c
+++ b/src/mpfao/3D/tdympfao3D_ts.c
@@ -37,8 +37,8 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_3DMesh(Vec Ul, Vec R, void *ctx) {
 
     if (!vertices->is_local[ivertex]) continue;
 
-    PetscInt *face_ids, num_faces;
-    PetscInt *subface_ids, num_subfaces;
+    PetscInt *face_ids, *subface_ids;
+    PetscInt num_faces, num_subfaces;
     ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 
@@ -258,8 +258,8 @@ PetscErrorCode TDyMPFAOIJacobian_Vertices_3DMesh(Vec Ul, Mat A, void *ctx) {
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
 
-    PetscInt *face_ids, num_faces;
-    PetscInt *subface_ids, num_subfaces;
+    PetscInt *face_ids, *subface_ids;
+    PetscInt num_faces, num_subfaces;
     ierr = TDyMeshGetVertexFaces(mesh, vertex_id, &face_ids, &num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetVertexSubfaces(mesh, vertex_id, &subface_ids, &num_subfaces); CHKERRQ(ierr);
 

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -659,12 +659,11 @@ PetscErrorCode TDyMPFAORecoverVelocity_3DMesh(TDy tdy, Vec U) {
 PetscErrorCode TDyMPFAO_SetBoundaryPressure(TDy tdy, Vec Ul) {
 
   TDyMesh *mesh = tdy->mesh;
-  TDyCell *cells = &mesh->cells;
   TDyFace *faces = &mesh->faces;
   PetscErrorCode ierr;
   PetscInt dim, ncells;
   PetscInt p_bnd_idx, cell_id, iface;
-  PetscReal *p, gz, *p_vec_ptr, *u_p;
+  PetscReal *p, *p_vec_ptr, *u_p;
   PetscInt c, cStart, cEnd;
 
   PetscFunctionBegin;

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -155,7 +155,9 @@ PetscErrorCode TDyMPFAORecoverVelocity_InternalVertices_3DMesh(TDy tdy, Vec U, P
       PetscScalar Vcomputed[nflux_in];
 
       PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
-      PetscInt vOffsetFace    = vertices->face_offset[ivertex];
+
+      PetscInt *face_ids, num_faces;
+      ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
 
       // Save local pressure stencil and initialize veloctiy
       PetscInt icell, cell_id;
@@ -172,7 +174,7 @@ PetscErrorCode TDyMPFAORecoverVelocity_InternalVertices_3DMesh(TDy tdy, Vec U, P
       // F = T*P
       for (irow=0; irow<nflux_in; irow++) {
 
-        PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+        PetscInt face_id = face_ids[irow];
         PetscInt fOffsetCell = faces->cell_offset[face_id];
 
         if (!faces->is_local[face_id]) continue;
@@ -285,7 +287,9 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
 
     PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
     PetscInt vOffsetSubcell = vertices->subcell_offset[ivertex];
-    PetscInt vOffsetFace    = vertices->face_offset[ivertex];
+
+    PetscInt *face_ids, num_faces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
 
     npcen    = vertices->num_internal_cells[ivertex];
     npitf_bc = vertices->num_boundary_faces[ivertex];
@@ -333,7 +337,7 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
 
     for (irow=0; irow<nflux_in; irow++){
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow];
+      PetscInt face_id = face_ids[irow];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       if (!faces->is_local[face_id]) continue;
@@ -419,7 +423,7 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
     // For fluxes through boundary edges, only add contribution to the vector
     for (irow=0; irow<npitf_bc; irow++) {
 
-      PetscInt face_id = vertices->face_ids[vOffsetFace + irow + nflux_in];
+      PetscInt face_id = face_ids[irow + nflux_in];
       PetscInt fOffsetCell = faces->cell_offset[face_id];
 
       if (!faces->is_local[face_id]) continue;

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -44,14 +44,15 @@ PetscErrorCode TDyUpdateBoundaryState(TDy tdy) {
 
     if (faces->is_internal[iface]) continue;
 
-    PetscInt fOffsetCell = faces->cell_offset[iface];
+    PetscInt *cell_ids, num_cells;
+    ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-    if (faces->cell_ids[fOffsetCell + 0] >= 0) {
-      cell_id = faces->cell_ids[fOffsetCell + 0];
-      p_bnd_idx = -faces->cell_ids[fOffsetCell + 1] - 1;
+    if (cell_ids[0] >= 0) {
+      cell_id = cell_ids[0];
+      p_bnd_idx = -cell_ids[1] - 1;
     } else {
-      cell_id = faces->cell_ids[fOffsetCell + 1];
-      p_bnd_idx = -faces->cell_ids[fOffsetCell + 0] - 1;
+      cell_id = cell_ids[1];
+      p_bnd_idx = -cell_ids[0] - 1;
     }
 
     switch (cc->SatFuncType[cell_id]) {
@@ -175,11 +176,12 @@ PetscErrorCode TDyMPFAORecoverVelocity_InternalVertices_3DMesh(TDy tdy, Vec U, P
       for (irow=0; irow<nflux_in; irow++) {
 
         PetscInt face_id = face_ids[irow];
-        PetscInt fOffsetCell = faces->cell_offset[face_id];
+        PetscInt *cell_ids, num_cells;
+        ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
         if (!faces->is_local[face_id]) continue;
 
-        cell_id_up = faces->cell_ids[fOffsetCell + 0];
+        cell_id_up = cell_ids[0];
 
         PetscInt iface=-1;
         PetscInt subcell_id;
@@ -321,10 +323,11 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
       for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
 
         PetscInt face_id = face_ids[iface];
-        PetscInt fOffsetCell = faces->cell_offset[face_id];
+        PetscInt *cell_ids, num_cells;
+        ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-        cell_id_up = faces->cell_ids[fOffsetCell + 0];
-        cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+        cell_id_up = cell_ids[0];
+        cell_id_dn = cell_ids[1];
 
         if (faces->is_internal[face_id] == 0) {
           PetscInt f;
@@ -343,12 +346,13 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
     for (irow=0; irow<nflux_in; irow++){
 
       PetscInt face_id = face_ids[irow];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
       if (!faces->is_local[face_id]) continue;
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
       icell = vertices->internal_cell_ids[vOffsetCell + irow];
 
       if (cells->is_local[cell_id_up]) {
@@ -435,12 +439,13 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertic
     for (irow=0; irow<npitf_bc; irow++) {
 
       PetscInt face_id = face_ids[irow + nflux_in];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
 
       if (!faces->is_local[face_id]) continue;
 
-      cell_id_up = faces->cell_ids[fOffsetCell + 0];
-      cell_id_dn = faces->cell_ids[fOffsetCell + 1];
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
 
       if (cell_id_up>-1 && cells->is_local[cell_id_up]) {
 
@@ -612,11 +617,12 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_NotSharedWithInternalVer
     for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
 
       PetscInt face_id = face_ids[iface];
-      PetscInt fOffsetCell = faces->cell_offset[face_id];
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
       if (!faces->is_local[face_id]) continue;
 
-      row = faces->cell_ids[fOffsetCell + 0];
+      row = cell_ids[0];
       if (row>-1) sign = -1.0;
       else        sign = +1.0;
 
@@ -716,14 +722,15 @@ PetscErrorCode TDyMPFAO_SetBoundaryPressure(TDy tdy, Vec Ul) {
 
     if (faces->is_internal[iface]) continue;
 
-      PetscInt fOffsetCell = faces->cell_offset[iface];
+    PetscInt *cell_ids, num_cells;
+    ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-    if (faces->cell_ids[fOffsetCell + 0] >= 0) {
-      cell_id = faces->cell_ids[fOffsetCell + 0];
-      p_bnd_idx = -faces->cell_ids[fOffsetCell + 1] - 1;
+    if (cell_ids[0] >= 0) {
+      cell_id = cell_ids[0];
+      p_bnd_idx = -cell_ids[1] - 1;
     } else {
-      cell_id = faces->cell_ids[fOffsetCell + 1];
-      p_bnd_idx = -faces->cell_ids[fOffsetCell + 0] - 1;
+      cell_id = cell_ids[1];
+      p_bnd_idx = -cell_ids[0] - 1;
     }
 
     if (tdy->ops->computedirichletvalue) {
@@ -772,14 +779,15 @@ PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
 
     if (faces->is_internal[iface]) continue;
 
-      PetscInt fOffsetCell = faces->cell_offset[iface];
+    PetscInt *cell_ids, num_cells;
+    ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
 
-    if (faces->cell_ids[fOffsetCell + 0] >= 0) {
-      cell_id = faces->cell_ids[fOffsetCell + 0];
-      t_bnd_idx = -faces->cell_ids[fOffsetCell + 1] - 1;
+    if (cell_ids[0] >= 0) {
+      cell_id = cell_ids[0];
+      t_bnd_idx = -cell_ids[1] - 1;
     } else {
-      cell_id = faces->cell_ids[fOffsetCell + 1];
-      t_bnd_idx = -faces->cell_ids[fOffsetCell + 0] - 1;
+      cell_id = cell_ids[1];
+      t_bnd_idx = -cell_ids[0] - 1;
     }
 
     if (tdy->ops->computetemperaturedirichletvalue) {

--- a/src/mpfao/3D/tdympfao3D_utils.c
+++ b/src/mpfao/3D/tdympfao3D_utils.c
@@ -600,7 +600,7 @@ PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_NotSharedWithInternalVer
     ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &face_ids, &num_faces); CHKERRQ(ierr);
     ierr = TDyMeshGetSubcellFaceAreas(mesh, subcell_id, &face_areas, &num_faces); CHKERRQ(ierr);
 
-    for (iface=0; iface<subcells->num_faces[subcell_id]; iface++) {
+    for (iface=0; iface<num_faces; iface++) {
       
       PetscInt face_id = face_ids[iface];
 

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -72,10 +72,8 @@ PetscErrorCode TDyIOSetMode(TDy tdy, TDyIOFormat format){
 
 PetscErrorCode TDyIOWriteVec(TDy tdy){
   PetscErrorCode ierr;
-  PetscInt numCell,istart,iend;
   PetscBool useNatural;
   
-  int num_vars = tdy->io->num_vars;
   Vec v = tdy->solution;
   DM dm = tdy->dm;
   PetscReal time = tdy->ti->time;
@@ -229,7 +227,7 @@ PetscErrorCode TDyIOWriteXMFHeader(PetscInt numCell,PetscInt dim,PetscInt numVer
 
   FILE *fid;
 
-  char *cellMap[24] = {"0"};
+  const char *cellMap[24] = {"0"};
   cellMap[1] = "Polyvertex";
   cellMap[2] = "Polyline";
   cellMap[6] = "Triangle";
@@ -285,6 +283,8 @@ PetscErrorCode TDyIOWriteXMFHeader(PetscInt numCell,PetscInt dim,PetscInt numVer
   fprintf(fid,"\n        </Geometry>");
 
   fclose(fid);
+
+  PetscFunctionReturn(0);
 }
 
 PetscErrorCode TDyIOWriteXMFAttribute(char* name,PetscInt numCell){
@@ -320,6 +320,8 @@ PetscErrorCode TDyIOWriteXMFAttribute(char* name,PetscInt numCell){
   fprintf(fid,"\n        </Attribute>");
 
   fclose(fid);
+
+  PetscFunctionReturn(0);
 }
 
 PetscErrorCode TDyIOWriteXMFFooter(){
@@ -332,6 +334,7 @@ PetscErrorCode TDyIOWriteXMFFooter(){
   fprintf(fid,"\n  </Domain>");
   fprintf(fid,"\n</Xdmf>\n");
   fclose(fid);
+  PetscFunctionReturn(0);
 }
 
 PetscErrorCode TDyIODestroy(TDyIO *io) {


### PR DESCRIPTION
The code changes include:
1. Use of refactored mesh functions to access various member variables of TDy mesh elements to avoid using `*Offset*`. e.g.

Old approach
```
PetscInt sOffsetFace = subcells->face_offset[subcell_id];

for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
  PetscInt face_id = subcells->face_ids[sOffsetFace + iface];
  ...
}
```
New approach:
```
PetscInt *face_ids, num_faces;
ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &face_ids, &num_faces); CHKERRQ(ierr);

for (iface=0;iface<subcells->num_faces[subcell_id];iface++) {
  PetscInt face_id = face_ids[iface];
}
```
2. Conversion of `TDySubcell` and `TDyVector` data to a compressed format.


Note: 
 - There is no need to compress `TDyFace` as it is already in compressed format.
 - `TDyCell` is not converted in the compressed format as it leads to an error that will be fixed in the future.