### PR TITLE
Tracking the latest PETSc revision.

### DIFF
--- a/.github/workflows/auto_pr_test.yml
+++ b/.github/workflows/auto_pr_test.yml
@@ -14,7 +14,7 @@ jobs:
   # This job builds the box model and runs our test suite.
   build:
     runs-on: ${{ matrix.os }}
-    container: coherellc/tdycore-petsc:latest
+    container: coherellc/tdycore-petsc:c29323cac9f
 
     # A build matrix storing all desired configurations.
     strategy:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ TDycores provides two dynamical cores:
 Both dycores can use meshes with hexahedral or triangular prismatic cells
 with planar faces. The prismatic cells are aligned logically along a z axis.
 
+## Dependencies
+
+`TDycore` uses [PETSc](https://petsc.org/release/), tracking the
+[main branch](https://gitlab.com/petsc/petsc) fairly closely. Currently,
+`TDycore` is tested against revision `c29323cac9f`.
+
+## More information
+
 Check out the [Wiki](https://github.com/TDycores-Project/TDycore/wiki) for
 documentation, including instructions for
 [building and installing TDycore](https://github.com/TDycores-Project/TDycore/wiki/Building-and-Installing-TDycore).

--- a/include/tdytimers.h
+++ b/include/tdytimers.h
@@ -19,7 +19,7 @@ PETSC_EXTERN PetscErrorCode TDyEnableTimers(void);
 
 // To accomplish this, we use a hash map with string keys and PetscLogEvent
 // values. PETSc ships with khash, so let's appropriate it.
-#include <petsc/private/kernels/khash.h>
+#include <petsc/private/khash/khash.h>
 KHASH_MAP_INIT_STR(TDY_TIMER_MAP, PetscLogEvent)
 PETSC_EXTERN khash_t(TDY_TIMER_MAP)* TDY_TIMERS;
 

--- a/tools/build-petsc-docker-image.sh
+++ b/tools/build-petsc-docker-image.sh
@@ -19,7 +19,7 @@ fi
 
 DOCKERHUB_USER=coherellc
 IMAGE_NAME=tdycore-petsc
-TAG=latest
+TAG=$PETSC_HASH
 
 # Build the image locally.
 mkdir -p docker-build


### PR DESCRIPTION
To clarify our dependencies, we note the tested PETSc revision in our README, and refer to the appropriate Docker image tag in our workflow files. In particular, we no longer use the `latest` tag, which is uninformative.

The only code change needed to adopt this new rev is the location of the `khash` header files.

In support of #188