### PR TITLE
Added requested features to CMocka-based unit testing approach.

### DIFF
--- a/gmakefile
+++ b/gmakefile
@@ -161,7 +161,7 @@ $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -o $@ $^ $(CMOCKA_LDFLAGS) $(TDYCORE_LIB) $(LIBS)
 
 unit-tests : % : $(UTEST.c:%.c=%)
-	+find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \;
+	+@find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \;
 
 UNITTESTS=unit-tests
 

--- a/gmakefile
+++ b/gmakefile
@@ -161,7 +161,7 @@ $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -o $@ $^ $(CMOCKA_LDFLAGS) $(TDYCORE_LIB) $(LIBS)
 
 unit-tests : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec ./src/tests/run_unit_tests.sh {} \;
+	+find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \;
 
 UNITTESTS=unit-tests
 

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -8,7 +8,7 @@ i=0
 while [ $i -lt $count ]
 do
   # Run the test with the appropriate number of MPI processes.
-  $MPIEXEC -np $nproc -quiet $1 $i
+  $MPIEXEC -np $nproc $1 $i
   status=$?
   if test $status -ne 0
   then

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -13,6 +13,8 @@ do
   if test $status -ne 0
   then
     echo "Unit test $1 FAILED with status $status."
+    echo "You can run this test with the following command:"
+    echo "mpiexec -np $nproc $1 $i"
     exit $status
   fi
   ((i++))

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -8,7 +8,7 @@ i=0
 while [ $i -lt $count ]
 do
   # Run the test with the appropriate number of MPI processes.
-  $MPIEXEC -np $nproc $1 $i
+  "$MPIEXEC" -n $nproc $1 $i
   status=$?
   if test $status -ne 0
   then

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -8,13 +8,13 @@ i=0
 while [ $i -lt $count ]
 do
   # Run the test with the appropriate number of MPI processes.
-  mpiexec -np $nproc -quiet $1 $i
+  $MPIEXEC -np $nproc -quiet $1 $i
   status=$?
   if test $status -ne 0
   then
     echo "Unit test $1 FAILED with status $status."
     echo "You can run this test with the following command:"
