### PR TITLE
We now construct a DMLabel for boundary faces.

### DIFF
--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -90,6 +90,8 @@ PETSC_EXTERN PetscErrorCode TDyView(TDy,PetscViewer viewer);
 
 PETSC_EXTERN PetscErrorCode TDyGetDimension(TDy,PetscInt*);
 PETSC_EXTERN PetscErrorCode TDyGetDM(TDy,DM*);
+PETSC_EXTERN PetscErrorCode TDyGetBoundaryFaces(TDy,PetscInt*, const PetscInt**);
+PETSC_EXTERN PetscErrorCode TDyRestoreBoundaryFaces(TDy,PetscInt*, const PetscInt**);
 PETSC_EXTERN PetscErrorCode TDyGetCentroidArray(TDy,PetscReal**);
 
 PETSC_EXTERN PetscErrorCode TDySetGravityVector(TDy,PetscReal*);

--- a/src/mesh/tdycoremesh.c
+++ b/src/mesh/tdycoremesh.c
@@ -729,6 +729,11 @@ PetscErrorCode SaveMeshConnectivityInfo(TDy tdy) {
     ierr = DMPlexGetSupportSize(dm, f, &support_size); CHKERRQ(ierr);
     ierr = DMPlexGetSupport(dm, f, &support); CHKERRQ(ierr);
 
+    // TODO: This is where we decide whether a face belongs to the domain
+    // TODO: boundary. It's logically consistent with the way that DMPlex
+    // TODO: decides on the domain boundary, so we can leave it like this
+    // TODO: for now, but we should favor the use of the "boundary" DMLabel
+    // TODO: in future efforts.
     if (support_size == 2) {
       faces->is_internal[iface] = PETSC_TRUE;
     } else {
@@ -737,19 +742,19 @@ PetscErrorCode SaveMeshConnectivityInfo(TDy tdy) {
 
     for (PetscInt s=0; s<support_size; s++) {
       PetscInt icell = support[s] - c_start;
-        PetscBool found = PETSC_FALSE;
-        PetscInt cOffsetFace = cells->face_offset[icell];
-        for (PetscInt ii=0; ii<cells->num_faces[icell]; ii++) {
-          if (cells->face_ids[cOffsetFace+ii] == f-f_start) {
-            found = PETSC_TRUE;
-            break;
-          }
-        }
-        if (!found) {
-          cells->face_ids[cOffsetFace + cells->num_faces[icell]] = f-f_start;
-          cells->num_faces[icell]++;
+      PetscBool found = PETSC_FALSE;
+      PetscInt cOffsetFace = cells->face_offset[icell];
+      for (PetscInt ii=0; ii<cells->num_faces[icell]; ii++) {
+        if (cells->face_ids[cOffsetFace+ii] == f-f_start) {
           found = PETSC_TRUE;
+          break;
         }
+      }
+      if (!found) {
+        cells->face_ids[cOffsetFace + cells->num_faces[icell]] = f-f_start;
+        cells->num_faces[icell]++;
+        found = PETSC_TRUE;
+      }
     }
 
     // If it is a boundary face, increment the number of boundary

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -245,6 +245,8 @@ PetscErrorCode TDyCreate(TDy *_tdy) {
   tdy->Tref = 25;
   tdy->gravity[0] = 0; tdy->gravity[1] = 0; tdy->gravity[2] = 0;
   tdy->dm = NULL;
+  tdy->solution = NULL;
+  tdy->J = NULL;
 
   /* initialize method information to null */
   tdy->vmap = NULL; tdy->emap = NULL; tdy->Alocal = NULL; tdy->Flocal = NULL;
@@ -376,7 +378,14 @@ PetscErrorCode TDyCreateGrid(TDy tdy) {
     tdy->dm = dm;
   }
 
-  /* compute/store plex geometry */
+  // Mark the grid's boundary faces.
+  DMLabel boundary_label;
+  ierr = DMCreateLabel(tdy->dm, "boundary"); CHKERRQ(ierr);
+  ierr = DMGetLabel(tdy->dm, "boundary", &boundary_label); CHKERRQ(ierr);
+  ierr = DMPlexMarkBoundaryFaces(tdy->dm, 1, boundary_label); CHKERRQ(ierr);
+  ierr = DMPlexLabelComplete(tdy->dm, boundary_label); CHKERRQ(ierr);
+
+  // Compute/store plex geometry.
   PetscLogEvent t1 = TDyGetTimer("ComputePlexGeometry");
   TDyStartTimer(t1);
   ierr = DMGetDimension(tdy->dm,&dim); CHKERRQ(ierr);
@@ -552,8 +561,10 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
 
+  MPI_Comm comm = PETSC_COMM_WORLD;
+
   if ((tdy->setupflags & TDySetupFinished) != 0) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
+    SETERRQ(comm,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
   }
 
   // Collect options from command line arguments.
@@ -568,7 +579,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   PetscBool flag;
 
   // Material property options
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: Material property options",""); CHKERRQ(ierr);
+  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Material property options",""); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_porosity", "Value of porosity", NULL, options->porosity, &options->porosity, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_permability", "Value of permeability", NULL, options->permeability, &options->permeability, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_soil_density", "Value of soil density", NULL, options->soil_density, &options->soil_density, NULL); CHKERRQ(ierr);
@@ -577,7 +588,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
   // Characteristic curve options
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: Characteristic curve options",""); CHKERRQ(ierr);
+  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Characteristic curve options",""); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_residual_satuaration", "Value of residual saturation", NULL, options->residual_saturation, &options->residual_saturation, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_gardner_param_n", "Value of Gardner n parameter", NULL, options->gardner_n, &options->gardner_n, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_vangenuchten_param_m", "Value of VanGenuchten m parameter", NULL, options->vangenuchten_m, &options->vangenuchten_m, NULL); CHKERRQ(ierr);
@@ -585,7 +596,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
   // Model options
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: Model options",""); CHKERRQ(ierr);
+  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Model options",""); CHKERRQ(ierr);
   ierr = PetscOptionsEnum("-tdy_mode","Flow mode",
                           "TDySetMode",TDyModes,(PetscEnum)options->mode,
                           (PetscEnum *)&options->mode, NULL); CHKERRQ(ierr);
@@ -632,7 +643,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
 
   // Numerics options
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: Numerics options",""); CHKERRQ(ierr);
+  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Numerics options",""); CHKERRQ(ierr);
   ierr = PetscOptionsEnum("-tdy_method","Discretization method",
                           "TDySetDiscretizationMethod",TDyMethods,
                           (PetscEnum)options->method,(PetscEnum *)&options->method,
@@ -669,7 +680,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
                                &options->init_from_file); CHKERRQ(ierr);
 
   if (options->init_from_file && options->init_with_random_field) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
+    SETERRQ(comm,PETSC_ERR_USER,
             "Only one of -tdy_init_from_file and -tdy_init_with_random_field can be specified");
   }
 
@@ -682,16 +693,16 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
                                sizeof(options->mesh_file),
                                &options->read_mesh); CHKERRQ(ierr);
   if (options->generate_mesh && options->read_mesh) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
+    SETERRQ(comm,PETSC_ERR_USER,
             "Only one of -tdy_generate_mesh and -tdy_read_mesh can be specified");
   }
   if ((tdy->dm != NULL) && (options->generate_mesh || options->read_mesh)) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
