### PR TITLE
PETSc hashes are now correctly handled in creation of Docker images.

### DIFF
--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: Building TDycore (${{ matrix.build-type }})
       run: |
+        grep PETSC_VERSION_GIT $PETSC_DIR/include/petscconf.h | sed -e s/#define\ //g
         make -j codecov=1 V=1
 
     - name: Running tests (${{ matrix.build-type }})

--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -41,7 +41,7 @@ WORKDIR /build
 ARG PETSC_HASH=HEAD
 ENV PETSC_HASH=$PETSC_HASH
 ENV PETSC_DIR=/usr/local/petsc/mpich-int32-real-opt
-RUN git clone --depth=1 --branch=main https://gitlab.com/petsc/petsc && \
+RUN git clone --branch=main https://gitlab.com/petsc/petsc && \
   cd petsc && \
   git reset --hard $PETSC_HASH && \
   PETSC_INSTALL_PREFIX=$PETSC_DIR; unset PETSC_DIR; \


### PR DESCRIPTION
They're also displayed at the beginning of TDycore's build process in the PR auto-test workflow.

Sorry for the noise on this one.