-    echo "mpiexec -np $nproc $1 $i"
+    echo "$MPIEXEC -np $nproc $1 $i"
     exit $status
   fi
   ((i++))

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -51,17 +51,25 @@ static int _run_selected_tests(int argc, char **argv,
           // We have a valid test index. If we have been given an initialization
           // function, construct our own argc and argv with the index argument
           // removed and call the initialization function with them.
+          int my_argc = -1;
+          char** my_argv = NULL;
           if (init_function != NULL) {
-            int my_argc = argc - 1;
-            char** my_argv = malloc(my_argc * sizeof(char*));
+            my_argc = argc - 1;
+            my_argv = malloc(my_argc * sizeof(char*));
             my_argv[0] = _strdup(argv[0]);
-            for (int i = 2; i < my_argc; ++i) {
-              my_argv[i] = _strdup(argv[i-1]);
+            for (int i = 1; i < my_argc; ++i) {
+              my_argv[i] = _strdup(argv[i+1]);
             }
             init_function(my_argc, my_argv);
           }
           const struct CMUnitTest selected_tests[] = { tests[index] };
           int result = cmocka_run_group_tests(selected_tests, NULL, NULL);
+          if (init_function != NULL) {
+            for (int i = 0; i < my_argc; ++i) {
+              free(my_argv[i]);
+            }
+            free(my_argv);
+          }
           return result;
         }
       } else {

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -26,7 +26,9 @@ static int _run_selected_tests(int argc, char **argv,
                                const struct CMUnitTest tests[num_tests],
                                int nproc) {
   if (argc == 1) {
-    init_function(argc, argv);
+    if (init_function != NULL) {
+      init_function(argc, argv);
+    }
     return cmocka_run_group_tests(tests, NULL, NULL);
   } else {
     const char* command = (const char*)argv[1];

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -33,9 +33,9 @@ static int _run_selected_tests(int argc, char **argv,
       setup(argc, argv);
     }
     fprintf(stdout, "Usage:\n");
-    fprintf(stdout, "%s count    reports the number of available unit tests\n", argv[0]);
-    fprintf(stdout, "%s nproc    reports the # of MPI procs supported\n", argv[0]);
-    fprintf(stdout, "%s <index>  runs the unit test with the (0-based) index\n", argv[0]);
+    fprintf(stdout, "%s count [arg1 [...]]  \treports the number of available unit tests\n", argv[0]);
+    fprintf(stdout, "%s nproc [arg1 [...]]  \treports the # of MPI procs supported\n", argv[0]);
+    fprintf(stdout, "%s <index> [arg1 [...]]\truns the unit test with the (0-based) index\n", argv[0]);
     return 1;
   } else {
     const char* command = (const char*)argv[1];

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -9,46 +9,80 @@
 #include <stdio.h>
 #include <cmocka.h>
 
+// Here's a tiny implementation of the non-standard strdup function.
+static char *_strdup(const char *s) {
+  size_t n = strlen(s);
+  char* dup = malloc(sizeof(char)*(n+1));
+  strcpy(dup, s);
+  return dup;
+}
 
 // Runs tests with selected index (or reports the number of available tests).
-static int _run_selected_tests(const char* command,
+// If init_function is non-NULL, the function is called with argc and argv, with
+// any given test index argument removed.
+static int _run_selected_tests(int argc, char **argv,
+                               void (*init_function)(int argc, char **argv),
                                int num_tests,
                                const struct CMUnitTest tests[num_tests],
                                int nproc) {
-  if (strcasecmp(command, "count") == 0) { // asked for # of tests
-    fprintf(stdout, "%d\n", num_tests);
-    return 0;
-  } else if (strcasecmp(command, "nproc") == 0) { // asked for # of procs
-    fprintf(stdout, "%d\n", nproc);
-    return 0;
-  } else { // asked for a specific test index
-    // Try to interpret the argument as an index for the desired test.
-    char *endptr;
-    long index = strtol(command, &endptr, 10);
-    if (*endptr == '\0') { // got a valid index!
-      if ((index < 0) || (index >= num_tests)) {
-        fprintf(stderr, "Invalid test index: %ld (must be in [0, %d])\n",
-            index, num_tests);
-        return 1;
+  if (argc == 1) {
+    init_function(argc, argv);
+    return cmocka_run_group_tests(tests, NULL, NULL);
+  } else {
+    const char* command = (const char*)argv[1];
+    if (strcasecmp(command, "count") == 0) { // asked for # of tests
+      fprintf(stdout, "%d\n", num_tests);
+      return 0;
+    } else if (strcasecmp(command, "nproc") == 0) { // asked for # of procs
+      fprintf(stdout, "%d\n", nproc);
+      return 0;
+    } else { // asked for a specific test index
+      // Try to interpret the argument as an index for the desired test.
+      char *endptr;
+      long index = strtol(command, &endptr, 10);
+      if (*endptr == '\0') { // got a valid index!
+        if ((index < 0) || (index >= num_tests)) {
+          fprintf(stderr, "Invalid test index: %ld (must be in [0, %d])\n",
+              index, num_tests);
+          return 1;
+        } else {
+          // We have a valid test index. If we have been given an initialization
+          // function, construct our own argc and argv with the index argument
+          // removed and call the initialization function with them.
+          if (init_function != NULL) {
+            int my_argc = argc - 1;
+            char** my_argv = malloc(my_argc * sizeof(char*));
+            my_argv[0] = _strdup(argv[0]);
+            for (int i = 2; i < my_argc; ++i) {
+              my_argv[i] = _strdup(argv[i-1]);
+            }
+            init_function(my_argc, my_argv);
+          }
+          const struct CMUnitTest selected_tests[] = { tests[index] };
+          int result = cmocka_run_group_tests(selected_tests, NULL, NULL);
+          return result;
+        }
       } else {
-        const struct CMUnitTest selected_tests[] = { tests[index] };
-        return cmocka_run_group_tests(selected_tests, NULL, NULL);
+        fprintf(stderr, "Invalid command: %s (must be 'nproc', 'count', or index)\n",
+            command);
+        return 1;
       }
-    } else {
-      fprintf(stderr, "Invalid command: %s (must be 'nproc', 'count', or index)\n",
-          command);
-      return 1;
     }
   }
 }
 
-// Call this macro instead of cmocka_run_group_tests, with the number of MPI
-// processes as the last argument.
-#define run_selected_tests(argc, argv, tests, nproc) \
-  (argc > 1) ? _run_selected_tests(argv[1], \
-                                   sizeof(tests) / sizeof((tests)[0]), \
-                                   tests, nproc) \
-             : cmocka_run_group_tests(tests, NULL, NULL)
+// Call this macro instead of cmocka_run_group_tests, with the following
+// arguments:
+// * argc and argv, as supplied to your main function
+// * init_function - a void function that takes argc and argv as arguments and
+//                   performs any required setup
+// * tests - A list of CMUnitTest structs that make up the test suite for your
+//           unit test
+// * nproc - The number of MPI processes required to execute this unit test
+#define run_selected_tests(argc, argv, init_function, tests, nproc) \
+  _run_selected_tests(argc, argv, init_function, \
+                      sizeof(tests) / sizeof((tests)[0]), \
+                      tests, nproc)
 
 #endif
 

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -8,6 +8,15 @@
 
 static MPI_Comm comm;
 
+static void setup(int argc, char** argv) {
+  PetscInitializeNoArguments();
+  comm = PETSC_COMM_WORLD;
+}
+
+static void breakdown() {
+  PetscFinalize();
+}
+
 // Test whether we can write a box mesh to a mesh file.
 static void TestMeshWrite(void **state)
 {
@@ -145,9 +154,6 @@ static void TestMeshReadLabel(void **state)
 
 int main(int argc, char* argv[])
 {
-  PetscInitializeNoArguments();
-  comm = PETSC_COMM_WORLD;
-
   // Define our set of unit tests.
   const struct CMUnitTest tests[] =
   {
@@ -157,6 +163,5 @@ int main(int argc, char* argv[])
     cmocka_unit_test(TestMeshReadLabel),
   };
 
-  run_selected_tests(argc, argv, NULL, tests, NULL, 1);
-  PetscFinalize();
+  return run_selected_tests(argc, argv, setup, tests, breakdown, 1);
 }

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -129,7 +129,7 @@ static void TestMeshReadLabel(void **state)
     const PetscInt *faces, *new_faces;
     ierr = ISGetIndices(label_IS, &faces);
     assert_int_equal(0, ierr);
-    ierr = ISGetIndices(label_IS, &new_faces);
+    ierr = ISGetIndices(new_label_IS, &new_faces);
     assert_int_equal(0, ierr);
     for (PetscInt f = 0; f < num_faces; ++f) {
       assert_int_equal(faces[f], new_faces[f]);
@@ -157,6 +157,6 @@ int main(int argc, char* argv[])
     cmocka_unit_test(TestMeshReadLabel),
   };
 
-  run_selected_tests(argc, argv, tests, 1);
+  run_selected_tests(argc, argv, NULL, tests, 1);
   PetscFinalize();
 }

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -157,6 +157,6 @@ int main(int argc, char* argv[])
     cmocka_unit_test(TestMeshReadLabel),
   };
 
-  run_selected_tests(argc, argv, NULL, tests, 1);
+  run_selected_tests(argc, argv, NULL, tests, NULL, 1);
   PetscFinalize();
 }

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -71,5 +71,5 @@ int main(int argc, char *argv[]) {
     cmocka_unit_test(TestMPIAllreduce),
   };
 
-  run_selected_tests(argc, argv, setup, tests, NULL, 2);
+  return run_selected_tests(argc, argv, setup, tests, NULL, 2);
 }

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -54,8 +54,8 @@ static void TestMPIAllreduce(void **state) {
   TDyFinalize();
 }
 
-// Here's an initialization function.
-void init_func(int argc, char **argv) {
+// Here's a setup function (we don't use a breakdown function).
+void setup(int argc, char **argv) {
   // Stash command line arguments for usage in tests.
   argc_ = argc;
   argv_ = argv;
@@ -71,5 +71,5 @@ int main(int argc, char *argv[]) {
     cmocka_unit_test(TestMPIAllreduce),
   };
 
-  run_selected_tests(argc, argv, init_func, tests, 2);
+  run_selected_tests(argc, argv, setup, tests, NULL, 2);
 }

--- a/src/tests/test_tdyinit.c
+++ b/src/tests/test_tdyinit.c
@@ -9,8 +9,7 @@ static int argc_;
 static char **argv_;
 
 // Test whether TDyInit works and initializes MPI properly.
-static void TestTDyInit(void **state)
-{
+static void TestTDyInit(void **state) {
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
   assert_false(mpi_initialized);
@@ -22,8 +21,7 @@ static void TestTDyInit(void **state)
 }
 
 // Test whether the PETSC_COMM_WORLD communicator behaves properly within cmocka.
-static void TestPetscCommWorld(void **state)
-{
+static void TestPetscCommWorld(void **state) {
   TDyInit(argc_, argv_);
 
   int num_procs;
@@ -39,8 +37,7 @@ static void TestPetscCommWorld(void **state)
 }
 
 // Test whether MPI performs as expected within CMocka's environment.
-static void TestMPIAllreduce(void **state)
-{
+static void TestMPIAllreduce(void **state) {
   TDyInit(argc_, argv_);
 
   // Let's see if we can properly sum over all ranks.
@@ -57,11 +54,14 @@ static void TestMPIAllreduce(void **state)
   TDyFinalize();
 }
 
-int main(int argc, char* argv[])
-{
-  // Stash command line arguments.
+// Here's an initialization function.
+void init_func(int argc, char **argv) {
+  // Stash command line arguments for usage in tests.
   argc_ = argc;
   argv_ = argv;
+}
+
+int main(int argc, char *argv[]) {
 
   // Define our set of unit tests.
   const struct CMUnitTest tests[] =
@@ -71,5 +71,5 @@ int main(int argc, char* argv[])
     cmocka_unit_test(TestMPIAllreduce),
   };
 
-  run_selected_tests(argc, argv, tests, 2);
+  run_selected_tests(argc, argv, init_func, tests, 2);
 }


### PR DESCRIPTION
Now we support an initialization function which receives `argc` and `argv` with any test index argument stripped out. You can use this to stash `argc` and `argv`, initialize PETSc, etc.

Also, the `run-tests` target prints out a command for each failed test that allows a user to run that test.

(Also fixed a minor glitch in the mesh labels unit test.)

Closes #176