+    SETERRQ(comm,PETSC_ERR_USER,
             "TDySetDM was called before TDySetFromOptions: can't generate or "
             "read a mesh");
   }
   if ((tdy->dm == NULL) && !(options->generate_mesh || options->read_mesh)) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,
+    SETERRQ(comm,PETSC_ERR_USER,
             "No mesh is available for TDycore: please use TDySetDM, "
             "-tdy_generate_mesh, or -tdy_read_mesh to specify a mesh");
   }
@@ -709,8 +720,27 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
   tdy->setupflags |= TDyOptionsSet;
 
+  // Create our mesh.
   ierr = TDyCreateGrid(tdy); CHKERRQ(ierr);
 
+  // If we have been instructed to initialize the solution from a random field
+  // or a file, do so.
+  if (options->init_with_random_field || options->init_from_file) {
+    ierr = TDyCreateVectors(tdy); CHKERRQ(ierr);
+    if (options->init_with_random_field) {
+      PetscRandom rand;
+      ierr = PetscRandomCreate(comm, &rand); CHKERRQ(ierr);
+      ierr = PetscRandomSetInterval(rand,1e4, 1e6); CHKERRQ(ierr);
+      ierr = VecSetRandom(tdy->solution, rand); CHKERRQ(ierr);
+      ierr = PetscRandomDestroy(&rand); CHKERRQ(ierr);
+    } else {
+      PetscViewer viewer;
+      ierr = PetscViewerBinaryOpen(comm, options->init_file, FILE_MODE_READ,
+                                   &viewer); CHKERRQ(ierr);
+      ierr = VecLoad(tdy->solution, viewer); CHKERRQ(ierr);
+      ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+    }
+  }
   PetscFunctionReturn(0);
 }
 
@@ -1561,24 +1591,33 @@ PetscErrorCode TDyPostSolveSNESSolver(TDy tdy,Vec U) {
   PetscFunctionReturn(0);
 }
 
