### PR TITLE
Added TDyCreateDiagnostics and TDyComputeDiagnostics functions.

### DIFF
--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -69,6 +69,13 @@ struct _TDyOps {
   // Called by TDyIOWriteVec to retrieve the saturation values -- can we figure
   // out a better way to do this?
   PetscErrorCode (*get_saturation)(void*, PetscReal*);
+
+  // Sets up diagnostic fields in the section for a given auxiliary DM. This
+  // function is not expected to create the section or to call PetscSectionSetUp.
+  PetscErrorCode (*set_diagnostics_section)(void*, TDyOptions, PetscSection);
+
+  // Computes diagnostic fields given an auxiliary DM.
+  PetscErrorCode (*compute_diagnostics)(void*, DM, Vec);
 };
 
 // This type represents the dycore and all of its settings.

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -70,9 +70,9 @@ struct _TDyOps {
   // out a better way to do this?
   PetscErrorCode (*get_saturation)(void*, PetscReal*);
 
-  // Sets up diagnostic fields in the section for a given auxiliary DM. This
-  // function is not expected to create the section or to call PetscSectionSetUp.
-  PetscErrorCode (*set_diagnostics_section)(void*, TDyOptions, PetscSection);
+  // Sets up diagnostic fields for a given auxiliary DM, in the same way as
+  // dm_set_fields.
+  PetscErrorCode (*set_diagnostic_fields)(void*, TDyOptions, DM);
 
   // Computes diagnostic fields given an auxiliary DM.
   PetscErrorCode (*compute_diagnostics)(void*, DM, Vec);

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -72,7 +72,7 @@ struct _TDyOps {
 
   // Sets up diagnostic fields for a given auxiliary DM, in the same way as
   // dm_set_fields.
-  PetscErrorCode (*set_diagnostic_fields)(void*, TDyOptions, DM);
+  PetscErrorCode (*set_diagnostic_fields)(void*, DM);
 
   // Computes diagnostic fields given an auxiliary DM.
   PetscErrorCode (*compute_diagnostics)(void*, DM, Vec);

--- a/include/private/tdympfaoimpl.h
+++ b/include/private/tdympfaoimpl.h
@@ -95,7 +95,8 @@ PETSC_INTERN PetscErrorCode TDySetup_TH_MPFAO(void*, DM, EOS*, MaterialProp*, Ch
 PETSC_INTERN PetscErrorCode TDyUpdateState_Richards_MPFAO(void*, DM, EOS*, MaterialProp*, CharacteristicCurves*, PetscReal*);
 PETSC_INTERN PetscErrorCode TDyUpdateState_TH_MPFAO(void*, DM, EOS*, MaterialProp*, CharacteristicCurves*, PetscReal*);
 PETSC_INTERN PetscErrorCode TDyComputeErrorNorms_MPFAO(void*,DM,Conditions*,Vec,PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode TDyGetSaturation_MPFAO(void*,PetscReal*);
+PETSC_INTERN PetscErrorCode TDySetDiagnosticFields_MPFAO(void*,DM);
+PETSC_INTERN PetscErrorCode TDyComputeDiagnostics_MPFAO(void*,DM,Vec);
 
 PETSC_INTERN PetscErrorCode TDyUpdateTransmissibilityMatrix(TDy);
 PETSC_INTERN PetscErrorCode TDyComputeTransmissibilityMatrix(TDy);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -152,7 +152,7 @@ PETSC_EXTERN PetscErrorCode TDySetSoilDensityFunction(TDy,TDyScalarSpatialFuncti
 PETSC_EXTERN PetscErrorCode TDySetConstantSoilSpecificHeat(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetSoilSpecificHeatFunction(TDy,TDyScalarSpatialFunction);
 
-// Set boundary and source-sink: via PETSc operations
+// Set boundary conditions and sources/sinks
 PETSC_EXTERN PetscErrorCode TDySetForcingFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetEnergyForcingFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureFunction(TDy,TDyScalarSpatialFunction);
@@ -166,6 +166,10 @@ PETSC_EXTERN PetscErrorCode TDySelectBoundaryVelocityFunction(TDy,const char*);
 
 PETSC_EXTERN PetscErrorCode TDyUpdateState(TDy,PetscReal*);
 PETSC_EXTERN PetscErrorCode TDyComputeErrorNorms(TDy,Vec,PetscReal*,PetscReal*);
+
+// Access to diagnostic variables
+PETSC_EXTERN PetscErrorCode TDyCreateDiagnostics(TDy,DM*);
+PETSC_EXTERN PetscErrorCode TDyComputeDiagnostics(TDy,DM,Vec);
 
 // We will remove the following functions in favor of setting function pointers
 // that a given solver uses to extract info from a DM.

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -167,7 +167,16 @@ PETSC_EXTERN PetscErrorCode TDySelectBoundaryVelocityFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDyUpdateState(TDy,PetscReal*);
 PETSC_EXTERN PetscErrorCode TDyComputeErrorNorms(TDy,Vec,PetscReal*,PetscReal*);
 
+//--------------------------------
 // Access to diagnostic variables
+//--------------------------------
+
+// This type can be used to index fields in a diagnostic vector populated by
+// TDyComputeDiagnostics.
+typedef enum {
+  DIAG_SATURATION = 0, // liquid saturation
+  DIAG_LIQUID_MASS,    // liquid mass
+} TDyDiag;
 PETSC_EXTERN PetscErrorCode TDyCreateDiagnostics(TDy,DM*);
 PETSC_EXTERN PetscErrorCode TDyComputeDiagnostics(TDy,DM,Vec);
 

--- a/src/f90-mod/tdycore.h
+++ b/src/f90-mod/tdycore.h
@@ -40,3 +40,13 @@
       ! The parameters values need to match those defined in
       ! the C code (i.e. include/tdycore.h)
       parameter (WATER_DENSITY_CONSTANT=0,WATER_DENSITY_EXPONENTIAL=1)
+
+!
+!  TDy diagnostic variables
+!
+      PetscEnum DIAG_SATURATION
+      PetscEnum DIAG_LIQUID_MASS
+
+      ! The parameters values need to match those defined in
+      ! the C code (i.e. include/tdycore.h)
+      parameter (DIAG_SATURATION=0,DIAG_LIQUID_MASS=1)

--- a/src/f90-mod/tdycoref.c
+++ b/src/f90-mod/tdycoref.c
@@ -129,7 +129,9 @@ PETSC_EXTERN void  tdycreatediagnostics_(TDy _tdy, DM *dm, int *__ierr){
 }
 
 PETSC_EXTERN void  tdycomputediagnostics_(TDy _tdy, DM dm, Vec v, int *__ierr){
-*__ierr = TDyComputeDiagnostics((TDy)PetscToPointer((_tdy)), dm, v);
+*__ierr = TDyComputeDiagnostics((TDy)PetscToPointer((_tdy)),
+                                (DM)PetscToPointer(dm),
+                                (Vec)PetscToPointer(v));
 }
 
 PETSC_EXTERN void  tdysetwaterdensitytype_(TDy tdy, PetscInt *method, int *__ierr){

--- a/src/f90-mod/tdycoref.c
+++ b/src/f90-mod/tdycoref.c
@@ -21,6 +21,8 @@
 #define tdydtimeintegratoroutputregression_            TDYTIMEINTEGRATOROUTPUTREGRESSION
 #define tdysetup_                                      TDYSETUP
 #define tdygetdm_                                      TDYGETDM
+#define tdycreatediagnostics_                          TDYCREATEDIAGNOSTICS
+#define tdycomputediagnostics_                         TDYCOMPUTEDIAGNOSTICS
 #define tdysetwaterdensitytype_                        TDYSETWATERDENSITYTYPE
 #define tdympfaosetgmatrixmethod_                      TDYMPFAOSETGMATRIXMETHOD
 #define tdympfaosetboundaryconditiontype_              TDYMPFAOSETBOUNDARYCONDITIONTYPE
@@ -52,6 +54,8 @@
 #define tdydtimeintegratoroutputregression_            tdydtimeintegratoroutputregression
 #define tdysetup_                                      tdysetup
 #define tdygetdm_                                      tdygetdm
+#define tdycreatediagnostics_                          tdycreatediagnostics
+#define tdycomputediagnostics_                         tdycomputediagnostics
 #define tdysetwaterdensitytype_                        tdysetwaterdensitytype
 #define tdympfaosetgmatrixmethod_                      tdympfaosetgmatrixmethod
 #define tdympfaosetboundaryconditiontype_              tdympfaosetboundaryconditiontype
@@ -118,6 +122,14 @@ PETSC_EXTERN void  tdysetup_(TDy _tdy, int *__ierr){
 
 PETSC_EXTERN void  tdygetdm_(TDy _tdy, DM *dm, int *__ierr){
 *__ierr = TDyGetDM((TDy)PetscToPointer((_tdy)), dm);
+}
+
+PETSC_EXTERN void  tdycreatediagnostics_(TDy _tdy, DM *dm, int *__ierr){
+*__ierr = TDyCreateDiagnostics((TDy)PetscToPointer((_tdy)), dm);
+}
+
+PETSC_EXTERN void  tdycomputediagnostics_(TDy _tdy, DM dm, Vec v, int *__ierr){
+*__ierr = TDyComputeDiagnostics((TDy)PetscToPointer((_tdy)), dm, v);
 }
 
 PETSC_EXTERN void  tdysetwaterdensitytype_(TDy tdy, PetscInt *method, int *__ierr){

--- a/src/fe/tdybdm.c
+++ b/src/fe/tdybdm.c
@@ -569,7 +569,7 @@ PetscErrorCode TDyComputeErrorNorms_BDM(void *context, DM dm, Conditions *condit
     }
     ierr = VecGetArray(U,&u); CHKERRQ(ierr);
     ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-    ierr = DMGetSection(dm,&sec); CHKERRQ(ierr);
+    ierr = DMGetLocalSection(dm,&sec); CHKERRQ(ierr);
     ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
     norm = 0; norm_sum = 0;
     for(c=cStart; c<cEnd; c++) {

--- a/src/fe/tdywy.c
+++ b/src/fe/tdywy.c
@@ -823,7 +823,7 @@ PetscErrorCode TDyWYRecoverVelocity(TDy tdy,Vec U) {
   ierr = DMGetLocalVector(dm,&localU); CHKERRQ(ierr);
   ierr = TDyGlobalToLocal(tdy,U,localU); CHKERRQ(ierr);
   ierr = VecGetArray(localU,&u); CHKERRQ(ierr);
-  ierr = DMGetSection(dm, &section); CHKERRQ(ierr);
+  ierr = DMGetLocalSection(dm, &section); CHKERRQ(ierr);
   nq   = wy->ncv;
   nv   = wy->nfv;
   ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -762,7 +762,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->setup = TDySetup_Richards_MPFAO;
       tdy->ops->update_state = TDyUpdateState_Richards_MPFAO;
       tdy->ops->compute_error_norms = TDyComputeErrorNorms_MPFAO;
-      tdy->ops->get_saturation = TDyGetSaturation_MPFAO;
+      tdy->ops->set_diagnostic_fields = TDySetDiagnosticFields_MPFAO;
+      tdy->ops->compute_diagnostics = TDyComputeDiagnostics_MPFAO;
     } else if (discretization == MPFA_O_DAE) {
       tdy->ops->create = TDyCreate_MPFAO;
       tdy->ops->destroy = TDyDestroy_MPFAO;
@@ -771,7 +772,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->setup = TDySetup_Richards_MPFAO_DAE;
       tdy->ops->update_state = TDyUpdateState_Richards_MPFAO;
       tdy->ops->compute_error_norms = TDyComputeErrorNorms_MPFAO;
-      tdy->ops->get_saturation = TDyGetSaturation_MPFAO;
+      tdy->ops->set_diagnostic_fields = TDySetDiagnosticFields_MPFAO;
+      tdy->ops->compute_diagnostics = TDyComputeDiagnostics_MPFAO;
     } else if (discretization == MPFA_O_TRANSIENTVAR) {
       tdy->ops->create = TDyCreate_MPFAO;
       tdy->ops->destroy = TDyDestroy_MPFAO;
@@ -780,7 +782,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->setup = TDySetup_Richards_MPFAO;
       tdy->ops->update_state = TDyUpdateState_Richards_MPFAO;
       tdy->ops->compute_error_norms = TDyComputeErrorNorms_MPFAO;
-      tdy->ops->get_saturation = TDyGetSaturation_MPFAO;
+      tdy->ops->set_diagnostic_fields = TDySetDiagnosticFields_MPFAO;
+      tdy->ops->compute_diagnostics = TDyComputeDiagnostics_MPFAO;
     } else if (discretization == BDM) {
       tdy->ops->create = TDyCreate_BDM;
       tdy->ops->destroy = TDyDestroy_BDM;
@@ -789,6 +792,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->set_dm_fields = TDySetDMFields_BDM;
       tdy->ops->update_state = NULL; // FIXME: ???
       tdy->ops->compute_error_norms = TDyComputeErrorNorms_BDM;
+      tdy->ops->set_diagnostic_fields = NULL; // FIXME
+      tdy->ops->compute_diagnostics = NULL; // FIXME
     } else if (discretization == WY) {
       tdy->ops->create = TDyCreate_WY;
       tdy->ops->destroy = TDyDestroy_WY;
@@ -797,6 +802,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->setup = TDySetup_WY;
       tdy->ops->update_state = TDyUpdateState_WY;
       tdy->ops->compute_error_norms = TDyComputeErrorNorms_WY;
+      tdy->ops->set_diagnostic_fields = NULL; // FIXME
+      tdy->ops->compute_diagnostics = NULL; // FIXME
     } else {
       SETERRQ(comm,PETSC_ERR_USER, "Invalid discretization given!");
     }
@@ -808,7 +815,8 @@ PetscErrorCode TDySetDiscretization(TDy tdy, TDyDiscretization discretization) {
       tdy->ops->set_dm_fields = TDySetDMFields_TH_MPFAO;
       tdy->ops->setup = TDySetup_TH_MPFAO;
       tdy->ops->update_state = TDyUpdateState_TH_MPFAO;
-      tdy->ops->get_saturation = TDyGetSaturation_MPFAO;
+      tdy->ops->set_diagnostic_fields = TDySetDiagnosticFields_MPFAO;
+      tdy->ops->compute_diagnostics = TDyComputeDiagnostics_MPFAO;
     } else {
       SETERRQ(comm,PETSC_ERR_USER,
         "The TH mode does not support the selected discretization!");
@@ -1366,8 +1374,8 @@ PetscErrorCode TDyCreateDiagnostics(TDy tdy, DM *diags_dm) {
   ierr = DMClone(tdy->dm, diags_dm); CHKERRQ(ierr);
 
   // Set the layout of the diagnostic fields according to the implementation.
-  ierr = tdy->ops->set_diagnostic_fields(tdy->context, tdy->options,
-                                         *diags_dm); CHKERRQ(ierr);
+  ierr = tdy->ops->set_diagnostic_fields(tdy->context, *diags_dm);
+  CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
 }

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -1358,21 +1358,16 @@ PetscErrorCode TDyCreateDiagnostics(TDy tdy, DM *diags_dm) {
 
   if ((tdy->setup_flags & TDySetupFinished) == 0) {
     SETERRQ(comm,PETSC_ERR_USER,"You must call TDyCreateDiagnostics after TDySetup()");
-  } else if (!tdy->ops->set_diagnostics_section) {
+  } else if (!tdy->ops->set_diagnostic_fields) {
     SETERRQ(comm,PETSC_ERR_USER,"TDyCreateDiagnostics is not supported by this implementation.");
   }
 
   // Clone our own DM (which copies the mesh topology but not its fields).
   ierr = DMClone(tdy->dm, diags_dm); CHKERRQ(ierr);
 
-  // Create a section that holds the layout of the diagnostic fields, and set
-  // it up according to the implementation.
-  PetscSection diags_section;
-  ierr = PetscSectionCreate(comm, &diags_section); CHKERRQ(ierr);
-  ierr = tdy->ops->set_diagnostics_section(tdy->context, tdy->options,
-                                           diags_section); CHKERRQ(ierr);
-  ierr = PetscSectionSetUp(diags_section); CHKERRQ(ierr);
-  ierr = DMSetLocalSection(*diags_dm, diags_section); CHKERRQ(ierr);
+  // Set the layout of the diagnostic fields according to the implementation.
+  ierr = tdy->ops->set_diagnostic_fields(tdy->context, tdy->options,
+                                         *diags_dm); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
 }

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -396,8 +396,6 @@ PetscErrorCode TDyIOSetMode(TDy tdy, TDyIOFormat format){
 PetscErrorCode TDyIOWriteVec(TDy tdy){
   PetscErrorCode ierr;
   PetscBool useNatural;
-  Vec s;
-  PetscReal *s_vec_ptr;
   Vec p = tdy->solution;
   DM dm = tdy->dm;
   PetscReal time = tdy->ti->time;
@@ -408,10 +406,25 @@ PetscErrorCode TDyIOWriteVec(TDy tdy){
     zonalVarNames[i] =  tdy->io->zonalVarNames[i];
   }
 
+  // Create a diagnostics DM that stores computed diagnostics fields for the
+  // dycore.
+  DM diags_dm;
+  ierr = TDyCreateDiagnostics(tdy, &diags_dm); CHKERRQ(ierr);
+
+  // Create a diagnostics vector and compute the diagnostic fields.
+  Vec diags_vec;
+  ierr = DMCreateGlobalVector(diags_dm, &diags_vec); CHKERRQ(ierr);
+  ierr = TDyComputeDiagnostics(tdy, diags_dm, diags_vec); CHKERRQ(ierr);
+
+  // Extract the saturation from the diagnostics vector.
+  Vec s;
   ierr = TDyCreateGlobalVector(tdy, &s); CHKERRQ(ierr);
-  ierr = VecGetArray(s,&s_vec_ptr); CHKERRQ(ierr);
-  ierr = TDyGetSaturation(tdy, s_vec_ptr); CHKERRQ(ierr);
-  ierr = VecRestoreArray(s,&s_vec_ptr);CHKERRQ(ierr);
+  ierr = VecStrideGather(diags_vec, DIAG_SATURATION, s, INSERT_VALUES);
+  CHKERRQ(ierr);
+
+  // Clean up.
+  ierr = VecDestroy(&diags_vec);
+  ierr = DMDestroy(&diags_dm);
 
   if (tdy->io->format == PetscViewerASCIIFormat) {
     ierr = TDyIOWriteAsciiViewer(p,time,zonalVarNames[0]);CHKERRQ(ierr);

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -480,7 +480,7 @@ PetscErrorCode TDyIOWriteHDF5Var(char *ofilename,DM dm,Vec U,char *VariableName,
   ierr = PetscViewerHDF5Open(PETSC_COMM_WORLD,ofilename,FILE_MODE_APPEND,&viewer);CHKERRQ(ierr);
 
   ierr = PetscObjectSetName((PetscObject) U,word);CHKERRQ(ierr);
-  ierr = DMGetSection(dm, &sec);
+  ierr = DMGetLocalSection(dm, &sec);
   //Change to field name
   ierr = PetscSectionSetFieldName(sec, 0, VariableName); CHKERRQ(ierr);
   ierr = VecView(U,viewer);CHKERRQ(ierr);

--- a/src/tdyregression.c
+++ b/src/tdyregression.c
@@ -165,7 +165,7 @@ PetscErrorCode TDyRegressionOutput(TDy tdy, Vec U) {
 
   PetscSection sec;
   PetscInt num_fields;
-  ierr = DMGetSection(dm,&sec); CHKERRQ(ierr);
+  ierr = DMGetLocalSection(dm,&sec); CHKERRQ(ierr);
   ierr = PetscSectionGetNumFields(sec,&num_fields); CHKERRQ(ierr);
 
   PetscReal *temp_p, *pres_p, *u_p;


### PR DESCRIPTION
This PR implements the solution to obtaining "diagnostic" fields computed from the solution vector, as discussed in #217. These functions are part of the TDycore interface and have their own implementation-specific function pointers. Currently, they are only implemented for the MPFA-O method.

See `demo/transient/transient_snes_mpfaof90.F90` for how these functions are used in practice.

Fixes #217 