### PR TITLE
A starting point for a polymorphic solver-based TDycore interface.

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
   ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
 
   /* Setup problem parameters */
-  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
+  ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -734,7 +734,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
+  ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Compute system */
   Mat K;

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
   ierr = TDySetForcingFunction(tdy,Forcing,NULL); CHKERRQ(ierr);
   ierr = TDySetBoundaryPressureFn(tdy,Pressure,NULL); CHKERRQ(ierr);
 
-  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
+  ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   /* Setup initial condition */
   Vec U;

--- a/demo/transient/transient_mpfaof90.F90
+++ b/demo/transient/transient_mpfaof90.F90
@@ -161,7 +161,7 @@ implicit none
   call TDySetResidualSaturationValuesLocal(tdy,cEnd-cStart,index,residualSat,ierr);
   CHKERRA(ierr);
 
-  call TDySetupNumericalMethods(tdy,ierr);
+  call TDySetup(tdy,ierr);
   CHKERRA(ierr);
 
   ! Set initial condition

--- a/demo/transient/transient_snes_mpfaof90.F90
+++ b/demo/transient/transient_snes_mpfaof90.F90
@@ -357,7 +357,7 @@ implicit none
   if (use_tdydriver) then
      call TDyDriverInitializeTDy(tdy, ierr);
   else
