### PR TITLE
[WIP] Created a unit test for verifying that nodes can see their subcells (FV approach)

### DIFF
--- a/gmakefile
+++ b/gmakefile
@@ -151,6 +151,7 @@ ifneq ($(CMOCKA_LDFLAGS),) # begin unit tests
 UTEST.c = \
 	src/tests/test_tdyinit.c \
 	src/tests/test_mesh_labels.c \
+	src/tests/test_parallel_node_subcells.c \
 
 # Compile the unit tests
 $(UTEST.c:%.c=%.o) : %.o : %.c src/tests/tdycore_tests.h

--- a/gmakefile
+++ b/gmakefile
@@ -162,7 +162,7 @@ $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -o $@ $^ $(CMOCKA_LDFLAGS) $(TDYCORE_LIB) $(LIBS)
 
 unit-tests : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \;
+	+@find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \+
 
 UNITTESTS=unit-tests
 

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
 
 # This runs unit tests using a one-test-per-process protocol.
-
-count=`$1 count`
-nproc=`$1 nproc`
-i=0
-while [ $i -lt $count ]
+num_failures=0
+for arg in "$@"
 do
-  # Run the test with the appropriate number of MPI processes.
-  $MPIEXEC -n $nproc $1 $i
-  status=$?
-  if test $status -ne 0
-  then
-    echo "Unit test $1 FAILED with status $status."
-    echo "You can run this test with the following command:"
-    echo "$MPIEXEC -np $nproc $1 $i"
-    exit $status
-  fi
-  ((i++))
+  echo "Running $arg"
+  count=`$arg count`
+  nproc=`$arg nproc`
+  i=0
+  while [ $i -lt $count ]
+  do
+    # Run the test with the appropriate number of MPI processes.
+    $MPIEXEC -n $nproc $arg $i
+    status=$?
+    if test $status -ne 0
+    then
+      echo "Unit test $arg FAILED with status $status."
+      echo "You can run this test with the following command:"
+      echo "$MPIEXEC -np $nproc $arg $i"
+      ((num_failures++))
+    fi
+    ((i++))
+  done
 done
+exit $num_failures

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -8,7 +8,7 @@ i=0
 while [ $i -lt $count ]
 do
   # Run the test with the appropriate number of MPI processes.
