### PR TITLE
Updating PETSc image and workflow, and updating calls to Exodus viewer

### DIFF
--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: Building TDycore (${{ matrix.build-type }})
       run: |
+        grep PETSC_VERSION_GIT $PETSC_DIR/include/petscconf.h | sed -e s/#define\ //g
         make -j codecov=1 V=1
 
     - name: Running tests (${{ matrix.build-type }})

--- a/gmakefile
+++ b/gmakefile
@@ -160,13 +160,6 @@ $(UTEST.c:%.c=%.o) : %.o : %.c
 $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -L$(CMOCKA_LIBRARY_DIR) -o $@ $^ -lcmocka-static $(TDYCORE_LIB) $(LIBS)
 
-# Make a list of all the unit test exes.
-utestname = $(basename $(1))
-#utestname = utest-$(subst _,-,$(basename $(notdir $(1))))
-ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
-
-$(ALLUNITTESTS) : % : $$(UTEST_EXE)
-
 unit-test : % : $(UTEST.c:%.c=%)
 	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
 

--- a/gmakefile
+++ b/gmakefile
@@ -42,6 +42,14 @@ else                   # Show the full command line
   quiet = $($1)
 endif
 
+# Set paths for CMocka-based unit tests.
+ifneq ($(CMOCKA_INCLUDE_DIR),)
+	ifneq ($(CMOCKA_LIBRARY_DIR),)
+		CFLAGS += "-I$(CMOCKA_INCLUDE_DIR)"
+		LDLAGS += "-L$(CMOCKA_LIBRARY_DIR) -lcmocka-static"
+	endif
+endif
+
 pcc = $(if $(findstring CONLY,$(PETSC_LANGUAGE)),CC,CXX)
 COMPILE.c = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
 COMPILE.cxx = $(call quiet,CXX) $(CXX_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(CXX_DEPFLAGS) -c
@@ -142,7 +150,24 @@ $(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(dem
 $(ALLTESTS) : test-% : $$(DEMO_EXE)
 	+@$(MAKE) -C regression_tests $@
 
-test : $(ALLTESTS)
+UTEST.c = \
+	src/tests/test_tdyinit.c \
+
+ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call testname,$(path)))
+# Set target-specific variables for each test
+define target_specific_utest_exe
+  $(call testname,$(1)) : UTEST_EXE = $(basename $(1))
+endef
+$(foreach utest_src,$(UTEST.c),$(eval $(call target_specific_utest_exe,$(utest_src))))
+
+$(ALLUNITTESTS) : test-% : $$(UTEST_EXE)
+	+@if [ $(CMOCKA_INCLUDE_DIR) != "" ] && [ $(CMOCKA_LIBRARY_DIR) != ""]; then \
+	+@$@ \
+	fi
+
+unit-test : $(ALLUNITTESTS)
+
+test : unit-test $(ALLTESTS)
 
 # make print VAR=the-variable
 print : ; @echo $($(VAR))

--- a/gmakefile
+++ b/gmakefile
@@ -147,24 +147,20 @@ CMOCKA_CFLAGS := $(shell pkg-config cmocka --cflags --silence-errors)
 CMOCKA_LDFLAGS := $(shell pkg-config cmocka --libs --silence-errors)
 ifneq ($(CMOCKA_LDFLAGS),) # begin unit tests
 
-ifndef MPI_NPROC
-MPI_NPROC=1
-endif
-
 # Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
 
 # Compile the unit tests
-$(UTEST.c:%.c=%.o) : %.o : %.c
-	$(COMPILE.c) $(CMOCKA_CFLAGS) $(abspath $<) -o $@
+$(UTEST.c:%.c=%.o) : %.o : %.c src/tests/tdycore_tests.h
+	$(COMPILE.c) $(CMOCKA_CFLAGS) -Isrc/tests $(abspath $<) -o $@
 
 # Link the unit tests into executables
 $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
-	$(call quiet,CLINKER) $(CMOCKA_LDFLAGS) -o $@ $^ $(TDYCORE_LIB) $(LIBS)
+	$(call quiet,CLINKER) -o $@ $^ $(CMOCKA_LDFLAGS) $(TDYCORE_LIB) $(LIBS)
 
 unit-tests : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
+	+@find src -name "test_*" -executable -exec ./src/tests/run_unit_tests.sh {} \;
 
 endif  # cmocka unit tests
 

--- a/gmakefile
+++ b/gmakefile
@@ -42,14 +42,6 @@ else                   # Show the full command line
   quiet = $($1)
 endif
 
-# Set paths for CMocka-based unit tests.
-ifneq ($(CMOCKA_INCLUDE_DIR),)
-	ifneq ($(CMOCKA_LIBRARY_DIR),)
-		CFLAGS += "-I$(CMOCKA_INCLUDE_DIR)"
-		LDLAGS += "-L$(CMOCKA_LIBRARY_DIR) -lcmocka-static"
-	endif
-endif
-
 pcc = $(if $(findstring CONLY,$(PETSC_LANGUAGE)),CC,CXX)
 COMPILE.c = $(call quiet,$(pcc)) $(PCC_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(C_DEPFLAGS) -c
 COMPILE.cxx = $(call quiet,CXX) $(CXX_FLAGS) $(CFLAGS) $(CCPPFLAGS) $(CXX_DEPFLAGS) -c
@@ -150,22 +142,31 @@ $(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(dem
 $(ALLTESTS) : test-% : $$(DEMO_EXE)
 	+@$(MAKE) -C regression_tests $@
 
+ifdef CMOCKA_INCLUDE_DIR # Begin unit tests
+
+# Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
 
-ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call testname,$(path)))
-# Set target-specific variables for each test
-define target_specific_utest_exe
-  $(call testname,$(1)) : UTEST_EXE = $(basename $(1))
-endef
-$(foreach utest_src,$(UTEST.c),$(eval $(call target_specific_utest_exe,$(utest_src))))
+# Compile the unit tests
+$(UTEST.c:%.c=%.o) : %.o : %.c
+	$(COMPILE.c) -I$(CMOCKA_INCLUDE_DIR) $(abspath $<) -o $@
 
-$(ALLUNITTESTS) : test-% : $$(UTEST_EXE)
-	+@if [ $(CMOCKA_INCLUDE_DIR) != "" ] && [ $(CMOCKA_LIBRARY_DIR) != ""]; then \
-	+@$@ \
-	fi
+# Link the unit tests into executables
+$(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
+	$(call quiet,CLINKER) -L$(CMOCKA_LIBRARY_DIR) -o $@ $^ -lcmocka-static $(TDYCORE_LIB) $(LIBS)
 
-unit-test : $(ALLUNITTESTS)
+# Make a list of all the unit test exes.
+utestname = $(basename $(1))
+#utestname = utest-$(subst _,-,$(basename $(notdir $(1))))
+ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
+
+$(ALLUNITTESTS) : % : $$(UTEST_EXE)
+
+unit-test : % : $(UTEST.c:%.c=%)
+	+@find src -name "test_*" -executable -exec {} \;
+
+endif  # ifdef CMOCKA_INCLUDE_DIR
 
 test : unit-test $(ALLTESTS)
 

--- a/gmakefile
+++ b/gmakefile
@@ -144,6 +144,10 @@ $(ALLTESTS) : test-% : $$(DEMO_EXE)
 
 ifdef CMOCKA_INCLUDE_DIR # Begin unit tests
 
+ifndef MPI_NPROC
+MPI_NPROC=1
+endif
+
 # Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
@@ -164,7 +168,7 @@ ALLUNITTESTS = $(foreach path,$(UTEST.c),$(call utestname,$(path)))
 $(ALLUNITTESTS) : % : $$(UTEST_EXE)
 
 unit-test : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec {} \;
+	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
 
 endif  # ifdef CMOCKA_INCLUDE_DIR
 

--- a/gmakefile
+++ b/gmakefile
@@ -142,7 +142,10 @@ $(foreach demo_src,$(TEST.c) $(TEST.F90),$(eval $(call target_specific_var,$(dem
 $(ALLTESTS) : test-% : $$(DEMO_EXE)
 	+@$(MAKE) -C regression_tests $@
 
-ifdef CMOCKA_INCLUDE_DIR # Begin unit tests
+# CMocka support for unit tests (via pkg-config).
+CMOCKA_CFLAGS := $(shell pkg-config cmocka --cflags --silence-errors)
+CMOCKA_LDFLAGS := $(shell pkg-config cmocka --libs --silence-errors)
+ifneq ($(CMOCKA_LDFLAGS),) # begin unit tests
 
 ifndef MPI_NPROC
 MPI_NPROC=1
@@ -154,18 +157,18 @@ UTEST.c = \
 
 # Compile the unit tests
 $(UTEST.c:%.c=%.o) : %.o : %.c
-	$(COMPILE.c) -I$(CMOCKA_INCLUDE_DIR) $(abspath $<) -o $@
+	$(COMPILE.c) $(CMOCKA_CFLAGS) $(abspath $<) -o $@
 
 # Link the unit tests into executables
 $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
-	$(call quiet,CLINKER) -L$(CMOCKA_LIBRARY_DIR) -o $@ $^ -lcmocka-static $(TDYCORE_LIB) $(LIBS)
+	$(call quiet,CLINKER) $(CMOCKA_LDFLAGS) -o $@ $^ $(TDYCORE_LIB) $(LIBS)
 
-unit-test : % : $(UTEST.c:%.c=%)
+unit-tests : % : $(UTEST.c:%.c=%)
 	+@find src -name "test_*" -executable -exec mpiexec -np ${MPI_NPROC} {} \;
 
-endif  # ifdef CMOCKA_INCLUDE_DIR
+endif  # cmocka unit tests
 
-test : unit-test $(ALLTESTS)
+test : unit-tests $(ALLTESTS)
 
 # make print VAR=the-variable
 print : ; @echo $($(VAR))

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This runs unit tests using a one-test-per-process protocol.
+
+count=`$1 count`
+nproc=`$1 nproc`
+i=0
+while [ $i -lt $count ]
+do
+  # Run the test with the appropriate number of MPI processes.
+  mpiexec -np $nproc -quiet $1 $i
+  status=$?
+  if test $status -ne 0
+  then
+    echo "Unit test $1 FAILED with status $status."
+    exit $status
+  fi
+  ((i++))
+done

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -1,0 +1,54 @@
+#ifndef TDYCORE_TESTS_H
+#define TDYCORE_TESTS_H
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <cmocka.h>
+
+
+// Runs tests with selected index (or reports the number of available tests).
+static int _run_selected_tests(const char* command,
+                               int num_tests,
+                               const struct CMUnitTest tests[num_tests],
+                               int nproc) {
+  if (strcasecmp(command, "count") == 0) { // asked for # of tests
+    fprintf(stdout, "%d\n", num_tests);
+    return 0;
+  } else if (strcasecmp(command, "nproc") == 0) { // asked for # of procs
+    fprintf(stdout, "%d\n", nproc);
+    return 0;
+  } else { // asked for a specific test index
+    // Try to interpret the argument as an index for the desired test.
+    char *endptr;
+    long index = strtol(command, &endptr, 10);
+    if (*endptr == '\0') { // got a valid index!
+      if ((index < 0) || (index >= num_tests)) {
+        fprintf(stderr, "Invalid test index: %ld (must be in [0, %d])\n",
+            index, num_tests);
+        return 1;
+      } else {
+        const struct CMUnitTest selected_tests[] = { tests[index] };
+        return cmocka_run_group_tests(selected_tests, NULL, NULL);
+      }
+    } else {
+      fprintf(stderr, "Invalid command: %s (must be 'nproc', 'count', or index)\n",
+          command);
+      return 1;
+    }
+  }
+}
+
+// Call this macro instead of cmocka_run_group_tests, with the number of MPI
+// processes as the last argument.
+#define run_selected_tests(argc, argv, tests, nproc) \
+  (argc > 1) ? _run_selected_tests(argv[1], \
+                                   sizeof(tests) / sizeof((tests)[0]), \
+                                   tests, nproc) \
+             : cmocka_run_group_tests(tests, NULL, NULL)
+
+#endif
+

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -1,0 +1,77 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include <tdycore.h>
+
+// This unit test suite tests the initialization and finalization of the
+// TDycore library.
+
+// Globals for holding command line arguments.
+static int argc_;
+static char **argv_;
+
+// Test whether TDyInit works and initializes MPI properly.
+static void TestTDyInit(void **state)
+{
+  int mpi_initialized;
+  MPI_Initialized(&mpi_initialized);
+  assert_false(mpi_initialized);
+  TDyInit(argc_, argv_);
+  MPI_Initialized(&mpi_initialized);
+  assert_true(mpi_initialized);
+}
+
+// Test whether the PETSC_COMM_WORLD communicator behaves properly within cmocka.
+static void TestPetscCommWorld(void **state)
+{
+  int num_procs;
+  MPI_Comm_size(PETSC_COMM_WORLD, &num_procs);
+  assert_true(num_procs >= 1);
+
+  int rank;
+  MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+  assert_true(rank >= 0);
+  assert_true(rank < num_procs);
+}
+
+// Test whether MPI performs as expected within CMocka's environment.
+static void TestMPIAllreduce(void **state)
+{
+  // Let's see if we can properly sum over all ranks.
+  int num_procs;
+  MPI_Comm_size(PETSC_COMM_WORLD, &num_procs);
+
+  int one = 1;
+  int sum;
+
+  MPI_Allreduce(&one, &sum, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD);
+  assert_int_equal(num_procs, sum);
+}
+
+// Test whether TDyFinalize works as expected.
+static void TestTDyFinalize(void **state)
+{
+  int mpi_initialized;
+  MPI_Initialized(&mpi_initialized);
+  assert_true(mpi_initialized);
+  TDyFinalize();
+}
+
+int main(int argc, char* argv[])
+{
+  // Stash command line arguments.
+  argc_ = argc;
+  argv_ = argv;
+
+  const struct CMUnitTest tests[] =
+  {
+    cmocka_unit_test(TestTDyInit),
+    cmocka_unit_test(TestPetscCommWorld),
+    cmocka_unit_test(TestMPIAllreduce),
+    cmocka_unit_test(TestTDyFinalize),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -61,19 +61,19 @@ static void TestTDyFinalize(void **state)
   TDyFinalize();
 }
 
-static int run_selected_tests(int argc, char* argv[],
-                              const struct CMUnitTest tests[]) {
+static int _run_selected_tests(const char* command,
+                               int num_tests,
+                               const struct CMUnitTest tests[num_tests]) {
   // If we're asked for a count of the tests available, print that number to
   // stdout.
-  if (argc > 1) {
-    int num_tests = sizeof(tests)/sizeof((tests)[0]);
-    if (strcasecmp(argv[1], "count") == 0) {
+  if (command != NULL) {
+    if (strcasecmp(command, "count") == 0) {
       fprintf(stdout, "%d\n", num_tests);
       exit(0);
     } else {
       // Try to interpret the argument as an index for the desired test.
       char *endptr;
-      long index = strtol(argv[1], &endptr, 10);
+      long index = strtol(command, &endptr, 10);
       if (*endptr == '\0') { // got a valid index!
         if ((index < 0) || (index >= num_tests)) {
           fprintf(stderr, "Invalid test index: %ld (must be in [0, %d])\n",
@@ -93,6 +93,11 @@ static int run_selected_tests(int argc, char* argv[],
     return cmocka_run_group_tests(tests, NULL, NULL);
   }
 }
+
+#define run_selected_tests(argc, argv, tests) { \
+  const char* command = (argc > 1) ? argv[1] : NULL; \
+  int num_tests = sizeof(tests) / sizeof((tests)[0])); \
+  _run_selected_tests(command, num_tests, tests)
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
I rebuilt the Docker image using a recent PETSc commit to try to add a few things to it, but this broke our calls to the Exodus viewer, since that interface was very recently updated. I realized it's difficult to figure out which hash we're using in the Docker image, so I'm adding it to the test output.

First I'm verifying that the hash gets printed intelligibly and that the compilation fails because of the outdated Exodus viewer calls. Then I'll update the calls to the viewer to bring it in line with the latest PETSc main branch.