### PR TITLE
Added a unit test for generating a boxmesh and marking boundary faces.

### DIFF
--- a/gmakefile
+++ b/gmakefile
@@ -150,6 +150,7 @@ ifneq ($(CMOCKA_LDFLAGS),) # begin unit tests
 # Unit test source files
 UTEST.c = \
 	src/tests/test_tdyinit.c \
+	src/tests/test_mesh_labels.c \
 
 # Compile the unit tests
 $(UTEST.c:%.c=%.o) : %.o : %.c src/tests/tdycore_tests.h

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -1,0 +1,79 @@
+#include <tdycore_tests.h>
+#include <tdycore.h>
+
+// This unit test suite tests the ability to read mesh files and add labels for
+// specifying boundary conditions.
+
+// Test whether we can write a box mesh to an Exodus file.
+static void TestExodusWrite(void **state)
+{
+  // Create a box mesh.
+  PetscInt N = 10, ierr;
+  DM dm, dmDist = NULL;
+  PetscInt dim = 3;
+  const PetscInt  faces[3] = {N,N,N};
+  const PetscReal lower[3] = {0.0,0.0,0.0};
+  const PetscReal upper[3] = {1.0,1.0,1.0};
+  ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD,dim,PETSC_FALSE,faces,lower,upper,
+                             NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
+  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist); CHKERRQ(ierr);
+  if (dmDist) {
+    DMDestroy(&dm);
+    dm = dmDist;
+  }
+
+  // Write it to an Exodus file.
+  PetscViewer v;
+  ierr = PetscViewerExodusIIOpen(PETSC_COMM_WORLD, "boxmesh.exo",
+                                 FILE_MODE_WRITE, &v); CHKERRQ(ierr);
+  ierr = DMView(dm, v); CHKERRQ(ierr);
+  PetscViewerDestroy(&v);
+
+  DMDestroy(&dm);
+}
+
+// Test whether we can read in an Exodus mesh file.
+static void TestExodusRead(void **state)
+{
+  PetscInt ierr;
+
+  // Read a DM from an Exodus file.
+  PetscViewer v;
+  ierr = PetscViewerExodusIIOpen(PETSC_COMM_WORLD, "boxmesh.exo",
+                                 FILE_MODE_READ, &v); CHKERRQ(ierr);
+  DM dm;
+  ierr = DMCreate(PETSC_COMM_WORLD, &dm); CHKERRQ(ierr);
+  DMSetType(dm, DMPLEX);
+  DMLoad(dm, v);
+  PetscViewerDestroy(&v);
+
+  DMDestroy(&dm);
+}
+
+// Test whether we can successfully write out side sets for boundary conditions
+// to an Exodus file.
+static void TestExodusWriteSideSets(void **state)
+{
+}
+
+// Test whether we can read an Exodus file we've written with side sets.
+static void TestExodusReadSideSets(void **state)
+{
+}
+
+int main(int argc, char* argv[])
+{
+  PetscInitializeNoArguments();
+
+  // Define our set of unit tests.
+  const struct CMUnitTest tests[] =
+  {
+    cmocka_unit_test(TestExodusWrite),
+    cmocka_unit_test(TestExodusRead),
+    cmocka_unit_test(TestExodusWriteSideSets),
+    cmocka_unit_test(TestExodusReadSideSets),
+  };
+
+  run_selected_tests(argc, argv, tests, 1);
+  PetscFinalize();
+}

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -1,11 +1,15 @@
 #include <tdycore_tests.h>
 #include <tdycore.h>
+#include <petscviewerhdf5.h>
+//#include <petscviewerexodusii.h>
 
 // This unit test suite tests the ability to read mesh files and add labels for
 // specifying boundary conditions.
 
