### PR TITLE
Renamed boundary-condition-related functions to better describe their purposes

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
   ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
 
   ierr = ReadSPE10Permeability(tdy,ang); CHKERRQ(ierr);
-  ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
+  ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   /* Setup problem parameters */
   ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);

--- a/demo/mpfao/mpfao.c
+++ b/demo/mpfao/mpfao.c
@@ -246,32 +246,32 @@ int main(int argc, char **argv) {
     switch(problem) {
     case 1:
       ierr = TDySetForcingFunction(tdy,ForcingConstantFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureConstantFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletFluxFunction(tdy,VelocityConstantFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureConstantFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstantFunction,NULL); CHKERRQ(ierr);
       break;
     case 2:
       ierr = TDySetForcingFunction(tdy,ForcingQuadraticFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureQuadraticFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletFluxFunction(tdy,VelocityQuadraticFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureQuadraticFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryVelocityFn(tdy,VelocityQuadraticFunction,NULL); CHKERRQ(ierr);
       break;
     case 3:
       ierr = TDySetForcingFunction(tdy,ForcingFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletFluxFunction(tdy,VelocityFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryVelocityFn(tdy,VelocityFunction,NULL); CHKERRQ(ierr);
       break;
     case 4:
       ierr = TDySetPermeabilityFunction(tdy,PermeabilitySineFunction,NULL); CHKERRQ(ierr);
       ierr = TDySetForcingFunction(tdy,ForcingSineFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureSineFunction,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletFluxFunction(tdy,VelocitySineFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureSineFunction,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryVelocityFn(tdy,VelocitySineFunction,NULL); CHKERRQ(ierr);
       break;
     }
   } else {
     ierr = TDySetPermeabilityFunction(tdy,PermeabilityFunction3D,NULL); CHKERRQ(ierr);
     ierr = TDySetPermeabilityTensor(tdy,Permeability3D); CHKERRQ(ierr);
     ierr = TDySetForcingFunction(tdy,Forcing3D,NULL); CHKERRQ(ierr);
-    ierr = TDySetDirichletValueFunction(tdy,Pressure3D,NULL); CHKERRQ(ierr);
-    ierr = TDySetDirichletFluxFunction(tdy,Velocity3D,NULL); CHKERRQ(ierr);
+    ierr = TDySetBoundaryPressureFn(tdy,Pressure3D,NULL); CHKERRQ(ierr);
+    ierr = TDySetBoundaryVelocityFn(tdy,Velocity3D,NULL); CHKERRQ(ierr);
   }
 
   ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);

--- a/demo/qa_test/qa_test.c
+++ b/demo/qa_test/qa_test.c
@@ -73,8 +73,8 @@ int main(int argc, char **argv) {
     case 1:
       ierr = TDySetPermeabilityTensor(tdy,Permeability); CHKERRQ(ierr);
       ierr = TDySetForcingFunction(tdy,ForcingConstant,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureConstant,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletFluxFunction(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureConstant,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
       break;
     }
   }
@@ -97,13 +97,13 @@ int main(int argc, char **argv) {
   ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
   ierr = KSPSetUp(ksp); CHKERRQ(ierr);
   ierr = KSPSolve(ksp,F,U); CHKERRQ(ierr);
-  
+
   /* Output solution */
   PetscViewer viewer;
   PetscViewerVTKOpen(PetscObjectComm((PetscObject)dm),"sol.vtk",FILE_MODE_WRITE,&viewer);
   ierr = DMView(dm,viewer); CHKERRQ(ierr);
   ierr = VecView(U,viewer); CHKERRQ(ierr); // the approximate solution
-  ierr = OperatorApplicationResidual(tdy,Ue,K,tdy->ops->computedirichletvalue,F); 
+  ierr = OperatorApplicationResidual(tdy,Ue,K,tdy->ops->compute_boundary_pressure,F);
   ierr = VecView(F,viewer); CHKERRQ(ierr); // the residual K*Ue-F
   ierr = VecView(Ue,viewer); CHKERRQ(ierr);  // the exact solution
   ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -453,7 +453,7 @@ PetscErrorCode SaveTrueSolution(TDy tdy, char filename[256]){
   for(c=cStart; c<cEnd; c++) {
     ierr = DMPlexComputeCellGeometryFVM(dm, c, PETSC_NULL, &centroid[0],
                                         PETSC_NULL); CHKERRQ(ierr);
-    ierr = tdy->ops->computedirichletvalue(tdy,&centroid[0],&pres[c],NULL);
+    ierr = tdy->ops->compute_boundary_pressure(tdy,&centroid[0],&pres[c],NULL);
   }
   ierr = VecRestoreArray(coordinates,&coords); CHKERRQ(ierr);
   ierr = VecRestoreArray(pressure,&pres); CHKERRQ(ierr);
@@ -638,20 +638,20 @@ int main(int argc, char **argv) {
         case 0: // not a problem in the paper, but want to check constants on the geometry
         ierr = TDySetPermeabilityTensor(tdy,PermTest2D); CHKERRQ(ierr);
         ierr = TDySetForcingFunction(tdy,ForcingConstant,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureConstant,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureConstant,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
         break;
         case 1:
         ierr = TDySetPermeabilityTensor(tdy,PermWheeler2006_1); CHKERRQ(ierr);
         ierr = TDySetForcingFunction(tdy,ForcingWheeler2006_1,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2006_1,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2006_1,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2006_1,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2006_1,NULL); CHKERRQ(ierr);
         break;
         case 2:
         ierr = TDySetPermeabilityTensor(tdy,PermWheeler2006_2); CHKERRQ(ierr);
         ierr = TDySetForcingFunction(tdy,ForcingWheeler2006_2,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2006_2,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2006_2,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2006_2,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2006_2,NULL); CHKERRQ(ierr);
         break;
         default:
         SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"-paper wheeler2006 only valid for -problem {0,1,2}");
@@ -664,8 +664,8 @@ int main(int argc, char **argv) {
         }
         ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_1); CHKERRQ(ierr);
         ierr = TDySetForcingFunction(tdy,ForcingWheeler2012_1,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2012_1,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2012_1,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2012_1,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2012_1,NULL); CHKERRQ(ierr);
         break;
         case 2:
         if(dim != 3){
@@ -673,8 +673,8 @@ int main(int argc, char **argv) {
         }
         ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_2); CHKERRQ(ierr);
         ierr = TDySetForcingFunction(tdy,ForcingWheeler2012_2,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2012_2,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2012_2,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2012_2,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2012_2,NULL); CHKERRQ(ierr);
         break;
         default:
         SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"-paper wheeler2012 only valid for -problem {1,2}");
@@ -688,8 +688,8 @@ int main(int argc, char **argv) {
           ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_2); CHKERRQ(ierr);
         }
         ierr = TDySetForcingFunction(tdy,ForcingConstant,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletValueFunction(tdy,PressureConstant,NULL); CHKERRQ(ierr);
-        ierr = TDySetDirichletFluxFunction(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryPressureFn(tdy,PressureConstant,NULL); CHKERRQ(ierr);
+        ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
         break;
 
         case 2:
@@ -697,13 +697,13 @@ int main(int argc, char **argv) {
         if (dim == 2) {
           ierr = TDySetPermeabilityTensor(tdy,PermTest2D); CHKERRQ(ierr);
           ierr = TDySetForcingFunction(tdy,ForcingQuadratic2D,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletValueFunction(tdy,PressureQuadratic2D,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletFluxFunction(tdy,VelocityQuadratic2D,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryPressureFn(tdy,PressureQuadratic2D,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryVelocityFn(tdy,VelocityQuadratic2D,NULL); CHKERRQ(ierr);
         } else {
           ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_2); CHKERRQ(ierr);
           ierr = TDySetForcingFunction(tdy,ForcingWheeler2012_2,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2012_2,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2012_2,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2012_2,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2012_2,NULL); CHKERRQ(ierr);
         }
         break;
 
@@ -711,13 +711,13 @@ int main(int argc, char **argv) {
         if (dim == 2) {
           ierr = TDySetPermeabilityTensor(tdy,PermTest2D); CHKERRQ(ierr);
           ierr = TDySetForcingFunction(tdy,ForcingWheeler2006_1,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2006_1,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2006_1,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2006_1,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2006_1,NULL); CHKERRQ(ierr);
         } else {
           ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_2); CHKERRQ(ierr);
           ierr = TDySetForcingFunction(tdy,Forcing3,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletValueFunction(tdy,Pressure3,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletFluxFunction(tdy,Velocity3,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryPressureFn(tdy,Pressure3,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryVelocityFn(tdy,Velocity3,NULL); CHKERRQ(ierr);
         }
         break;
 
@@ -725,8 +725,8 @@ int main(int argc, char **argv) {
         if (dim == 2) {
           ierr = TDySetPermeabilityTensor(tdy,PermWheeler2012_1); CHKERRQ(ierr);
           ierr = TDySetForcingFunction(tdy,ForcingWheeler2012_1,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletValueFunction(tdy,PressureWheeler2012_1,NULL); CHKERRQ(ierr);
-          ierr = TDySetDirichletFluxFunction(tdy,VelocityWheeler2012_1,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryPressureFn(tdy,PressureWheeler2012_1,NULL); CHKERRQ(ierr);
+          ierr = TDySetBoundaryVelocityFn(tdy,VelocityWheeler2012_1,NULL); CHKERRQ(ierr);
         } else {
 
         }
@@ -758,7 +758,7 @@ int main(int argc, char **argv) {
   PetscViewerVTKOpen(PetscObjectComm((PetscObject)dm),"sol.vtk",FILE_MODE_WRITE,&viewer);
   ierr = DMView(dm,viewer); CHKERRQ(ierr);
   ierr = VecView(U,viewer); CHKERRQ(ierr); // the approximate solution
-  //ierr = OperatorApplicationResidual(tdy,Ue,K,tdy->ops->computedirichletvalue,F);
+  //ierr = OperatorApplicationResidual(tdy,Ue,K,tdy->ops->compute_boundary_pressure,F);
   ierr = VecView(F,viewer); CHKERRQ(ierr); // the residual K*Ue-F
   ierr = VecView(Ue,viewer); CHKERRQ(ierr);  // the exact solution
   ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);

--- a/demo/steadyblock/steadyblock.c
+++ b/demo/steadyblock/steadyblock.c
@@ -153,8 +153,8 @@ int main(int argc, char **argv) {
     switch(problem) {
     case 1:
 //      ierr = TDySetForcingFunction(tdy,ForcingConstant,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureConstant,NULL); CHKERRQ(ierr);
-//      ierr = TDySetDirichletFluxFunction(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureConstant,NULL); CHKERRQ(ierr);
+//      ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
       break;
     }
   } else if (dim == 2) {
@@ -162,8 +162,8 @@ int main(int argc, char **argv) {
     switch(problem) {
     case 1:
 //      ierr = TDySetForcingFunction(tdy,ForcingConstant,NULL); CHKERRQ(ierr);
-      ierr = TDySetDirichletValueFunction(tdy,PressureConstant,NULL); CHKERRQ(ierr);
-//      ierr = TDySetDirichletFluxFunction(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
+      ierr = TDySetBoundaryPressureFn(tdy,PressureConstant,NULL); CHKERRQ(ierr);
+//      ierr = TDySetBoundaryVelocityFn(tdy,VelocityConstant,NULL); CHKERRQ(ierr);
       break;
       break;
     }

--- a/demo/steadyf90/steadyf90.F90
+++ b/demo/steadyf90/steadyf90.F90
@@ -20,9 +20,9 @@ contains
     K(3) = 1.d0; K(4) = 2.d0
 
     ierr = 0
-    
+
   end subroutine PermeabilityFunction
-  
+
   subroutine PressureFunction(tdy,x,f,dummy,ierr)
 
     implicit none
@@ -96,7 +96,7 @@ contains
     integer   :: dummy2(1)
 
     call PermeabilityFunction(tdy,x,K,dummy2,ierr)
-    
+
     !(*f)  = -K[0]*(12*PetscPowReal(1-x[0],2)+PetscSinReal(x[1]-1)*PetscCosReal(x[0]-1))
     !(*f) += -K[1]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1))
     !(*f) += -K[2]*( 3*PetscPowReal(1-x[1],2)+PetscSinReal(x[0]-1)*PetscCosReal(x[1]-1))
@@ -166,7 +166,7 @@ program main
   faces(:) = N
   lower(:) = 0.d0
   upper(:) = 1.d0
-  
+
   call DMPlexCreateBoxMesh(PETSC_COMM_WORLD, dim, PETSC_FALSE, faces, &
                            lower, upper, PETSC_NULL_INTEGER, PETSC_TRUE, &
                            dm, ierr)
@@ -192,11 +192,11 @@ program main
 
   call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr)
   CHKERRA(ierr)
-  call TDySetDirichletValueFunction(tdy,PressureFunction,0,ierr)
+  call TDySetBoundaryPressureFn(tdy,PressureFunction,0,ierr)
   CHKERRA(ierr)
   call TDySetForcingFunction(tdy,ForcingFunction,0,ierr)
   CHKERRA(ierr)
-  call TDySetDirichletFluxFunction(tdy,VelocityFunction,0,ierr)
+  call TDySetBoundaryVelocityFn(tdy,VelocityFunction,0,ierr)
   CHKERRA(ierr)
 
   call TDySetupNumericalMethods(tdy, ierr)
@@ -248,7 +248,7 @@ program main
   call TDyDestroy(tdy,ierr)
   CHKERRQ(ierr)
 
-  call TDyFinalize(ierr) 
+  call TDyFinalize(ierr)
   CHKERRA(ierr)
 
   call exit(successful_exit_code)

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
   ierr = TDySetPorosity(tdy,Porosity); CHKERRQ(ierr);
   ierr = TDySetPermeabilityScalar(tdy,Permeability); CHKERRQ(ierr);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
-  ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
+  ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
   Vec U;
   ierr = DMCreateGlobalVector(dm,&U); CHKERRQ(ierr);
   ierr = VecSet(U,91325); CHKERRQ(ierr);
-  
+
   /* Create time stepping and solve */
   TS  ts;
   ierr = TSCreate(PETSC_COMM_WORLD,&ts); CHKERRQ(ierr);

--- a/demo/transient/transient_mpfao.c
+++ b/demo/transient/transient_mpfao.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
   ierr = TDySetPermeabilityFunction(tdy,PermeabilityFunction3D,NULL); CHKERRQ(ierr);
   ierr = TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
-  //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
+  //ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -152,7 +152,7 @@ implicit none
   call TDySetPermeabilityFunction(tdy,PermeabilityFunction,0,ierr);
   CHKERRA(ierr);
 
-  call TDySetDirichletValueFunction(tdy,PressureFunction,0,ierr);
+  call TDySetBoundaryPressureFn(tdy,PressureFunction,0,ierr);
   CHKERRA(ierr);
 
   call TDySetBlockPermeabilityValuesLocal(tdy,cEnd-cStart,index,blockPerm,ierr);

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -340,7 +340,7 @@ implicit none
   end if
 
   if (bc_type == MPFAO_DIRICHLET_BC .OR. bc_type == MPFAO_SEEPAGE_BC ) then
-     call TDySetDirichletValueFunction(tdy,PressureFunction,0,ierr);
+     call TDySetBoundaryPressureFn(tdy,PressureFunction,0,ierr);
      CHKERRQ(ierr)
   endif
 

--- a/demo/transient/transient_th_mpfao.c
+++ b/demo/transient/transient_th_mpfao.c
@@ -188,8 +188,8 @@ int main(int argc, char **argv) {
   ierr = TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat);
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   ierr = TDySetEnergyForcingFunction(tdy,EnergyForcing,NULL); CHKERRQ(ierr);
-  //ierr = TDySetDirichletValueFunction(tdy,Pressure,NULL); CHKERRQ(ierr);
-  //ierr = TDySetTemperatureDirichletValueFunction(tdy,Temperature,NULL); CHKERRQ(ierr);
+  //ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
+  //ierr = TDySetBoundaryTemperatureFn(tdy,Temperature,NULL); CHKERRQ(ierr);
 
   ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
 

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -28,9 +28,9 @@ struct _TDyOps {
   PetscErrorCode (*computeresidualsaturation)(TDy,PetscReal*,PetscReal*,void*);
   PetscErrorCode (*computeforcing)(TDy,PetscReal*,PetscReal*,void*);
   PetscErrorCode (*computeenergyforcing)(TDy,PetscReal*,PetscReal*,void*);
-  PetscErrorCode (*computedirichletvalue)(TDy,PetscReal*,PetscReal*,void*);
-  PetscErrorCode (*computetemperaturedirichletvalue)(TDy,PetscReal*,PetscReal*,void*);
-  PetscErrorCode (*computedirichletflux)(TDy,PetscReal*,PetscReal*,void*);
+  PetscErrorCode (*compute_boundary_pressure)(TDy,PetscReal*,PetscReal*,void*);
+  PetscErrorCode (*compute_boundary_temperature)(TDy,PetscReal*,PetscReal*,void*);
+  PetscErrorCode (*compute_boundary_velocity)(TDy,PetscReal*,PetscReal*,void*);
   PetscErrorCode (*computesoildensity)(TDy,PetscReal*,PetscReal*,void*);
   PetscErrorCode (*computesoilspecificheat)(TDy,PetscReal*,PetscReal*,void*);
 };
@@ -95,9 +95,9 @@ struct _p_TDy {
   void *residualsaturationctx;
   void *forcingctx;
   void *energyforcingctx;
-  void *dirichletvaluectx;
-  void *temperaturedirichletvaluectx;
-  void *dirichletfluxctx;
+  void *boundary_pressure_ctx;
+  void *boundary_temperature_ctx;
+  void *boundary_velocity_ctx;
   void *soildensityctx;
   void *soilspecificheatctx;
 

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -104,9 +104,9 @@ PETSC_EXTERN PetscErrorCode TDySetSoilSpecificHeatFunction(TDy,PetscErrorCode(*)
 // Set boundary and source-sink: via PETSc operations
 PETSC_EXTERN PetscErrorCode TDySetForcingFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
 PETSC_EXTERN PetscErrorCode TDySetEnergyForcingFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
-PETSC_EXTERN PetscErrorCode TDySetDirichletValueFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
-PETSC_EXTERN PetscErrorCode TDySetTemperatureDirichletValueFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
-PETSC_EXTERN PetscErrorCode TDySetDirichletFluxFunction(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
+PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureFn(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
+PETSC_EXTERN PetscErrorCode TDySetBoundaryTemperatureFn(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
+PETSC_EXTERN PetscErrorCode TDySetBoundaryVelocityFn(TDy,PetscErrorCode(*)(TDy,PetscReal*,PetscReal*,void*),void*);
 
 // Set material properties: via spatial function
 PETSC_EXTERN PetscErrorCode TDySetPermeabilityScalar  (TDy,SpatialFunction f);
@@ -116,9 +116,6 @@ PETSC_EXTERN PetscErrorCode TDySetCellPermeability(TDy,PetscInt,PetscReal*);
 PETSC_EXTERN PetscErrorCode TDySetPorosity            (TDy,SpatialFunction f);
 PETSC_EXTERN PetscErrorCode TDySetSoilSpecificHeat    (TDy,SpatialFunction f);
 PETSC_EXTERN PetscErrorCode TDySetSoilDensity         (TDy,SpatialFunction f);
-
-// Set boundary condition: via spatial function
-PETSC_EXTERN PetscErrorCode TDySetDirichletFlux(TDy,SpatialFunction);
 
 // Set material properties: For each cell
 PETSC_EXTERN PetscErrorCode TDySetPorosityValuesLocal(TDy,PetscInt,const PetscInt[],const PetscScalar[]);

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -39,8 +39,8 @@
 #define tdysetpermeabilityfunction_                    TDYSETPERMEABILITYFUNCTION
 #define tdysetresidualsaturationfunction_              TDYSETRESIDUALSATURATIONFUNCTION
 #define tdysetforcingfunction_                         TDYSETFORCINGFUNCTION
-#define tdysetdirichletvaluefunction_                  TDYSETDIRICHLETVALUEFUNCTION
-#define tdysetdirichletfluxfunction_                   TDYSETDIRICHLETFLUXFUNCTION
+#define tdysetboundarypressurefn_                      TDYSETBOUNDARYPRESSUREFN
+#define tdysetboundaryvelocityfn_                      TDYSETBOUNDARYVELOCITYFN
 #define tdysetporosityvalueslocal0_                    TDYSETPOROSITYVALUESLOCAL0
 #define tdysetporosityvalueslocal11_                   TDYSETPOROSITYVALUESLOCAL11
 #define tdysetblockpermeabilityueslocal0_              TDYSETBLOCKPERMEABILITYVALUESLOCAL0
@@ -101,8 +101,8 @@
 #define tdysetpermeabilityfunction_                    tdysetpermeabilityfunction
 #define tdysetresidualsaturationfunction_              tdysetresidualsaturationfunction
 #define tdysetforcingfunction_                         tdysetforcingfunction
-#define tdysetdirichletvaluefunction_                  tdysetdirichletvaluefunction
-#define tdysetdirichletfluxfunction_                   tdysetdirichletfluxfunction
+#define tdysetboundarypressurefn_                      tdysetboundarypressurefn
+#define tdysetboundaryvelocityfn_                      tdysetboundaryvelocityfn
 #define tdysetporosityvalueslocal0_                    tdysetporosityvalueslocal0
 #define tdysetporosityvalueslocal11_                   tdysetporosityvalueslocal11
 #define tdysetblockpermeabilityueslocal0_              tdysetblockpermeabilityvalueslocal0
@@ -135,8 +135,8 @@ static struct {
   PetscFortranCallbackId permeability;
   PetscFortranCallbackId residualsaturation;
   PetscFortranCallbackId forcing;
-  PetscFortranCallbackId dirichletvalue;
-  PetscFortranCallbackId dirichletflux;
+  PetscFortranCallbackId boundary_pressure;
+  PetscFortranCallbackId boundary_velocity;
 #if defined(PETSC_HAVE_F90_2PTR_ARG)
   PetscFortranCallbackId function_pgiptr;
 #endif
@@ -543,42 +543,42 @@ PETSC_EXTERN void tdysetforcingfunction_(TDy *tdy, PetscErrorCode (*func)(TDy*,P
   *ierr = TDySetForcingFunction(*tdy,ourtdyforcingfunction2,NULL);
 }
 
-static PetscErrorCode ourtdydirichletvaluefunction(TDy tdy,PetscReal *x,PetscReal *f,void *ctx)
+static PetscErrorCode ourtdyboundarypressurefn(TDy tdy,PetscReal *x,PetscReal *f,void *ctx)
 {
 #if defined(PETSC_HAVE_F90_2PTR_ARG)
   void* ptr;
   PetscObjectGetFortranCallback((PetscObject)tdy,PETSC_FORTRAN_CALLBACK_CLASS,_cb.function_pgiptr,NULL,&ptr);
 #endif
-  PetscObjectUseFortranCallback(tdy,_cb.dirichletvalue,(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode* PETSC_F90_2PTR_PROTO_NOVAR),(&tdy,x,f,_ctx,&ierr PETSC_F90_2PTR_PARAM(ptr)));
+  PetscObjectUseFortranCallback(tdy,_cb.boundary_pressure,(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode* PETSC_F90_2PTR_PROTO_NOVAR),(&tdy,x,f,_ctx,&ierr PETSC_F90_2PTR_PARAM(ptr)));
 }
 
-PETSC_EXTERN void tdysetdirichletvaluefunction_(TDy *tdy, PetscErrorCode (*func)(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode*),void *ctx,PetscErrorCode *ierr PETSC_F90_2PTR_PROTO(ptr))
+PETSC_EXTERN void tdysetboundarypressurefn_(TDy *tdy, PetscErrorCode (*func)(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode*),void *ctx,PetscErrorCode *ierr PETSC_F90_2PTR_PROTO(ptr))
 {
-  *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy ,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.dirichletvalue,(PetscVoidFunction)func,ctx);
+  *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy ,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.boundary_pressure,(PetscVoidFunction)func,ctx);
   if (*ierr) return;
 #if defined(PETSC_HAVE_F90_2PTR_ARG)
   *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.function_pgiptr,NULL,ptr);if (*ierr) return;
 #endif
-  *ierr = TDySetDirichletValueFunction(*tdy,ourtdydirichletvaluefunction,NULL);
+  *ierr = TDySetBoundaryPressureFn(*tdy,ourtdyboundarypressurefn,NULL);
 }
 
-static PetscErrorCode ourtdydirichletfluxfunction(TDy tdy,PetscReal *x,PetscReal *f,void *ctx)
+static PetscErrorCode ourtdyboundaryvelocityfn(TDy tdy,PetscReal *x,PetscReal *f,void *ctx)
 {
 #if defined(PETSC_HAVE_F90_2PTR_ARG)
   void* ptr;
   PetscObjectGetFortranCallback((PetscObject)tdy,PETSC_FORTRAN_CALLBACK_CLASS,_cb.function_pgiptr,NULL,&ptr);
 #endif
-  PetscObjectUseFortranCallback(tdy,_cb.dirichletflux,(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode* PETSC_F90_2PTR_PROTO_NOVAR),(&tdy,x,f,_ctx,&ierr PETSC_F90_2PTR_PARAM(ptr)));
+  PetscObjectUseFortranCallback(tdy,_cb.boundary_velocity,(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode* PETSC_F90_2PTR_PROTO_NOVAR),(&tdy,x,f,_ctx,&ierr PETSC_F90_2PTR_PARAM(ptr)));
 }
 
-PETSC_EXTERN void tdysetdirichletfluxfunction_(TDy *tdy, PetscErrorCode (*func)(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode*),void *ctx,PetscErrorCode *ierr PETSC_F90_2PTR_PROTO(ptr))
+PETSC_EXTERN void tdysetboundaryvelocityfn_(TDy *tdy, PetscErrorCode (*func)(TDy*,PetscReal*,PetscReal*,void*,PetscErrorCode*),void *ctx,PetscErrorCode *ierr PETSC_F90_2PTR_PROTO(ptr))
 {
-  *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy ,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.dirichletflux,(PetscVoidFunction)func,ctx);
+  *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy ,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.boundary_velocity,(PetscVoidFunction)func,ctx);
   if (*ierr) return;
 #if defined(PETSC_HAVE_F90_2PTR_ARG)
   *ierr = PetscObjectSetFortranCallback((PetscObject)*tdy,PETSC_FORTRAN_CALLBACK_CLASS,&_cb.function_pgiptr,NULL,ptr);if (*ierr) return;
 #endif
-  *ierr = TDySetDirichletFluxFunction(*tdy,ourtdydirichletfluxfunction,NULL);
+  *ierr = TDySetBoundaryVelocityFn(*tdy,ourtdyboundaryvelocityfn,NULL);
 }
 
 PETSC_EXTERN void tdysetporosityvalueslocal_(TDy *tdy,PetscInt *ni, PetscInt ix[], PetscScalar y[], int *ierr )

--- a/src/mpfao/3D/tdympfao3D_steady.c
+++ b/src/mpfao/3D/tdympfao3D_steady.c
@@ -26,7 +26,7 @@ PetscErrorCode TDyMPFAOComputeSystem_InternalVertices_3DMesh(TDy tdy,Mat K,Vec F
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
 
-  
+
   ierr = DMPlexGetDepthStratum (dm, 0, &vStart, &vEnd); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm, 1, &fStart, &fEnd); CHKERRQ(ierr);
 
@@ -105,7 +105,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
 
-  
+
   ierr = DMPlexGetDepthStratum (dm, 0, &vStart, &vEnd); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum( dm, 2, &fStart, &fEnd); CHKERRQ(ierr);
 
@@ -184,7 +184,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_SharedWithInternalVertices
         if (faces->is_internal[face_id] == 0) {
           PetscInt f;
           f = faces->id[face_id] + fStart;
-          ierr = (*tdy->ops->computedirichletvalue)(tdy, &(tdy->X[f*dim]), &pBoundary[numBoundary], tdy->dirichletvaluectx);CHKERRQ(ierr);
+          ierr = (*tdy->ops->compute_boundary_pressure)(tdy, &(tdy->X[f*dim]), &pBoundary[numBoundary], tdy->boundary_pressure_ctx);CHKERRQ(ierr);
           numBoundary++;
         }
       }
@@ -318,7 +318,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
 
-  
+
   ierr = DMPlexGetDepthStratum(dm, 0, &vStart, &vEnd); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum(dm, 2, &fStart, &fEnd); CHKERRQ(ierr);
 
@@ -356,7 +356,7 @@ PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWithInternalVerti
 
       PetscInt f;
       f = faces->id[face_id] + fStart;
-       ierr = (*tdy->ops->computedirichletvalue)(tdy, &(tdy->X[f*dim]), &pBoundary[numBoundary], tdy->dirichletvaluectx);CHKERRQ(ierr);
+       ierr = (*tdy->ops->compute_boundary_pressure)(tdy, &(tdy->X[f*dim]), &pBoundary[numBoundary], tdy->boundary_pressure_ctx);CHKERRQ(ierr);
        numBoundary++;
 
     }

--- a/src/mpfao/tdympfao.c
+++ b/src/mpfao/tdympfao.c
@@ -737,9 +737,9 @@ PetscReal TDyMPFAOPressureNorm(TDy tdy, Vec U) {
 
   cells = &mesh->cells;
 
-  if (! tdy->ops->computedirichletvalue) {
+  if (! tdy->ops->compute_boundary_pressure) {
     SETERRQ(((PetscObject)dm)->comm,PETSC_ERR_USER,
-            "Must set the dirichlet function with TDySetDirichletValueFunction");
+            "Must set the boundary pressure function with TDySetBoundaryPressureFn");
   }
 
   ierr = DMGetDimension(dm, &dim); CHKERRQ(ierr);
@@ -756,7 +756,7 @@ PetscReal TDyMPFAOPressureNorm(TDy tdy, Vec U) {
 
     if (!cells->is_local[icell]) continue;
 
-    ierr = (*tdy->ops->computedirichletvalue)(tdy, &(tdy->X[icell*dim]), &pressure, tdy->dirichletvaluectx);CHKERRQ(ierr);
+    ierr = (*tdy->ops->compute_boundary_pressure)(tdy, &(tdy->X[icell*dim]), &pressure, tdy->boundary_pressure_ctx);CHKERRQ(ierr);
     norm += (PetscSqr(pressure - u[icell])) * cells->volume[icell];
   }
 
@@ -807,7 +807,7 @@ PetscReal TDyMPFAOVelocityNorm_3DMesh(TDy tdy) {
       face_id = cells->face_ids[faceStart + iface];
       //face    = &(faces[face_id]);
 
-      ierr = (*tdy->ops->computedirichletflux)(tdy, &(tdy->X[(face_id + fStart)*dim]), vel, tdy->dirichletfluxctx);CHKERRQ(ierr);
+      ierr = (*tdy->ops->compute_boundary_velocity)(tdy, &(tdy->X[(face_id + fStart)*dim]), vel, tdy->boundary_velocity_ctx);CHKERRQ(ierr);
       vel_normal = TDyADotB(vel,&(faces->normal[face_id].V[0]),dim);
       if (tdy->vel_count[face_id] != faces->num_vertices[face_id]) {
         SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"tdy->vel_count != faces->num_vertices[face_id]");

--- a/src/tdyconditions.c
+++ b/src/tdyconditions.c
@@ -18,24 +18,24 @@ PetscErrorCode TDySetEnergyForcingFunction(TDy tdy, PetscErrorCode(*f)(TDy,Petsc
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetTemperatureDirichletValueFunction(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
+PetscErrorCode TDySetBoundaryTemperatureFn(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
   PetscFunctionBegin;
-  if (f) tdy->ops->computetemperaturedirichletvalue = f;
-  if (ctx) tdy->temperaturedirichletvaluectx = ctx;
+  if (f) tdy->ops->compute_boundary_temperature = f;
+  if (ctx) tdy->boundary_temperature_ctx = ctx;
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetDirichletValueFunction(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
+PetscErrorCode TDySetBoundaryPressureFn(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
   PetscFunctionBegin;
-  if (f) tdy->ops->computedirichletvalue = f;
-  if (ctx) tdy->dirichletvaluectx = ctx;
+  if (f) tdy->ops->compute_boundary_pressure = f;
+  if (ctx) tdy->boundary_pressure_ctx = ctx;
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetDirichletFluxFunction(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
+PetscErrorCode TDySetBoundaryVelocityFn(TDy tdy, PetscErrorCode(*f)(TDy,PetscReal*,PetscReal*,void*),void *ctx) {
   PetscFunctionBegin;
-  if (f) tdy->ops->computedirichletflux = f;
-  if (ctx) tdy->dirichletfluxctx = ctx;
+  if (f) tdy->ops->compute_boundary_velocity = f;
+  if (ctx) tdy->boundary_velocity_ctx = ctx;
   PetscFunctionReturn(0);
 }
 


### PR DESCRIPTION
* TDySetDirichletValueFunction -> TDySetBoundaryPressureFn
* TDySetTemperatureDirichletValueFunction -> TDySetBoundaryTemperatureFn
* TDySetDirichletFluxFunction -> TDySetBoundaryVelocityFn

Boundary conditions are tricky enough! It's important for us to be precise
about our language. C and Fortran interfaces have been updated, and all the
demos use the new functions.

FYI @ghammond86 @nocollier 