-  "$MPIEXEC" -n $nproc $1 $i
+  $MPIEXEC -n $nproc $1 $i
   status=$?
   if test $status -ne 0
   then

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -81,16 +81,6 @@ static int _run_selected_tests(int argc, char **argv,
           const struct CMUnitTest selected_tests[] = { tests[index] };
           int result = cmocka_run_group_tests(selected_tests, NULL, NULL);
 
-          // In an MPI context, we take the max number of failed tests across
-          // processes.
-          int have_mpi;
-          MPI_Initialized(&have_mpi);
-          if (have_mpi) {
-            int max_result;
-            MPI_Allreduce(&result, &max_result, 1, MPI_INT, MPI_MAX, PETSC_COMM_WORLD);
-            result = max_result;
-          }
-
           // Clean up our duplicated argument list if needed.
           if (setup != NULL) {
             for (int i = 0; i < my_argc; ++i) {

--- a/src/tests/tdycore_tests.h
+++ b/src/tests/tdycore_tests.h
@@ -36,7 +36,7 @@ static int _run_selected_tests(int argc, char **argv,
     fprintf(stdout, "%s count [arg1 [...]]  \treports the number of available unit tests\n", argv[0]);
     fprintf(stdout, "%s nproc [arg1 [...]]  \treports the # of MPI procs supported\n", argv[0]);
     fprintf(stdout, "%s <index> [arg1 [...]]\truns the unit test with the (0-based) index\n", argv[0]);
-    return 1;
+    return 0;
   } else {
     const char* command = (const char*)argv[1];
     if (strcasecmp(command, "count") == 0) { // asked for # of tests

--- a/src/tests/test_parallel_node_subcells.c
+++ b/src/tests/test_parallel_node_subcells.c
@@ -8,7 +8,7 @@ static MPI_Comm comm;
 
 // This function is called before the selected tests execute.
 static void setup(int argc, char** argv) {
-  PetscInitializeNoArguments();
+  PetscInitialize(&argc, &argv, NULL, NULL);
   comm = PETSC_COMM_WORLD;
 }
 

--- a/src/tests/test_parallel_node_subcells.c
+++ b/src/tests/test_parallel_node_subcells.c
@@ -1,6 +1,10 @@
 #include <tdycore_tests.h>
 #include <tdycore.h>
 
+// We store a set of indices of locally-owned mesh points in an INT_SET.
+#include <petsc/private/kernels/khash.h>
+KHASH_SET_INIT_INT(INT_SET)
+
 // This unit test suite tests that each node in a periodic box mesh is connected
 // to exactly 8 subcells in a parallel configuration.
 
@@ -54,9 +58,9 @@ static void TestPeriodicBoxMeshNodeSubcells(void **state)
   ierr = DMSetBasicAdjacency(mesh, PETSC_TRUE, PETSC_TRUE);
   assert_int_equal(0, ierr);
 
-  // Distribute the mesh amongst the processes and construct ghost cells. Create
-  // a distributed star forest so that we can tell which vertices are owned by
-  // the local process ("roots").
+  // Distribute the mesh amongst the processes and construct a single layer of
+  // cells overlapping with other processes. Create a distributed star forest so
+  // we can tell which vertices are owned by the local process ("roots").
   PetscSF sf;
   {
     DM mesh_dist = NULL;
@@ -74,47 +78,76 @@ static void TestPeriodicBoxMeshNodeSubcells(void **state)
         sf = sf_dist;
       }
     }
+    PetscSFSetUp(sf);
   }
 
-  // Get the number of locally-owned points ("roots") on this process.
-  PetscInt num_local_points;
-  ierr = PetscSFGetGraph(sf, &num_local_points, NULL, NULL, NULL);
+  int my_rank;
+  MPI_Comm_rank(PETSC_COMM_WORLD, &my_rank);
 
-  // Traverse the vertices of the mesh and check that they are connected to
-  // the appropriate cells.
+  // Get the indices of all mesh points owned by other processes and store them
+  // in a set.
+  khash_t(INT_SET)* remote_points = kh_init(INT_SET);
+  {
+    PetscInt nranks, num_leaves;
+    const PetscMPIInt *ranks;
+    const PetscInt *rank_offsets, *local_indices;
+    ierr = PetscSFGetRootRanks(sf, &nranks, &ranks, &rank_offsets,
+                               &local_indices, NULL);
+    if (nranks == 0) {
+    } else {
+      for (int r = 0; r < nranks; ++r) {
+        if (ranks[r] != my_rank) {
+          PetscInt begin = rank_offsets[r];
+          PetscInt end = rank_offsets[r+1];
+          int retval;
+          for (PetscInt i = begin; i < end; ++i) {
+            kh_put(INT_SET, remote_points, local_indices[i], &retval);
+          }
+        }
+      }
+    }
+  }
+
+  // Traverse the **locally owned** vertices of the mesh and check that they are
+  // connected to the appropriate cells.
   PetscInt v_start, v_end;
   ierr = DMPlexGetHeightStratum(mesh, vertex_height, &v_start, &v_end);
   assert_int_equal(0, ierr);
   for (PetscInt v = v_start; v < v_end; ++v) {
-    // Get all points in the transitive closure for this vertex. The point array
-    // is populated here each point and its orientation, so points[2*p] gives
-    // the index of the the pth point.
-    PetscInt num_points, *points = NULL;
-    ierr = DMPlexGetTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
-    assert_int_equal(0, ierr);
 
-    // Count all the points that are cells (height == 0).
-    PetscInt num_cells = 0;
-    for (PetscInt p = 0; p < num_points; ++p) {
-      PetscInt height;
-      PetscInt point = points[2*p];
-      assert_true(point < num_local_points);
-      ierr = DMPlexGetPointHeight(mesh, point, &height);
+    // A vertex is owned locally if it's not in the set of remote points.
+    PetscBool v_is_local = ((kh_size(remote_points) == 0) || !kh_exist(remote_points, v));
+    if (v_is_local) {
+      // Get all points in the transitive closure for this vertex. The point array
+      // is populated here each point and its orientation, so points[2*p] gives
+      // the index of the the pth point.
+      PetscInt num_points, *points = NULL;
+      ierr = DMPlexGetTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
       assert_int_equal(0, ierr);
-      if (height == 0) {
-        ++num_cells;
+
+      // Count all the points that are cells (height == 0).
+      PetscInt num_cells = 0;
+      for (PetscInt p = 0; p < num_points; ++p) {
+        PetscInt height;
+        PetscInt point = points[2*p];
+        //      assert_true(point < num_local_points);
+        ierr = DMPlexGetPointHeight(mesh, point, &height);
+        assert_int_equal(0, ierr);
+        if (height == 0) {
+          ++num_cells;
+        }
       }
+
+      // Put our toys away.
+      ierr = DMPlexRestoreTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
+      assert_int_equal(0, ierr);
+
+      assert_int_equal(8, num_cells);
     }
-
-    // Put our toys away.
-    ierr = DMPlexRestoreTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
-    assert_int_equal(0, ierr);
-
-//    printf("vertex %d has %d subcells\n", v, num_cells);
-    assert_int_equal(8, num_cells);
   }
 
   // Clean up.
+  kh_destroy(INT_SET, remote_points);
   PetscSFDestroy(&sf);
   DMDestroy(&mesh);
 }

--- a/src/tests/test_parallel_node_subcells.c
+++ b/src/tests/test_parallel_node_subcells.c
@@ -5,6 +5,11 @@
 #include <petsc/private/kernels/khash.h>
 KHASH_SET_INIT_INT(INT_SET)
 
+#ifdef CHKERRQ
+#undef CHKERRQ
+#endif
+#define CHKERRQ(x) assert_int_equal(0, x)
+
 // This unit test suite tests that each node in a periodic box mesh is connected
 // to exactly 8 subcells in a parallel configuration.
 
@@ -40,115 +45,89 @@ static void TestPeriodicBoxMeshNodeSubcells(void **state)
   // We create an "interpolated" DMPlex, which includes edges and faces in
   // addition to cells and vertices. These various mesh "points" are accessible
   // via "strata" at specific "heights":
+  //
   // Height | Type
   // 0      | cell
   // 1      | face
   // 2      | edge
   // 3      | vertex
-  // Note: An "uninterpolated" mesh is just a cell-vertex mesh without edges and
-  // Note: faces.
-  const PetscBool interpolate = PETSC_FALSE;
+  //
+  // (An "uninterpolated" mesh is just a cell-vertex mesh without edges and
+  //  faces.)
+  const PetscBool interpolate = PETSC_TRUE;
   PetscInt vertex_height = interpolate ? 3 : 1;
+  PetscInt cell_height = 0;
   ierr = DMPlexCreateBoxMesh(comm, dim, PETSC_FALSE, faces, lower, upper,
-                             periodicity, interpolate, &mesh);
-  assert_int_equal(0, ierr);
+                             periodicity, interpolate, &mesh); CHKERRQ(ierr);
 
   // Here we set the adjacency relations for the mesh so that nodes can see
-  // their attached cells.
-  ierr = DMSetBasicAdjacency(mesh, PETSC_TRUE, PETSC_TRUE);
-  assert_int_equal(0, ierr);
+  // their attached cells ("FVM++").
+  ierr = DMSetBasicAdjacency(mesh, PETSC_TRUE, PETSC_TRUE); CHKERRQ(ierr);
 
-  // Distribute the mesh amongst the processes and construct a single layer of
-  // cells overlapping with other processes. Create a distributed star forest so
-  // we can tell which vertices are owned by the local process ("roots").
-  PetscSF sf;
+  // Distribute the mesh amongst all processes and gather the "local" vertices
+  // that appear only on this process.
+  khash_t(INT_SET)* local_vertices = kh_init(INT_SET);
   {
     DM mesh_dist = NULL;
-    PetscSF sf_dist = NULL;
-    ierr = DMPlexDistribute(mesh, 1, &sf, &mesh_dist);
-    assert_int_equal(0, ierr);
+    ierr = DMPlexDistribute(mesh, 0, NULL, &mesh_dist); CHKERRQ(ierr);
     if (mesh_dist != NULL) {
       DMDestroy(&mesh);
       mesh = mesh_dist;
-
-      ierr = DMPlexCreatePointSF(mesh, sf, PETSC_TRUE, &sf_dist);
-      assert_int_equal(0, ierr);
-      if (sf_dist != NULL) {
-        PetscSFDestroy(&sf);
-        sf = sf_dist;
-      }
     }
-    PetscSFSetUp(sf);
+
+    PetscInt v_start, v_end;
+    ierr = DMPlexGetHeightStratum(mesh, vertex_height, &v_start, &v_end); CHKERRQ(ierr);
+    int retval;
+    for (PetscInt v = v_start; v < v_end; ++v) {
+      kh_put(INT_SET, local_vertices, v, &retval);
+    }
   }
 
-  int my_rank;
-  MPI_Comm_rank(PETSC_COMM_WORLD, &my_rank);
-
-  // Get the indices of all mesh points owned by other processes and store them
-  // in a set.
-  khash_t(INT_SET)* remote_points = kh_init(INT_SET);
+  // Add a layer of overlapping cells from other processes.
   {
-    PetscInt nranks, num_leaves;
-    const PetscMPIInt *ranks;
-    const PetscInt *rank_offsets, *local_indices;
-    ierr = PetscSFGetRootRanks(sf, &nranks, &ranks, &rank_offsets,
-                               &local_indices, NULL);
-    if (nranks == 0) {
-    } else {
-      for (int r = 0; r < nranks; ++r) {
-        if (ranks[r] != my_rank) {
-          PetscInt begin = rank_offsets[r];
-          PetscInt end = rank_offsets[r+1];
-          int retval;
-          for (PetscInt i = begin; i < end; ++i) {
-            kh_put(INT_SET, remote_points, local_indices[i], &retval);
-          }
-        }
-      }
+    DM mesh_dist = NULL;
+    ierr = DMPlexDistributeOverlap(mesh, 1, NULL, &mesh_dist); CHKERRQ(ierr);
+    if (mesh_dist != NULL) {
+      DMDestroy(&mesh);
+      mesh = mesh_dist;
     }
   }
 
   // Traverse the **locally owned** vertices of the mesh and check that they are
   // connected to the appropriate cells.
   PetscInt v_start, v_end;
-  ierr = DMPlexGetHeightStratum(mesh, vertex_height, &v_start, &v_end);
-  assert_int_equal(0, ierr);
+  ierr = DMPlexGetHeightStratum(mesh, vertex_height, &v_start, &v_end); CHKERRQ(ierr);
   for (PetscInt v = v_start; v < v_end; ++v) {
 
-    // A vertex is owned locally if it's not in the set of remote points.
-    PetscBool v_is_local = ((kh_size(remote_points) == 0) || !kh_exist(remote_points, v));
+    PetscBool v_is_local = kh_exist(local_vertices, v);
     if (v_is_local) {
-      // Get all points in the transitive closure for this vertex. The point array
-      // is populated here each point and its orientation, so points[2*p] gives
-      // the index of the the pth point.
+      // Get all points in the transitive closure for this vertex.
       PetscInt num_points, *points = NULL;
-      ierr = DMPlexGetTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
-      assert_int_equal(0, ierr);
+      ierr = DMPlexGetTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points); CHKERRQ(ierr);
 
-      // Count all the points that are cells (height == 0).
+      // Count all the points that are cells. The points array is populated with
+      // each point and its orientation, so points[2*p] gives the index of the
+      // pth point.
       PetscInt num_cells = 0;
       for (PetscInt p = 0; p < num_points; ++p) {
         PetscInt height;
         PetscInt point = points[2*p];
-        //      assert_true(point < num_local_points);
-        ierr = DMPlexGetPointHeight(mesh, point, &height);
-        assert_int_equal(0, ierr);
-        if (height == 0) {
+        ierr = DMPlexGetPointHeight(mesh, point, &height); CHKERRQ(ierr);
+        if (height == cell_height) {
           ++num_cells;
         }
       }
 
       // Put our toys away.
-      ierr = DMPlexRestoreTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points);
-      assert_int_equal(0, ierr);
+      ierr = DMPlexRestoreTransitiveClosure(mesh, v, PETSC_FALSE, &num_points, &points); CHKERRQ(ierr);
 
+      // Every local vertex should see exactly 8 cells.
       assert_int_equal(8, num_cells);
     }
   }
 
   // Clean up.
-  kh_destroy(INT_SET, remote_points);
-  PetscSFDestroy(&sf);
+  kh_destroy(INT_SET, local_vertices);
   DMDestroy(&mesh);
 }
 

--- a/src/tests/test_parallel_node_subcells.c
+++ b/src/tests/test_parallel_node_subcells.c
@@ -51,12 +51,6 @@ static void TestPeriodicBoxMeshNodeSubcells(void **state)
   ierr = DMSetBasicAdjacency(mesh, PETSC_TRUE, PETSC_TRUE);
   assert_int_equal(0, ierr);
 
-  // Mark all boundary faces with a "boundary" label.
-  DMCreateLabel(mesh, "boundary");
-  DMGetLabel(mesh, "boundary", &label);
-  DMPlexMarkBoundaryFaces(mesh, 1, label);
-  DMPlexLabelComplete(mesh, label);
-
   // Distribute the mesh amongst the processes and construct ghost cells.
   {
     DM mesh_dist = NULL;

--- a/src/tests/test_parallel_node_subcells.c
+++ b/src/tests/test_parallel_node_subcells.c
@@ -1,0 +1,61 @@
+#include <tdycore_tests.h>
+#include <tdycore.h>
+
+// This unit test suite tests that each node in a periodic box mesh is connected
+// to exactly 8 subcells in a parallel configuration.
+
+static MPI_Comm comm;
+
+// This function is called before the selected tests execute.
+static void setup(int argc, char** argv) {
+  PetscInitializeNoArguments();
+  comm = PETSC_COMM_WORLD;
+}
+
+// This function is called at the end of the program.
+static void breakdown() {
+  PetscFinalize();
+}
+
+// This function creates a 3D domain-decomposed box mesh that's periodic in all
+// directions and verifies that each of its nodes is attached to exactly 8
+// subcells on each subdomain.
+static void TestPeriodicBoxMeshNodeSubcells(void **state)
+{
+  // Create a 10x10x10 box mesh, periodic in all directions.
+  PetscInt N = 10, ierr;
+  DM dm;
+  PetscInt dim = 3;
+  const PetscInt  faces[3] = {N,N,N};
+  const PetscReal lower[3] = {0.0,0.0,0.0};
+  const PetscReal upper[3] = {1.0,1.0,1.0};
+  const DMBoundaryType periodicity[3] = {DM_BOUNDARY_PERIODIC,
+                                         DM_BOUNDARY_PERIODIC,
+                                         DM_BOUNDARY_PERIODIC};
+  ierr = DMPlexCreateBoxMesh(comm,dim,PETSC_FALSE,faces,lower,upper,
+                             periodicity,PETSC_TRUE,&dm);
+  {
+    DM dmDist = NULL;
+    ierr = DMPlexDistribute(dm, 1, NULL, &dmDist);
+    assert_int_equal(0, ierr);
+    if (dmDist != NULL) {
+      DMDestroy(&dm);
+      dm = dmDist;
+    }
+  }
+
+  // Clean up.
+  DMDestroy(&dm);
+}
+
+int main(int argc, char* argv[])
+{
+  // Define our set of unit tests.
+  const struct CMUnitTest tests[] =
+  {
+    cmocka_unit_test(TestPeriodicBoxMeshNodeSubcells),
+  };
+
+  // Run the selected tests on 3 processes.
+  run_selected_tests(argc, argv, setup, tests, breakdown, 3);
+}


### PR DESCRIPTION
This PR (based on features in #178) introduces another unit test that constructs a mesh on a 3-torus, distributes it, creates ghost cells, and checks that its nodes each have 8 cells attached.

The test fails, perhaps because I assumed that in a domain-decomposed thrice-periodic mesh, every node "should" have exactly 8 cells attached, provided the overlap is expressed properly, and this assumption appears not to be true.

@knepley , would you mind taking a look at `src/tests/test_parallel_node_subcells.c` in this branch? I'd be interested to see how much of DMPlex I've managed to understand.