-     call TDySetupNumericalMethods(tdy,ierr);
+     call TDySetup(tdy,ierr);
      CHKERRA(ierr);
   end if
 

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -34,13 +34,8 @@ struct _TDyOps {
   // from command-line arguments.
   PetscErrorCode (*set_from_options)(void*);
 
-  // Called by TDySetSNES -- sets up an SNES nonlinear solver for use with the
-  // given TDycore context.
-  PetscErrorCode (*set_snes)(void*, DM, SNES);
-
-  // Called by TDySetTS -- sets up a PETSc TS ODE solver for use with the
-  // given TDycore context.
-  PetscErrorCode (*set_ts)(void*, DM, TS);
+  // Called by TDySetup -- configures the DM for the dycore.
+  PetscErrorCode (*config_dm)(void*, DM);
 
   // Called by TDyComputeErrorNorms -- computes error norms given a solution
   // vector.
@@ -63,16 +58,20 @@ struct _TDyOps {
 struct _p_TDy {
   PETSCHEADER(struct _TDyOps);
 
-  // Implementation-specific context pointer.
+  // Implementation-specific context pointer
   void *context;
 
-  PetscBool setup;
+  // Flags that indicate where the dycore is in the setup process
+  TDySetupFlags setup_flags;
 
-  // Grid.
+  // Grid and data management -- handed to a solver when the dycore is fully
+  // configured
   DM dm;
 
+  // We'll likely get rid of this.
   TDyTimeIntegrator ti;
-  TDySetupFlags setupflags;
+
+  // I/O subsystem
   TDyIO io;
 
   // options that determine the behavior(s) of the dycore

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -155,11 +155,17 @@ PETSC_EXTERN PetscErrorCode TDySetWaterDensityType(TDy,TDyWaterDensityType);
 PETSC_EXTERN PetscErrorCode TDySetMPFAOGmatrixMethod(TDy,TDyMPFAOGmatrixMethod);
 PETSC_EXTERN PetscErrorCode TDySetMPFAOBoundaryConditionType(TDy,TDyMPFAOBoundaryConditionType);
 
+// Setup functions for PETSc solvers (implementation-specific)
+PETSC_EXTERN PetscErrorCode TDySetSNES(TDy,SNES);
+PETSC_EXTERN PetscErrorCode TDySetTS(TDy,TS);
+
+// The following functions will probably be replaced by the TDySet* functions
 PETSC_EXTERN PetscErrorCode TDyComputeSystem(TDy,Mat,Vec);
 PETSC_EXTERN PetscErrorCode TDySetIFunction(TS,TDy);
 PETSC_EXTERN PetscErrorCode TDySetIJacobian(TS,TDy);
 PETSC_EXTERN PetscErrorCode TDySetSNESFunction(SNES,TDy);
 PETSC_EXTERN PetscErrorCode TDySetSNESJacobian(SNES,TDy);
+
 PETSC_EXTERN PetscErrorCode TDyComputeErrorNorms(TDy,Vec,PetscReal*,PetscReal*);
 
 PETSC_EXTERN PetscErrorCode TDySetDtimeForSNESSolver(TDy,PetscReal);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -82,9 +82,8 @@ PETSC_EXTERN PetscErrorCode TDyFinalize(void);
 PETSC_EXTERN PetscErrorCode TDyCreate(TDy*);
 PETSC_EXTERN PetscErrorCode TDySetMode(TDy,TDyMode);
 PETSC_EXTERN PetscErrorCode TDySetDiscretizationMethod(TDy,TDyMethod);
-PETSC_EXTERN PetscErrorCode TDySetDM(TDy,DM);
 PETSC_EXTERN PetscErrorCode TDySetFromOptions(TDy);
-PETSC_EXTERN PetscErrorCode TDySetupNumericalMethods(TDy);
+PETSC_EXTERN PetscErrorCode TDySetup(TDy);
 PETSC_EXTERN PetscErrorCode TDyDestroy(TDy *tdy);
 PETSC_EXTERN PetscErrorCode TDyView(TDy,PetscViewer viewer);
 
@@ -155,11 +154,8 @@ PETSC_EXTERN PetscErrorCode TDySetWaterDensityType(TDy,TDyWaterDensityType);
 PETSC_EXTERN PetscErrorCode TDySetMPFAOGmatrixMethod(TDy,TDyMPFAOGmatrixMethod);
 PETSC_EXTERN PetscErrorCode TDySetMPFAOBoundaryConditionType(TDy,TDyMPFAOBoundaryConditionType);
 
-// Setup functions for PETSc solvers (implementation-specific)
-PETSC_EXTERN PetscErrorCode TDySetSNES(TDy,SNES);
-PETSC_EXTERN PetscErrorCode TDySetTS(TDy,TS);
-
-// The following functions will probably be replaced by the TDySet* functions
+// We will probably remove the following functions.
+PETSC_EXTERN PetscErrorCode TDySetDM(TDy,DM);
 PETSC_EXTERN PetscErrorCode TDyComputeSystem(TDy,Mat,Vec);
 PETSC_EXTERN PetscErrorCode TDySetIFunction(TS,TDy);
 PETSC_EXTERN PetscErrorCode TDySetIJacobian(TS,TDy);

--- a/src/f90-mod/tdycoremod.F90
+++ b/src/f90-mod/tdycoremod.F90
@@ -85,11 +85,11 @@ module tdycore
      end subroutine TDyTimeIntegratorOutputRegression
   end interface
   interface
-     subroutine TDySetupNumericalMethods(a,z)
+     subroutine TDySetup(a,z)
        use tdycoredef
        TDy a
        integer z
-     end subroutine TDySetupNumericalMethods
+     end subroutine TDySetup
   end interface
   interface
      subroutine TDyComputeSystem(a,b,c,z)

--- a/src/interface/ftn/tdycoref.c
+++ b/src/interface/ftn/tdycoref.c
@@ -18,7 +18,7 @@
 #define tdydtimeintegratorruntotime_                   TDYTIMEINTEGRATORRUNTOTIME
 #define tdydtimeintegratorsettimestep_                 TDYTIMEINTEGRATORSETTIMESTEP
 #define tdydtimeintegratoroutputregression_            TDYTIMEINTEGRATOROUTPUTREGRESSION
-#define tdysetupnumericalmethods_                      TDYSETUPNUMERICALMETHODS
+#define tdysetup_                                      TDYSETUP
 #define tdysetwaterdensitytype_                        TDYSETWATERDENSITYTYPE
 #define tdysetmpfaogmatrixmethod_                      TDYSETMPFAOGMATRIXMETHOD
 #define tdysetmpfaoboundaryconditiontype_              TDYSETMPFAOGBOUNDARYCONDITIONTYPE
@@ -80,7 +80,7 @@
 #define tdydtimeintegratorruntotime_                   tdydtimeintegratorruntotime
 #define tdydtimeintegratorsettimestep_                 tdydtimeintegratorsettimestep
 #define tdydtimeintegratoroutputregression_            tdydtimeintegratoroutputregression
-#define tdysetupnumericalmethods_                      tdysetupnumericalmethods
+#define tdysetup_                                      tdysetup
 #define tdysetwaterdensitytype_                        tdysetwaterdensitytype
 #define tdysetmpfaogmatrixmethod_                      tdysetmpfaogmatrixmethod
 #define tdysetmpfaoboundaryconditiontype_              tdysetmpfaoboundaryconditiontype
@@ -255,8 +255,8 @@ PETSC_EXTERN void  tdytimeintegratoroutputregression_(TDy tdy, int *__ierr){
 #if defined(__cplusplus)
 extern "C" {
 #endif
-PETSC_EXTERN void  tdysetupnumericalmethods_(TDy _tdy, int *__ierr){
-*__ierr = TDySetupNumericalMethods((TDy)PetscToPointer((_tdy)));
+PETSC_EXTERN void  tdysetup_(TDy _tdy, int *__ierr){
+*__ierr = TDySetup((TDy)PetscToPointer((_tdy)));
 }
 #if defined(__cplusplus)
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -866,6 +866,44 @@ PetscErrorCode TDySetMPFAOBoundaryConditionType(TDy tdy,TDyMPFAOBoundaryConditio
   PetscFunctionReturn(0);
 }
 
+/// Sets up an SNES nonlinear solver to solve a relevant system for the given
+/// dycore.
+/// @param tdy [in] A dycore object
+/// @param snes [inout] A PETSc SNES nonlinear solver object
+PetscErrorCode TDySetSNES(TDy tdy, SNES snes) {
+  int ierr;
+  PetscFunctionBegin;
+  TDY_START_FUNCTION_TIMER()
+  if (tdy->ops->set_snes) {
+    ierr = tdy->ops->set_snes(tdy->context, tdy->dm, snes); CHKERRQ(ierr);
+  } else {
+    MPI_Comm comm;
+    ierr = PetscObjectGetComm((PetscObject)tdy,&comm); CHKERRQ(ierr);
+    SETERRQ(comm,PETSC_ERR_SUP,"TDySetSNES not implemented for dycore");
+  }
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(ierr);
+}
+
+/// Sets up a TS ODE solver to solve a relevant system for the given
+/// dycore.
+/// @param tdy [in] A dycore object
+/// @param ts [inout] A PETSc TS ODE solver object
+PetscErrorCode TDySetTS(TDy tdy, TS ts) {
+  int ierr;
+  PetscFunctionBegin;
+  TDY_START_FUNCTION_TIMER()
+  if (tdy->ops->set_ts) {
+    ierr = tdy->ops->set_ts(tdy->context, tdy->dm, ts); CHKERRQ(ierr);
+  } else {
+    MPI_Comm comm;
+    ierr = PetscObjectGetComm((PetscObject)tdy,&comm); CHKERRQ(ierr);
+    SETERRQ(comm,PETSC_ERR_SUP,"TDySetTS not implemented for dycore");
+  }
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(ierr);
+}
+
 PetscErrorCode TDySetIFunction(TS ts,TDy tdy) {
   MPI_Comm       comm;
   DM             dm;

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -241,7 +241,7 @@ PetscErrorCode TDyCreate(TDy *_tdy) {
   ierr = PetscHeaderCreate(tdy,TDY_CLASSID,"TDy","TDy","TDy",PETSC_COMM_WORLD,
                            TDyDestroy,TDyView); CHKERRQ(ierr);
   *_tdy = tdy;
-  tdy->setupflags |= TDyCreated;
+  tdy->setup_flags |= TDyCreated;
 
   SetDefaultOptions(tdy);
 
@@ -260,7 +260,7 @@ PetscErrorCode TDyCreate(TDy *_tdy) {
   tdy->quad = NULL;
   tdy->faces = NULL; tdy->LtoG = NULL; tdy->orient = NULL;
 
-  tdy->setupflags |= TDyParametersInitialized;
+  tdy->setup_flags |= TDyParametersInitialized;
   PetscFunctionReturn(0);
 }
 
@@ -367,7 +367,7 @@ PetscErrorCode TDyCreateGrid(TDy tdy) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   MPI_Comm comm = PETSC_COMM_WORLD;
-  if ((tdy->setupflags & TDyOptionsSet) == 0) {
+  if ((tdy->setup_flags & TDyOptionsSet) == 0) {
     SETERRQ(comm,PETSC_ERR_USER,"Options must be set prior to TDyCreateGrid()");
   }
 
@@ -607,7 +607,7 @@ PetscErrorCode TDyView(TDy tdy,PetscViewer viewer) {
 }
 
 /// Sets options for the dycore based on command line arguments supplied by a
-/// user. TDySetFromOptions must be called before TDySetupNumericalMethods,
+/// user. TDySetFromOptions must be called before TDySetup,
 /// since the latter uses options specified by the former.
 /// @param tdy The dycore instance
 PetscErrorCode TDySetFromOptions(TDy tdy) {
@@ -616,8 +616,8 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
 
   MPI_Comm comm = PETSC_COMM_WORLD;
 
-  if ((tdy->setupflags & TDySetupFinished) != 0) {
-    SETERRQ(comm,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
+  if ((tdy->setup_flags & TDySetupFinished) != 0) {
+    SETERRQ(comm,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetup()");
   }
 
   // Collect options from command line arguments.
@@ -743,7 +743,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
 
   // Wrap up and indicate that options are set.
   ierr = PetscOptionsEnd(); CHKERRQ(ierr);
-  tdy->setupflags |= TDyOptionsSet;
+  tdy->setup_flags |= TDyOptionsSet;
 
   // Create our mesh.
   ierr = TDyCreateGrid(tdy); CHKERRQ(ierr);
@@ -793,16 +793,18 @@ PetscErrorCode TDySetupDiscretizationScheme(TDy tdy) {
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetupNumericalMethods(TDy tdy) {
+PetscErrorCode TDySetup(TDy tdy) {
   /* must follow TDySetFromOptions() is it relies upon options set by
      TDySetFromOptions */
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  if ((tdy->setupflags & TDyOptionsSet) == 0) {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetupNumericalMethods()");
+  if ((tdy->setup_flags & TDyOptionsSet) == 0) {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TDySetFromOptions must be called prior to TDySetup()");
   }
   TDY_START_FUNCTION_TIMER()
   TDyEnterProfilingStage("TDycore Setup");
+  // TODO: Stick a call to tdy->ops->config_dm here to configure the DM for our
+  // TODO: specific dycore setup.
   ierr = TDySetupDiscretizationScheme(tdy); CHKERRQ(ierr);
   if (tdy->options.regression_testing) {
     /* must come after Sections are set up in
@@ -816,7 +818,7 @@ PetscErrorCode TDySetupNumericalMethods(TDy tdy) {
     }
   }
   TDyExitProfilingStage("TDycore Setup");
-  tdy->setupflags |= TDySetupFinished;
+  tdy->setup_flags |= TDySetupFinished;
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);
 }
@@ -864,44 +866,6 @@ PetscErrorCode TDySetMPFAOBoundaryConditionType(TDy tdy,TDyMPFAOBoundaryConditio
   tdy->options.mpfao_bc_type = bctype;
 
   PetscFunctionReturn(0);
-}
-
-/// Sets up an SNES nonlinear solver to solve a relevant system for the given
-/// dycore.
-/// @param tdy [in] A dycore object
-/// @param snes [inout] A PETSc SNES nonlinear solver object
-PetscErrorCode TDySetSNES(TDy tdy, SNES snes) {
-  int ierr;
-  PetscFunctionBegin;
-  TDY_START_FUNCTION_TIMER()
-  if (tdy->ops->set_snes) {
-    ierr = tdy->ops->set_snes(tdy->context, tdy->dm, snes); CHKERRQ(ierr);
-  } else {
-    MPI_Comm comm;
-    ierr = PetscObjectGetComm((PetscObject)tdy,&comm); CHKERRQ(ierr);
-    SETERRQ(comm,PETSC_ERR_SUP,"TDySetSNES not implemented for dycore");
-  }
-  TDY_STOP_FUNCTION_TIMER()
-  PetscFunctionReturn(ierr);
-}
-
-/// Sets up a TS ODE solver to solve a relevant system for the given
-/// dycore.
-/// @param tdy [in] A dycore object
-/// @param ts [inout] A PETSc TS ODE solver object
-PetscErrorCode TDySetTS(TDy tdy, TS ts) {
-  int ierr;
-  PetscFunctionBegin;
-  TDY_START_FUNCTION_TIMER()
-  if (tdy->ops->set_ts) {
-    ierr = tdy->ops->set_ts(tdy->context, tdy->dm, ts); CHKERRQ(ierr);
-  } else {
-    MPI_Comm comm;
-    ierr = PetscObjectGetComm((PetscObject)tdy,&comm); CHKERRQ(ierr);
-    SETERRQ(comm,PETSC_ERR_SUP,"TDySetTS not implemented for dycore");
-  }
-  TDY_STOP_FUNCTION_TIMER()
-  PetscFunctionReturn(ierr);
 }
 
 PetscErrorCode TDySetIFunction(TS ts,TDy tdy) {

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -70,7 +70,7 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
     }
   }
 
-  ierr = TDySetupNumericalMethods(tdy); CHKERRQ(ierr);
+  ierr = TDySetup(tdy); CHKERRQ(ierr);
 
   ierr = TDyTimeIntegratorCreate(&tdy->ti); CHKERRQ(ierr);
   ierr = TDyCreateVectors(tdy); CHKERRQ(ierr);


### PR DESCRIPTION
This small PR lays part of the foundation for a move to a more solver-based interface. Our objective here, in the spirit of #197, is to move from our current approach of determining the behavior of the dycore (`if` tests in several functions scattered throughout the library, to match the dycore against its type of discretization, etc) to a new approach based on function pointers. The closest handy analogy for most is C++'s implementation of polymorphism using virtual tables. But PETSc itself uses this approach heavily.

In `include/tdycore.h`, line 162, you can see that I've written that certain functions using the old approach will likely be replaced by a smaller set of new polymorphic functions. Specifically, we are adding two new functions:

* `TDySetSNES(TDy dycore, SNES solver)` - takes an SNES nonlinear solver object and sets it up to solve the system relevant to the dycore.
* `TDySetTS(TDy dycore, TS solver)` - takes a TS ODE solver object and sets it up to solve the system relevant to the dycore.

These functions are simple wrappers and are implemented in `tdycore.c`. You can see all they do is pass the call along to the appropriate function pointer, or complain with an error if no such function pointer exists. This allows any given implementation of the dycore to simply supply the right function pointers instead of being added to a long chain of `if` tests in several functions throughout the code base.

Additionally (if people like the direction of this PR), we'll be retrofitting other functions such as `TDyComputeErrorNorms` to be polymorphic. Any function that contains `if` tests that try to figure out "which algorithm we're using in the dycore" will be replaced with an interface function that calls the appropriate implementation-specific function pointer.

The idea here is that we can use the solver interface to set specific solver parameters, and to step forward in time. We also talked about a higher level TDycore interface that does some of this stuff in solver-neutral language. That's very easy to add on top of this kind of interface.

I know the PETSc folks are very familiar with this approach--I expect them mostly to correct my "spelling"of polymorphic C code to their tastes. For others, I'm happy to chat about function pointers, polymorphism in general, and/or how this will look in specific cases.