### PR TITLE
Update some function prototypes and definitions to be consistent about using PetscReal vs. double.

### DIFF
--- a/include/private/tdymaterialpropertiesimpl.h
+++ b/include/private/tdymaterialpropertiesimpl.h
@@ -28,9 +28,9 @@ PETSC_INTERN PetscBool TDyIsSoilDensitySet(TDy);
 
 PETSC_INTERN void TDySoilDensityFunctionDefault(PetscReal*,PetscReal*);
 PETSC_INTERN void TDySpecificSoilHeatFunctionDefault(PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode TDyPermeabilityFunctionDefault(TDy,double*,double*,void*);
-PETSC_INTERN PetscErrorCode TDyThermalConductivityFunctionDefault(TDy,double*,double*,void*);
-PETSC_INTERN PetscErrorCode TDyPorosityFunctionDefault(TDy,double*,double*,void*);
+PETSC_INTERN PetscErrorCode TDyPermeabilityFunctionDefault(TDy,PetscReal*,PetscReal*,void*);
+PETSC_INTERN PetscErrorCode TDyThermalConductivityFunctionDefault(TDy,PetscReal*,PetscReal*,void*);
+PETSC_INTERN PetscErrorCode TDyPorosityFunctionDefault(TDy,PetscReal*,PetscReal*,void*);
 
 #endif
 

--- a/src/tdymaterialproperties.c
+++ b/src/tdymaterialproperties.c
@@ -404,7 +404,7 @@ PetscErrorCode TDyPermeabilityFunctionDefault(TDy tdy, PetscReal *x, PetscReal *
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDyThermalConductivityFunctionDefault(TDy tdy, double *x, double *K, void *ctx) {
+PetscErrorCode TDyThermalConductivityFunctionDefault(TDy tdy, PetscReal *x, PetscReal *K, void *ctx) {
   PetscErrorCode ierr;
   PetscInt dim;
   PetscFunctionBegin;
@@ -420,7 +420,7 @@ PetscErrorCode TDyThermalConductivityFunctionDefault(TDy tdy, double *x, double 
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDyPorosityFunctionDefault(TDy tdy, double *x, double *por, void *ctx) {
+PetscErrorCode TDyPorosityFunctionDefault(TDy tdy, PetscReal *x, PetscReal *por, void *ctx) {
   PetscFunctionBegin;
   *por = 0.25;
   PetscFunctionReturn(0);


### PR DESCRIPTION
This PR fixes some consistency issues with using `PetscReal` vs. `double` that showed up when I tried building TDycores using single precision (for testing on Intel integrated GPUs that do not support double precision).