-// Test whether we can write a box mesh to an Exodus file.
-static void TestExodusWrite(void **state)
+static MPI_Comm comm;
+
+// Test whether we can write a box mesh to a mesh file.
+static void TestMeshWrite(void **state)
 {
   // Create a box mesh.
   PetscInt N = 10, ierr;
@@ -14,64 +18,143 @@ static void TestExodusWrite(void **state)
   const PetscInt  faces[3] = {N,N,N};
   const PetscReal lower[3] = {0.0,0.0,0.0};
   const PetscReal upper[3] = {1.0,1.0,1.0};
-  ierr = DMPlexCreateBoxMesh(PETSC_COMM_WORLD,dim,PETSC_FALSE,faces,lower,upper,
-                             NULL,PETSC_TRUE,&dm); CHKERRQ(ierr);
-  ierr = DMPlexDistribute(dm, 1, NULL, &dmDist); CHKERRQ(ierr);
-  if (dmDist) {
-    DMDestroy(&dm);
-    dm = dmDist;
-  }
+  ierr = DMPlexCreateBoxMesh(comm,dim,PETSC_FALSE,faces,lower,upper,
+                             NULL,PETSC_TRUE,&dm);
+  assert_int_equal(0, ierr);
 
-  // Write it to an Exodus file.
+  // Write it to a mesh file.
   PetscViewer v;
-  ierr = PetscViewerExodusIIOpen(PETSC_COMM_WORLD, "boxmesh.exo",
-                                 FILE_MODE_WRITE, &v); CHKERRQ(ierr);
-  ierr = DMView(dm, v); CHKERRQ(ierr);
+  ierr = PetscViewerHDF5Open(comm, "boxmesh.hdf5", FILE_MODE_WRITE, &v);
+//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh.exo", FILE_MODE_WRITE, &v);
+  assert_int_equal(0, ierr);
+  ierr = DMView(dm, v);
+  assert_int_equal(0, ierr);
   PetscViewerDestroy(&v);
 
   DMDestroy(&dm);
 }
 
-// Test whether we can read in an Exodus mesh file.
-static void TestExodusRead(void **state)
+// Test whether we can read in a mesh file.
+static void TestMeshRead(void **state)
 {
   PetscInt ierr;
 
-  // Read a DM from an Exodus file.
+  // Read a DM from a mesh file.
   PetscViewer v;
-  ierr = PetscViewerExodusIIOpen(PETSC_COMM_WORLD, "boxmesh.exo",
-                                 FILE_MODE_READ, &v); CHKERRQ(ierr);
+  ierr = PetscViewerHDF5Open(comm, "boxmesh.hdf5", FILE_MODE_READ, &v);
+//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh.exo", FILE_MODE_READ, &v);
+  assert_int_equal(0, ierr);
   DM dm;
-  ierr = DMCreate(PETSC_COMM_WORLD, &dm); CHKERRQ(ierr);
+  ierr = DMCreate(comm, &dm);
+  assert_int_equal(0, ierr);
   DMSetType(dm, DMPLEX);
   DMLoad(dm, v);
   PetscViewerDestroy(&v);
 
+  // If we're here, things are good.
   DMDestroy(&dm);
 }
 
 // Test whether we can successfully write out side sets for boundary conditions
-// to an Exodus file.
-static void TestExodusWriteSideSets(void **state)
+// to a mesh file.
+static void TestMeshWriteLabel(void **state)
 {
+  PetscInt ierr;
+
+  // Read our mesh.
+  PetscViewer v;
+  ierr = PetscViewerHDF5Open(comm, "boxmesh.hdf5", FILE_MODE_READ, &v);
+//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh.exo", FILE_MODE_READ, &v);
+  assert_int_equal(0, ierr);
+  DM dm;
+  ierr = DMCreate(comm, &dm);
+  assert_int_equal(0, ierr);
+  DMSetType(dm, DMPLEX);
+  DMLoad(dm, v);
+  PetscViewerDestroy(&v);
+
+  // Now mark boundary faces with a label.
+  DMLabel label;
+  DMCreateLabel(dm, "boundary");
+  DMGetLabel(dm, "boundary", &label);
+  ierr = DMPlexMarkBoundaryFaces(dm, 1, label);
+  assert_int_equal(0, ierr);
+  ierr = DMPlexLabelComplete(dm, label);
+  assert_int_equal(0, ierr);
+
+  // Write out the mesh with boundary faces labeled.
+  ierr = PetscViewerHDF5Open(comm, "boxmesh_labeled.hdf5", FILE_MODE_WRITE, &v);
+//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh_labeled.exo", FILE_MODE_WRITE, &v);
+  assert_int_equal(0, ierr);
+  ierr = DMView(dm, v);
+  assert_int_equal(0, ierr);
+  PetscViewerDestroy(&v);
+
+  DMDestroy(&dm);
 }
 
