### PR TITLE
Fixes TPF for parallel runs

### DIFF
--- a/include/private/tdympfao3Dcoreimpl.h
+++ b/include/private/tdympfao3Dcoreimpl.h
@@ -3,7 +3,8 @@
 
 #include <petsc.h>
 
-PETSC_INTERN PetscErrorCode TDyComputeGMatrixFor3DMesh(TDy);
+PETSC_INTERN PetscErrorCode TDyComputeGMatrixDefaultFor3DMesh(TDy);
+PETSC_INTERN PetscErrorCode TDyComputeGMatrixTPFFor3DMesh(TDy);
 PETSC_INTERN PetscErrorCode TDyUpdateTransmissibilityMatrix(TDy);
 PETSC_INTERN PetscErrorCode TDyComputeTransmissibilityMatrix3DMesh(TDy);
 PETSC_INTERN PetscErrorCode TDyComputeGravityDiscretizationFor3DMesh(TDy);

--- a/include/private/tdympfao3Dcoreimpl.h
+++ b/include/private/tdympfao3Dcoreimpl.h
@@ -3,7 +3,7 @@
 
 #include <petsc.h>
 
-PETSC_INTERN PetscErrorCode TDyComputeGMatrixDefaultFor3DMesh(TDy);
+PETSC_INTERN PetscErrorCode TDyComputeGMatrixMPFAOFor3DMesh(TDy);
 PETSC_INTERN PetscErrorCode TDyComputeGMatrixTPFFor3DMesh(TDy);
 PETSC_INTERN PetscErrorCode TDyUpdateTransmissibilityMatrix(TDy);
 PETSC_INTERN PetscErrorCode TDyComputeTransmissibilityMatrix3DMesh(TDy);

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -807,8 +807,8 @@ PetscErrorCode ConvertMeshElementToCompressedFormatIntegerValues(TDy tdy, PetscI
   }
 
   if (update_offset) {
-    new_offset += (*subelement_num)[num_element];
-    (*subelement_offset)[num_element+1] = new_offset;
+    new_offset += (*subelement_num)[num_element-1];
+    (*subelement_offset)[num_element] = new_offset;
   }
 
   for (PetscInt ii = count; ii < default_offset_size*num_element; ii++) {
@@ -861,8 +861,8 @@ PetscErrorCode ConvertMeshElementToCompressedFormatTDyVectorValues(TDy tdy, Pets
   }
 
   if (update_offset) {
-    new_offset += (*subelement_num)[num_element];
-    (*subelement_offset)[num_element+1] = new_offset;
+    new_offset += (*subelement_num)[num_element-1];
+    (*subelement_offset)[num_element] = new_offset;
   }
 
   for (PetscInt ii = count; ii < default_offset_size*num_element; ii++) {
@@ -916,8 +916,8 @@ PetscErrorCode ConvertMeshElementToCompressedFormatTDyCoordinateValues(TDy tdy, 
   }
 
   if (update_offset) {
-    new_offset += (*subelement_num)[num_element];
-    (*subelement_offset)[num_element+1] = new_offset;
+    new_offset += (*subelement_num)[num_element-1];
+    (*subelement_offset)[num_element] = new_offset;
   }
 
   for (PetscInt ii = count; ii < default_offset_size*num_element; ii++) {
@@ -965,8 +965,8 @@ PetscErrorCode ConvertMeshElementToCompressedFormatRealValues(TDy tdy, PetscInt 
   }
 
   if (update_offset) {
-    new_offset += (*subelement_num)[num_element];
-    (*subelement_offset)[num_element+1] = new_offset;
+    new_offset += (*subelement_num)[num_element-1];
+    (*subelement_offset)[num_element] = new_offset;
   }
 
   for (PetscInt ii = count; ii < default_offset_size*num_element; ii++) {

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -1379,7 +1379,6 @@ PetscErrorCode UpdateFaceOrderAroundAVertex3DMesh(TDy tdy) {
 
   DM             dm = tdy->dm;
   TDyMesh       *mesh = tdy->mesh;
-  TDyVertex     *vertices = &mesh->vertices;
   TDyFace       *faces = &mesh->faces;
   PetscErrorCode ierr;
 
@@ -1998,7 +1997,6 @@ PetscInt VertexIdWithSameXYInACell(TDy tdy, PetscInt icell, PetscInt ivertex) {
   PetscFunctionBegin;
 
   TDyMesh *mesh = tdy->mesh;
-  TDyCell *cells = &mesh->cells;
   PetscInt result;
   PetscBool found = PETSC_FALSE;
 
@@ -2039,7 +2037,6 @@ PetscBool IsCellAboveTheVertex(TDy tdy, PetscInt icell, PetscInt ivertex) {
   PetscBool is_above;
 
   TDyMesh *mesh = tdy->mesh;
-  TDyCell *cells = &mesh->cells;
   TDyVertex *vertices = &mesh->vertices;
   PetscBool found = PETSC_FALSE;
   PetscErrorCode ierr;
@@ -2077,7 +2074,6 @@ PetscErrorCode DetermineCellsAboveAndBelow(TDy tdy, PetscInt ivertex, PetscInt *
   PetscFunctionBegin;
 
   TDyMesh *mesh = tdy->mesh;
-  TDyCell *cells = &mesh->cells;
   TDyFace *faces = &mesh->faces;
   TDyVertex *vertices = &mesh->vertices;
   PetscErrorCode ierr;
@@ -2222,7 +2218,6 @@ PetscBool AreCellsNeighbors(TDy tdy, PetscInt cell_id_1, PetscInt cell_id_2) {
   PetscFunctionBegin;
 
   TDyMesh *mesh = tdy->mesh;
-  TDyCell *cells = &mesh->cells;
   PetscErrorCode ierr;
 
   PetscInt *face_ids_1, num_faces_1;
@@ -2286,7 +2281,6 @@ PetscErrorCode ArrangeCellsInAnCircularOrder(TDy tdy, PetscInt *cellsAbvBlw, Pet
 PetscInt IDofFaceSharedByTwoCellsForACommonVertex(TDy tdy, PetscInt ivertex, PetscInt icell_1, PetscInt icell_2) {
 
   TDyMesh *mesh = tdy->mesh;
-  TDyVertex *vertices = &mesh->vertices;
   TDyFace *faces = &mesh->faces;
   PetscErrorCode ierr;
 

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -3660,6 +3660,7 @@ PetscErrorCode TDyBuildMesh(TDy tdy) {
     break;
 
   case 3:
+    ierr = ConvertCellsToCompressedFormat(tdy); CHKERRQ(ierr);
     ierr = ConvertVerticesToCompressedFormat(tdy); CHKERRQ(ierr);
     ierr = ConvertSubcellsToCompressedFormat(tdy); CHKERRQ(ierr);
     ierr = UpdateFaceOrderAroundAVertex3DMesh(tdy); CHKERRQ(ierr);

--- a/src/mpfao/3D/tdympfao3D_core.c
+++ b/src/mpfao/3D/tdympfao3D_core.c
@@ -324,7 +324,6 @@ PetscErrorCode ComputeCandFmatrix(TDy tdy, PetscInt ivertex, PetscInt varID,
   TDyMesh *mesh = tdy->mesh;
   TDyCell *cells = &mesh->cells;
   TDyVertex *vertices = &mesh->vertices;
-  TDySubcell *subcells = &mesh->subcells;
 
   PetscInt vOffsetCell    = vertices->internal_cell_offset[ivertex];
   PetscInt vOffsetSubcell = vertices->subcell_offset[ivertex];
@@ -400,7 +399,6 @@ PetscErrorCode DetermineNumberOfUpAndDownBoundaryFaces(TDy tdy, PetscInt ivertex
   TDyMesh *mesh = tdy->mesh;
   TDyCell *cells = &mesh->cells;
   TDyVertex *vertices = &mesh->vertices;
-  TDySubcell *subcells = &mesh->subcells;
   TDyFace *faces = &mesh->faces;
 
   PetscInt npcen = vertices->num_internal_cells[ivertex];
@@ -525,7 +523,6 @@ PetscErrorCode ComputeTransmissibilityMatrix_ForNonCornerVertex(TDy tdy,
 
   TDyMesh *mesh = tdy->mesh;
   TDyVertex *vertices = &mesh->vertices;
-  TDySubcell *subcells = &mesh->subcells;
   TDyFace *faces = &mesh->faces;
   PetscInt icell;
   PetscReal **Gmatrix;

--- a/src/mpfao/3D/tdympfao3D_core.c
+++ b/src/mpfao/3D/tdympfao3D_core.c
@@ -38,7 +38,88 @@ PetscErrorCode TDyComputeEntryOfGMatrix3D(PetscReal area, PetscReal n[3],
 }
 
 /* -------------------------------------------------------------------------- */
-PetscErrorCode TDyComputeGMatrixFor3DMesh(TDy tdy) {
+PetscErrorCode TDyComputeGMatrixDefaultFor3DMesh(TDy tdy) {
+
+  PetscFunctionBegin;
+  TDY_START_FUNCTION_TIMER()
+
+  PetscInt dim,icell;
+  PetscErrorCode ierr;
+
+  TDyMesh *mesh = tdy->mesh;
+  TDyCell *cells = &mesh->cells;
+  TDyFace *faces = &mesh->faces;
+  TDySubcell *subcells = &mesh->subcells;
+
+    MaterialProp *matprop = tdy->matprop;
+
+  ierr = DMGetDimension(tdy->dm, &dim); CHKERRQ(ierr);
+
+  for (icell=0; icell<mesh->num_cells; icell++) {
+
+    // extract permeability tensor
+    PetscReal K[3][3];
+
+    for (PetscInt ii=0; ii<dim; ii++) {
+      for (PetscInt jj=0; jj<dim; jj++) {
+        K[ii][jj] = matprop->K0[icell*dim*dim + ii*dim + jj];
+      }
+    }
+
+    // extract thermal conductivity tensor
+    PetscReal Kappa[3][3];
+
+    if (tdy->mode == TH) {
+      for (PetscInt ii=0; ii<dim; ii++) {
+        for (PetscInt jj=0; jj<dim; jj++) {
+          Kappa[ii][jj] = matprop->Kappa0[icell*dim*dim + ii*dim + jj];
+        }
+      }
+    }
+
+    for (PetscInt isubcell=0; isubcell<cells->num_subcells[icell]; isubcell++) {
+
+      PetscInt subcell_id = icell*cells->num_subcells[icell]+isubcell;
+
+      PetscInt *subcell_face_ids, subcell_num_faces;
+      PetscReal *subcell_face_areas;
+      ierr = TDyMeshGetSubcellFaces(mesh, subcell_id, &subcell_face_ids, &subcell_num_faces); CHKERRQ(ierr);
+      ierr = TDyMeshGetSubcellFaceAreas(mesh, subcell_id, &subcell_face_areas, &subcell_num_faces); CHKERRQ(ierr);
+
+      for (PetscInt ii=0;ii<subcell_num_faces;ii++) {
+
+        PetscInt face_id = subcell_face_ids[ii];
+        PetscReal area = subcell_face_areas[ii];
+
+        PetscReal normal[3];
+        ierr = TDyFace_GetNormal(faces, face_id, dim, &normal[0]); CHKERRQ(ierr);
+
+        for (PetscInt jj=0;jj<subcell_num_faces;jj++) {
+          PetscReal nu[dim];
+
+          ierr = TDySubCell_GetIthNuVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
+
+          ierr = TDyComputeEntryOfGMatrix3D(area, normal, K, nu, subcells->T[subcell_id], dim,
+                                          &(tdy->subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
+
+          if (tdy->mode == TH) {
+               ierr = TDySubCell_GetIthNuVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
+
+              ierr = TDyComputeEntryOfGMatrix3D(area, normal, Kappa,
+                                  nu, subcells->T[subcell_id], dim,
+                                  &(tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
+          } // TH
+        } // jj-subcell-faces
+      } // ii-isubcell faces
+    } // isubcell
+  } // icell
+
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(0);
+}
+
+/* -------------------------------------------------------------------------- */
+PetscErrorCode TDyComputeGMatrixTPFFor3DMesh(TDy tdy) {
 
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
@@ -103,93 +184,76 @@ PetscErrorCode TDyComputeGMatrixFor3DMesh(TDy tdy) {
         for (PetscInt jj=0;jj<subcell_num_faces;jj++) {
           PetscReal nu[dim];
 
-          switch (tdy->mpfao_gmatrix_method){
-          case MPFAO_GMATRIX_DEFAULT:
-             ierr = TDySubCell_GetIthNuVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
+          if (ii /= jj) {
 
-             ierr = TDyComputeEntryOfGMatrix3D(area, normal, K, nu, subcells->T[subcell_id], dim,
-                                            &(tdy->subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
-             break;
+            tdy->subc_Gmatrix[icell][isubcell][ii][jj] = 0.0;
 
-          case MPFAO_GMATRIX_TPF:
-            if (ii == jj) {
+          } else {
 
-              PetscInt neighbor_cell_id;
-              PetscReal neighbor_cell_cen[dim],cell_cen[dim], dist;
+            PetscInt neighbor_cell_id;
+            PetscReal neighbor_cell_cen[dim],cell_cen[dim], dist;
 
-              PetscInt faceCellOffset = faces->cell_offset[face_id];
+            PetscInt faceCellOffset = faces->cell_offset[face_id];
 
-              ierr = TDyCell_GetCentroid2(cells, icell, dim, &cell_cen[0]); CHKERRQ(ierr);
+            ierr = TDyCell_GetCentroid2(cells, icell, dim, &cell_cen[0]); CHKERRQ(ierr);
 
-              if ( (faces->cell_ids[faceCellOffset]==icell) ) {
-                neighbor_cell_id = faces->cell_ids[faceCellOffset+1];
-              } else {
-                neighbor_cell_id = faces->cell_ids[faceCellOffset];
-              }
-
-              PetscReal K_neighbor[3][3];
-              PetscInt kk,mm;
-
-              if (neighbor_cell_id >=0) {
-                ierr = TDyCell_GetCentroid2(cells, neighbor_cell_id, dim, &neighbor_cell_cen[0]); CHKERRQ(ierr);
-                ierr = TDyComputeLength(neighbor_cell_cen, cell_cen, dim, &dist); CHKERRQ(ierr);
-                dist *= 0.50;
-
-                for (kk=0; kk<dim; kk++) {
-                  for (mm=0; mm<dim; mm++) {
-                    K_neighbor[kk][mm] = matprop->K0[neighbor_cell_id*dim*dim + kk*dim + mm];
-                  }
-                }
-              } else {
-                ierr = TDyFace_GetCentroid(faces, face_id, dim, &neighbor_cell_cen[0]); CHKERRQ(ierr);
-                ierr = TDyComputeLength(neighbor_cell_cen, cell_cen, dim, &dist); CHKERRQ(ierr);
-                for (kk=0; kk<dim; kk++) {
-                  for (mm=0; mm<dim; mm++) {
-                    K_neighbor[kk][mm] = matprop->K0[icell*dim*dim + kk*dim + mm];
-                  }
-                }
-              }
-              PetscReal K_neighbor_value = 0.0, K_value = 0.0, K_aveg;
-
-              PetscReal dot_prod, normal_up2dn[dim];
-              ierr = TDyUnitNormalVectorJoiningTwoVertices(neighbor_cell_cen, cell_cen, normal_up2dn); CHKERRQ(ierr);
-              ierr = TDyDotProduct(normal,normal_up2dn,&dot_prod); CHKERRQ(ierr);
-
-              for (kk=0;kk<dim;kk++) K_neighbor_value += pow(normal_up2dn[kk],2.0)/K_neighbor[kk][kk];
-              for (kk=0;kk<dim;kk++) K_value          += pow(normal_up2dn[kk],2.0)/K[kk][kk];
-              K_neighbor_value = 1.0/K_neighbor_value;
-              K_value = 1.0/K_value;
-              K_aveg = 0.5*K_value + 0.5*K_neighbor_value;
-
-              tdy->subc_Gmatrix[icell][isubcell][ii][jj] = area * (dot_prod) * K_aveg/(dist);
-
+            if ( (faces->cell_ids[faceCellOffset]==icell) ) {
+              neighbor_cell_id = faces->cell_ids[faceCellOffset+1];
             } else {
-              tdy->subc_Gmatrix[icell][isubcell][ii][jj] = 0.0;
+              neighbor_cell_id = faces->cell_ids[faceCellOffset];
             }
+
+            PetscReal K_neighbor[3][3];
+            PetscInt kk,mm;
+
+            if (neighbor_cell_id >=0) {
+              ierr = TDyCell_GetCentroid2(cells, neighbor_cell_id, dim, &neighbor_cell_cen[0]); CHKERRQ(ierr);
+              ierr = TDyComputeLength(neighbor_cell_cen, cell_cen, dim, &dist); CHKERRQ(ierr);
+              dist *= 0.50;
+
+              for (kk=0; kk<dim; kk++) {
+                for (mm=0; mm<dim; mm++) {
+                  K_neighbor[kk][mm] = matprop->K0[neighbor_cell_id*dim*dim + kk*dim + mm];
+                }
+              }
+            } else {
+              ierr = TDyFace_GetCentroid(faces, face_id, dim, &neighbor_cell_cen[0]); CHKERRQ(ierr);
+              ierr = TDyComputeLength(neighbor_cell_cen, cell_cen, dim, &dist); CHKERRQ(ierr);
+              for (kk=0; kk<dim; kk++) {
+                for (mm=0; mm<dim; mm++) {
+                  K_neighbor[kk][mm] = matprop->K0[icell*dim*dim + kk*dim + mm];
+                }
+              }
+            }
+            PetscReal K_neighbor_value = 0.0, K_value = 0.0, K_aveg;
+
+            PetscReal dot_prod, normal_up2dn[dim];
+            ierr = TDyUnitNormalVectorJoiningTwoVertices(neighbor_cell_cen, cell_cen, normal_up2dn); CHKERRQ(ierr);
+            ierr = TDyDotProduct(normal,normal_up2dn,&dot_prod); CHKERRQ(ierr);
+
+            for (kk=0;kk<dim;kk++) {
+              K_neighbor_value += pow(normal_up2dn[kk],2.0)/K_neighbor[kk][kk];
+              K_value          += pow(normal_up2dn[kk],2.0)/K[kk][kk];
+            }
+
+            K_neighbor_value = 1.0/K_neighbor_value;
+            K_value          = 1.0/K_value;
+            K_aveg = 0.5*K_value + 0.5*K_neighbor_value;
+
+            tdy->subc_Gmatrix[icell][isubcell][ii][jj] = area * (dot_prod) * K_aveg/(dist);
           }
 
           if (tdy->mode == TH) {
-            switch (tdy->mpfao_gmatrix_method){
-            case MPFAO_GMATRIX_DEFAULT:
-               ierr = TDySubCell_GetIthNuVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
+              if (ii == jj) {
+              ierr = TDySubCell_GetIthNuStarVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
 
-              ierr = TDyComputeEntryOfGMatrix3D(area, normal, Kappa,
-                                  nu, subcells->T[subcell_id], dim,
-                                  &(tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
-               break;
+              ierr = TDyComputeEntryOfGMatrix3D(area, normal, Kappa, nu, subcells->T[subcell_id], dim,
+                                          &(tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
+              } else {
+                tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj] = 0.0;
+              }
+          } // TH
 
-            case MPFAO_GMATRIX_TPF:
-               if (ii == jj) {
-                ierr = TDySubCell_GetIthNuStarVector(subcells, subcell_id, jj, dim, &nu[0]); CHKERRQ(ierr);
-
-                ierr = TDyComputeEntryOfGMatrix3D(area, normal, Kappa, nu, subcells->T[subcell_id], dim,
-                                           &(tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj])); CHKERRQ(ierr);
-                } else {
-                  tdy->Temp_subc_Gmatrix[icell][isubcell][ii][jj] = 0.0;
-                }
-                break;
-            }
-          }
         } // jj-subcell-faces
       } // ii-isubcell faces
     } // isubcell

--- a/src/mpfao/3D/tdympfao3D_core.c
+++ b/src/mpfao/3D/tdympfao3D_core.c
@@ -184,7 +184,7 @@ PetscErrorCode TDyComputeGMatrixTPFFor3DMesh(TDy tdy) {
         for (PetscInt jj=0;jj<subcell_num_faces;jj++) {
           PetscReal nu[dim];
 
-          if (ii /= jj) {
+          if (ii != jj) {
 
             tdy->subc_Gmatrix[icell][isubcell][ii][jj] = 0.0;
 

--- a/src/mpfao/3D/tdympfao3D_core.c
+++ b/src/mpfao/3D/tdympfao3D_core.c
@@ -38,7 +38,7 @@ PetscErrorCode TDyComputeEntryOfGMatrix3D(PetscReal area, PetscReal n[3],
 }
 
 /* -------------------------------------------------------------------------- */
-PetscErrorCode TDyComputeGMatrixDefaultFor3DMesh(TDy tdy) {
+PetscErrorCode TDyComputeGMatrixMPFAOFor3DMesh(TDy tdy) {
 
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()

--- a/src/mpfao/tdympfao.c
+++ b/src/mpfao/tdympfao.c
@@ -155,7 +155,15 @@ PetscErrorCode ComputeGMatrix(TDy tdy) {
     ierr = TDyComputeGMatrixFor2DMesh(tdy); CHKERRQ(ierr);
     break;
   case 3:
-    ierr = TDyComputeGMatrixFor3DMesh(tdy); CHKERRQ(ierr);
+    switch (tdy->mpfao_gmatrix_method) {
+      case MPFAO_GMATRIX_DEFAULT:
+        ierr = TDyComputeGMatrixDefaultFor3DMesh(tdy); CHKERRQ(ierr);
+        break;
+
+      case MPFAO_GMATRIX_TPF:
+        ierr = TDyComputeGMatrixTPFFor3DMesh(tdy); CHKERRQ(ierr);
+        break;
+    }
     break;
   default:
     SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"Unsupported dim in ComputeGMatrix");

--- a/src/mpfao/tdympfao.c
+++ b/src/mpfao/tdympfao.c
@@ -157,7 +157,7 @@ PetscErrorCode ComputeGMatrix(TDy tdy) {
   case 3:
     switch (tdy->mpfao_gmatrix_method) {
       case MPFAO_GMATRIX_DEFAULT:
-        ierr = TDyComputeGMatrixDefaultFor3DMesh(tdy); CHKERRQ(ierr);
+        ierr = TDyComputeGMatrixMPFAOFor3DMesh(tdy); CHKERRQ(ierr);
         break;
 
       case MPFAO_GMATRIX_TPF:


### PR DESCRIPTION
- Corrects the offset value when converting mesh elements to a compressed format
- Cleans up code by removing unused variables and splitting Gmatrix computation