### PR TITLE
Unit tests now report error code failures to make

### DIFF
--- a/gmakefile
+++ b/gmakefile
@@ -161,7 +161,7 @@ $(UTEST.c:%.c=%) : % : %.o $$^ $(libtdycore)
 	$(call quiet,CLINKER) -o $@ $^ $(CMOCKA_LDFLAGS) $(TDYCORE_LIB) $(LIBS)
 
 unit-tests : % : $(UTEST.c:%.c=%)
-	+@find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \;
+	+@find src -name "test_*" -executable -exec env MPIEXEC="$(MPIEXEC)" ./src/tests/run_unit_tests.sh {} \+
 
 UNITTESTS=unit-tests
 

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
 
 # This runs unit tests using a one-test-per-process protocol.
-
-count=`$1 count`
-nproc=`$1 nproc`
-i=0
-while [ $i -lt $count ]
+num_failures=0
+for arg in "$@"
 do
-  # Run the test with the appropriate number of MPI processes.
-  "$MPIEXEC" -n $nproc $1 $i
-  status=$?
-  if test $status -ne 0
-  then
-    echo "Unit test $1 FAILED with status $status."
-    echo "You can run this test with the following command:"
-    echo "$MPIEXEC -np $nproc $1 $i"
-    exit $status
-  fi
-  ((i++))
+  count=`$arg count`
+  nproc=`$arg nproc`
+  i=0
+  while [ $i -lt $count ]
+  do
+    # Run the test with the appropriate number of MPI processes.
+    $MPIEXEC -n $nproc $arg $i
+    status=$?
+    if test $status -ne 0
+    then
+      echo "Unit test $arg FAILED with status $status."
+      echo "You can run this test with the following command:"
+      echo "$MPIEXEC -np $nproc $arg $i"
+      ((num_failures++))
+    fi
+    ((i++))
+  done
 done
+exit $num_failures

--- a/src/tests/run_unit_tests.sh
+++ b/src/tests/run_unit_tests.sh
@@ -16,7 +16,7 @@ do
     then
       echo "Unit test $arg FAILED with status $status."
       echo "You can run this test with the following command:"
-      echo "$MPIEXEC -np $nproc $arg $i"
+      echo "$MPIEXEC -n $nproc $arg $i"
       ((num_failures++))
     fi
     ((i++))

--- a/src/tests/test_mesh_labels.c
+++ b/src/tests/test_mesh_labels.c
@@ -22,7 +22,7 @@ static void TestMeshWrite(void **state)
 {
   // Create a box mesh.
   PetscInt N = 10, ierr;
-  DM dm, dmDist = NULL;
+  DM dm;
   PetscInt dim = 3;
   const PetscInt  faces[3] = {N,N,N};
   const PetscReal lower[3] = {0.0,0.0,0.0};
@@ -34,7 +34,6 @@ static void TestMeshWrite(void **state)
   // Write it to a mesh file.
   PetscViewer v;
   ierr = PetscViewerHDF5Open(comm, "boxmesh.hdf5", FILE_MODE_WRITE, &v);
-//  ierr = PetscViewerExodusIIOpen(comm, "boxmesh.exo", FILE_MODE_WRITE, &v);
   assert_int_equal(0, ierr);
   ierr = DMView(dm, v);
   assert_int_equal(0, ierr);


### PR DESCRIPTION
These commits allow failed unit tests to report failures accurately via `make`, which means they'll register as test failures in our autotesting environment.