### PR TITLE
Changes for new PETSc image, plus output of PETSc git commit

### DIFF
--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: Building TDycore (${{ matrix.build-type }})
       run: |
+        grep PETSC_VERSION_GIT $PETSC_DIR/include/petscconf.h | sed -e s/#define\ //g
         make -j codecov=1 V=1
 
     - name: Running tests (${{ matrix.build-type }})


### PR DESCRIPTION
I rebuilt the Docker image using a recent PETSc commit to try to add a few things to it, but this broke our calls to the Exodus viewer, since that interface was very recently updated. I realized it's difficult to figure out which hash we're using in the Docker image, so I'm adding it to the test output.

First I'm verifying that the hash gets printed intelligibly and that the compilation fails because of the outdated Exodus viewer calls. Then I'll update the calls to the viewer to bring it in line with the latest PETSc main branch.