-// Test whether we can read an Exodus file we've written with side sets.
-static void TestExodusReadSideSets(void **state)
+// Test whether we can read a mesh file we've written with side sets.
+static void TestMeshReadLabel(void **state)
 {
+  PetscInt ierr;
+
+  // Read the boundary-labeled mesh.
+  PetscViewer v;
+  ierr = PetscViewerHDF5Open(comm, "boxmesh_labeled.hdf5", FILE_MODE_READ, &v);
+//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh_labeled.exo", FILE_MODE_READ, &v);
+  assert_int_equal(0, ierr);
+  DM dm;
+  ierr = DMCreate(comm, &dm);
+  assert_int_equal(0, ierr);
+  DMSetType(dm, DMPLEX);
+  DMLoad(dm, v);
+  PetscViewerDestroy(&v);
+
+  // Traverse the boundary faces and compare them to a newly-generated boundary.
+  DMLabel label, new_label;
+  DMGetLabel(dm, "boundary", &label);
+  DMCreateLabel(dm, "new_boundary");
+  DMGetLabel(dm, "new_boundary", &new_label);
+  DMPlexMarkBoundaryFaces(dm, 1, new_label);
+  IS label_IS, new_label_IS;
+  if (label) {
+    ierr = DMLabelGetValueIS(label, &label_IS);
+    ierr = DMLabelGetValueIS(new_label, &new_label_IS);
+    PetscInt num_faces, num_new_faces;
+    ierr = ISGetSize(label_IS, &num_faces);
+    assert_int_equal(0, ierr);
+    ierr = ISGetSize(label_IS, &num_new_faces);
+    assert_int_equal(0, ierr);
+    assert_int_equal(num_faces, num_new_faces);
+    const PetscInt *faces, *new_faces;
+    ierr = ISGetIndices(label_IS, &faces);
+    assert_int_equal(0, ierr);
+    ierr = ISGetIndices(label_IS, &new_faces);
+    assert_int_equal(0, ierr);
+    for (PetscInt f = 0; f < num_faces; ++f) {
+      assert_int_equal(faces[f], new_faces[f]);
+    }
+    ISRestoreIndices(label_IS, &faces);
+    ISRestoreIndices(new_label_IS, &new_faces);
+    ISDestroy(&label_IS);
+    ISDestroy(&new_label_IS);
+  }
+
+  DMDestroy(&dm);
 }
 
 int main(int argc, char* argv[])
 {
   PetscInitializeNoArguments();
+  comm = PETSC_COMM_WORLD;
 
   // Define our set of unit tests.
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test(TestExodusWrite),
-    cmocka_unit_test(TestExodusRead),
-    cmocka_unit_test(TestExodusWriteSideSets),
-    cmocka_unit_test(TestExodusReadSideSets),
+    cmocka_unit_test(TestMeshWrite),
+    cmocka_unit_test(TestMeshRead),
+    cmocka_unit_test(TestMeshWriteLabel),
+    cmocka_unit_test(TestMeshReadLabel),
   };
 
   run_selected_tests(argc, argv, tests, 1);


### PR DESCRIPTION
This PR piggybacks on #146, adding a set of unit tests:

1. Generate a box mesh
2. Read a box mesh
3. Mark boundary faces in the box mesh and write it out
4. Read the labeled box mesh and make sure the boundary faces match a newly created set

I used the HDF5 viewer to read and write the meshes. The Exodus one doesn't seem to be working properly just yet (I get a segfault when trying to write out the original mesh using the Exodus viewer).

Closes #157 
