### PR TITLE
Disabling Sphinx mermaid extension, which breaks with Sphinx 4.0+.

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -49,7 +49,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.githubpages',
     'sphinxcontrib.katex',
-    'sphinxcontrib.mermaid',  # still in beta; fails with latexpdf builder
+#    'sphinxcontrib.mermaid',  # still in beta; fails with latexpdf builder
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinxcontrib.bibtex',


### PR DESCRIPTION
Our most recent attempt at auto-publishing our documentation site failed with this error:

```
...
Running Sphinx v4.0.1

Extension error:
Could not import extension sphinxcontrib.mermaid (exception: cannot import name 'ENOENT' from 'sphinx.util.osutil' (/usr/local/lib/python3.8/site-packages/sphinx/util/osutil.py))
make: *** [Makefile:19: html] Error 2
...
[sphinx-action] Starting sphinx-action build.
Running: pip install -r requirements.txt
====================================
Building docs in doc/sphinx
====================================
[sphinx-action] Running: ['make', 'html', '-e']
[sphinx-action] Build failed with 0 warnings
Traceback (most recent call last):
  File "/entrypoint.py", line 22, in <module>
    action.build_all_docs(github_env, [os.environ.get("INPUT_DOCS-FOLDER")])
  File "/sphinx_action/action.py", line 167, in build_all_docs
    raise RuntimeError("Build failed")
RuntimeError: Build failed
```

It seems like Sphinx 4.0 has removed `sphinx.util.osutil.ENOENT`, and the Mermaid extension contributors haven't gotten the memo yet. I don't think we're using Mermaid anywhere just yet, so I've removed it from our configuration. We'll see if this fixes the issue.