+/// Allocates storage for the vectors used by the dycore. Storage is allocated
+/// the first time the function is called. Subsequent calls have no effect.
 PetscErrorCode TDyCreateVectors(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
-  ierr = TDyCreateGlobalVector(tdy,&tdy->solution); CHKERRQ(ierr);
-  ierr = VecDuplicate(tdy->solution,&tdy->residual); CHKERRQ(ierr);
-  ierr = VecDuplicate(tdy->solution,&tdy->accumulation_prev); CHKERRQ(ierr);
-  ierr = VecDuplicate(tdy->solution,&tdy->soln_prev); CHKERRQ(ierr);
+  if (tdy->solution == NULL) {
+    ierr = TDyCreateGlobalVector(tdy,&tdy->solution); CHKERRQ(ierr);
+    ierr = VecDuplicate(tdy->solution,&tdy->residual); CHKERRQ(ierr);
+    ierr = VecDuplicate(tdy->solution,&tdy->accumulation_prev); CHKERRQ(ierr);
+    ierr = VecDuplicate(tdy->solution,&tdy->soln_prev); CHKERRQ(ierr);
+  }
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);
 }
 
+/// Allocates storage for the dycore's Jacobian and preconditioner matrices.
+/// Storage is allocated the first time the function is called. Subsequent calls
+/// have no effect.
 PetscErrorCode TDyCreateJacobian(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   TDY_START_FUNCTION_TIMER()
-  ierr = TDyCreateJacobianMatrix(tdy,&tdy->J); CHKERRQ(ierr);
-  ierr = TDyCreateJacobianMatrix(tdy,&tdy->Jpre); CHKERRQ(ierr);
+  if (tdy->J == NULL) {
+    ierr = TDyCreateJacobianMatrix(tdy,&tdy->J); CHKERRQ(ierr);
+    ierr = TDyCreateJacobianMatrix(tdy,&tdy->Jpre); CHKERRQ(ierr);
+  }
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -378,7 +378,8 @@ PetscErrorCode TDyCreateGrid(TDy tdy) {
     tdy->dm = dm;
   }
 
-  // Mark the grid's boundary faces.
+  // Mark the grid's boundary faces and their transitive closure. All are
+  // stored at their appropriate strata within the label.
   DMLabel boundary_label;
   ierr = DMCreateLabel(tdy->dm, "boundary"); CHKERRQ(ierr);
   ierr = DMGetLabel(tdy->dm, "boundary", &boundary_label); CHKERRQ(ierr);

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -760,23 +760,14 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
   // Create our mesh.
   ierr = TDyCreateGrid(tdy); CHKERRQ(ierr);
 
-  // If we have been instructed to initialize the solution from a random field
-  // or a file, do so.
-  if (options->init_with_random_field || options->init_from_file) {
+  // If we have been instructed to initialize the solution from a file, do so.
+  if (options->init_from_file) {
     ierr = TDyCreateVectors(tdy); CHKERRQ(ierr);
-    if (options->init_with_random_field) {
-      PetscRandom rand;
-      ierr = PetscRandomCreate(comm, &rand); CHKERRQ(ierr);
-      ierr = PetscRandomSetInterval(rand,1e4, 1e6); CHKERRQ(ierr);
-      ierr = VecSetRandom(tdy->solution, rand); CHKERRQ(ierr);
-      ierr = PetscRandomDestroy(&rand); CHKERRQ(ierr);
-    } else {
-      PetscViewer viewer;
-      ierr = PetscViewerBinaryOpen(comm, options->init_file, FILE_MODE_READ,
-                                   &viewer); CHKERRQ(ierr);
-      ierr = VecLoad(tdy->solution, viewer); CHKERRQ(ierr);
-      ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-    }
+    PetscViewer viewer;
+    ierr = PetscViewerBinaryOpen(comm, options->init_file, FILE_MODE_READ,
+                                 &viewer); CHKERRQ(ierr);
+    ierr = VecLoad(tdy->solution, viewer); CHKERRQ(ierr);
+    ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
   }
   PetscFunctionReturn(0);
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -479,10 +479,47 @@ PetscErrorCode TDyGetDimension(TDy tdy,PetscInt *dim) {
   PetscFunctionReturn(0);
 }
 
+/// Retrieves the DM used by the dycore. This must be called after
+/// TDySetDM or TDySetFromOptions.
+/// @param dm A pointer that stores the DM in use by the dycore
 PetscErrorCode TDyGetDM(TDy tdy,DM *dm) {
   PetscFunctionBegin;
   PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
   *dm = tdy->dm;
+  PetscFunctionReturn(0);
+}
+
+/// Retrieves the indices of the faces belonging to the domain boundary
+/// for the dycore. This must be called after TDySetFromOptions. Call
+/// TDyRestoreBoundaryFaces when you're finished manipulating boundary
+/// faces.
+/// @param num_faces A pointer that stores the number of boundary faces
+/// @param faces A pointer to an array that stores the indices of boundary faces
+PetscErrorCode TDyGetBoundaryFaces(TDy tdy, PetscInt *num_faces,
+                                   const PetscInt **faces) {
+  PetscFunctionBegin;
+  PetscErrorCode ierr;
+  DMLabel label;
+  IS is;
+  ierr = DMGetLabel(tdy->dm, "boundary", &label); CHKERRQ(ierr);
+  ierr = DMLabelGetStratumSize(label, 1, num_faces); CHKERRQ(ierr);
+  ierr = DMLabelGetStratumIS(label, 1, &is); CHKERRQ(ierr);
+  ierr = ISGetIndices(is, faces); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+/// Resets the pointers set by TDyGetBoundaryFaces.
+/// @param num_faces A pointer that stores the number of boundary faces
+/// @param faces A pointer to an array that stores the indices of boundary faces
+PetscErrorCode TDyRestoreBoundaryFaces(TDy tdy, PetscInt *num_faces,
+                                       const PetscInt** faces) {
+  PetscFunctionBegin;
+  PetscErrorCode ierr;
+  DMLabel label;
+  IS is;
+  ierr = DMGetLabel(tdy->dm, "boundary", &label); CHKERRQ(ierr);
+  ierr = DMLabelGetStratumIS(label, 1, &is); CHKERRQ(ierr);
+  ierr = ISRestoreIndices(is, faces); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/tdyth.c
+++ b/src/tdyth.c
@@ -54,9 +54,9 @@ PetscErrorCode TDyTHTSPostStep(TS ts) {
   PetscFunctionBegin;
   ierr = PetscObjectGetComm((PetscObject)ts,&comm); CHKERRQ(ierr);
   ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
-  ierr = TSGetTimeStep(ts,&dt); CHKERRQ(ierr); 
-  ierr = TSGetTime(ts,&time); CHKERRQ(ierr); 
-  ierr = TSGetStepNumber(ts,&istep); CHKERRQ(ierr); 
+  ierr = TSGetTimeStep(ts,&dt); CHKERRQ(ierr);
+  ierr = TSGetTime(ts,&time); CHKERRQ(ierr);
+  ierr = TSGetStepNumber(ts,&istep); CHKERRQ(ierr);
   ierr = TSGetSNES(ts,&snes); CHKERRQ(ierr);
   ierr = SNESGetIterationNumber(snes,&nit); CHKERRQ(ierr); ierr = SNESGetLinearSolveIterations(snes,&lit); CHKERRQ(ierr);
   ierr = SNESGetConvergedReason(snes,&reason); CHKERRQ(ierr);
@@ -108,8 +108,8 @@ PetscErrorCode TDyTHConvergenceTest(SNES snes, PetscInt it,
   ierr = VecView(r,viewer);
   ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
 #endif
-  if (!rank) 
+  if (!rank)
     printf("%3d: %9.2e %9.2e %9.2e\n",it,fnorm,xnorm,unorm);
-    
+
   PetscFunctionReturn(0);
 }


### PR DESCRIPTION
As discussed in #187, this PR introduces the use of `DMPlexMarkBoundaryFaces` to produce a `DMLabel` named `"boundary"` that we can use to enforce boundary conditions. I'm trying to be careful about how we approach this, because our demos are all pretty historical-looking. So this is just another in a series of PRs to improve the organization of the TDycore library.

Additional items:

* If given `-tdy_init_file`,`TDySetFromOptions` allocates storage for the solution vector and friends with `TDyCreateVectors` and initializes things accordingly. I tried to initialize from a random field, too, but TH does this differently, so this must be done elsewhere for now.
* `TDyCreateVectors` and `TDyCreateJacobian` are documented and can be safely called multiple times (with no effect after the first time).
* `TDyGetBoundaryFaces` and `TDyRestoreBoundaryFaces` are introduced, to provide access to the (undifferentiated) faces on the domain boundary via the label. This provides a simple mechanism for traversing just the boundary faces.
* The two-point-flux approximation method has been updated to use the `"boundary"` label. However, I haven't changed the MPFA-O method for marking boundary faces, since it's logically consistent already. I did leave a `TODO` comment in that section for subsequent cleanup if we want to tighten things up later.

At this point, the set of faces on the domain boundary is generated automatically when the grid is created, so all demos can access it. I think this should close #187. @bishtgautam , let me know if you don't agree. #188 probably demands a little more attention, and the callback/virtual table way of organizing our different algorithms (#197) is looking ever more appealing.

Closes #187