### PR TITLE
Plugged a bunch of memory leaks.

### DIFF
--- a/include/private/tdyregressionimpl.h
+++ b/include/private/tdyregressionimpl.h
@@ -14,5 +14,6 @@ typedef struct {
 
 PETSC_INTERN PetscErrorCode TDyRegressionInitialize(TDy);
 PETSC_INTERN PetscErrorCode TDyRegressionOutput(TDy,Vec);
+PETSC_INTERN PetscErrorCode TDyRegressionDestroy(TDy);
 
 #endif

--- a/src/materials/tdymaterialproperties.c
+++ b/src/materials/tdymaterialproperties.c
@@ -29,7 +29,7 @@ PetscErrorCode MaterialPropDestroy(MaterialProp *matprop) {
   MaterialPropSetResidualSaturation(matprop, NULL, NULL, NULL);
   MaterialPropSetSoilDensity(matprop, NULL, NULL, NULL);
   MaterialPropSetSoilSpecificHeat(matprop, NULL, NULL, NULL);
-
+  PetscFree(matprop);
   PetscFunctionReturn(0);
 }
 

--- a/src/mpfao/tdymesh.c
+++ b/src/mpfao/tdymesh.c
@@ -4216,7 +4216,104 @@ PetscErrorCode TDyMeshCreate(DM dm, PetscReal *volumes, PetscReal *coords,
 /// Destroy a mesh, freeing any resources it uses.
 /// @param [inout] mesh A mesh instance to be destroyed
 PetscErrorCode TDyMeshDestroy(TDyMesh *mesh) {
+  PetscErrorCode ierr;
   PetscFunctionBegin;
+
+  free(mesh->cells.id);
+  free(mesh->cells.global_id);
+  free(mesh->cells.natural_id);
+  free(mesh->cells.is_local);
+  free(mesh->cells.num_vertices);
+  free(mesh->cells.num_edges);
+  free(mesh->cells.num_faces);
+  free(mesh->cells.num_neighbors);
+  free(mesh->cells.num_subcells);
+  free(mesh->cells.vertex_offset);
+  free(mesh->cells.edge_offset);
+  free(mesh->cells.face_offset);
+  free(mesh->cells.neighbor_offset);
+  free(mesh->cells.vertex_ids);
+  free(mesh->cells.edge_ids);
+  free(mesh->cells.neighbor_ids);
+  free(mesh->cells.face_ids);
+  free(mesh->cells.centroid);
+  free(mesh->cells.volume);
+
+  free(mesh->subcells.nu_vector);
+  free(mesh->subcells.nu_star_vector);
+  free(mesh->subcells.variable_continuity_coordinates);
+  free(mesh->subcells.face_centroid);
+  free(mesh->subcells.vertices_coordinates);
+  free(mesh->subcells.id);
+  free(mesh->subcells.num_nu_vectors);
+  free(mesh->subcells.num_vertices);
+  free(mesh->subcells.num_faces);
+  free(mesh->subcells.type);
+  free(mesh->subcells.nu_vector_offset);
+  free(mesh->subcells.vertex_offset);
+  free(mesh->subcells.face_offset);
+  free(mesh->subcells.face_ids);
+  free(mesh->subcells.is_face_up);
+  free(mesh->subcells.face_unknown_idx);
+  free(mesh->subcells.face_flux_idx);
+  free(mesh->subcells.face_area);
+  free(mesh->subcells.vertex_ids);
+  free(mesh->subcells.T);
+
+  free(mesh->vertices.id);
+  free(mesh->vertices.global_id);
+  free(mesh->vertices.num_internal_cells);
+  free(mesh->vertices.num_edges);
+  free(mesh->vertices.num_faces);
+  free(mesh->vertices.num_boundary_faces);
+  free(mesh->vertices.is_local);
+  free(mesh->vertices.coordinate);
+  free(mesh->vertices.edge_offset);
+  free(mesh->vertices.face_offset);
+  free(mesh->vertices.internal_cell_offset);
+  free(mesh->vertices.subcell_offset);
+  free(mesh->vertices.boundary_face_offset);
+  free(mesh->vertices.edge_ids);
+  free(mesh->vertices.face_ids);
+  free(mesh->vertices.subface_ids);
+  free(mesh->vertices.internal_cell_ids);
+  free(mesh->vertices.subcell_ids);
+  free(mesh->vertices.boundary_face_ids);
+
+  free(mesh->edges.id);
+  free(mesh->edges.global_id);
+  free(mesh->edges.num_cells);
+  free(mesh->edges.vertex_ids);
+  free(mesh->edges.is_local);
+  free(mesh->edges.is_internal);
+  free(mesh->edges.cell_offset);
+  free(mesh->edges.cell_ids);
+  free(mesh->edges.centroid);
+  free(mesh->edges.normal);
+  free(mesh->edges.length);
+
+  free(mesh->faces.id);
+  free(mesh->faces.num_vertices);
+  free(mesh->faces.num_edges);
+  free(mesh->faces.num_cells);
+  free(mesh->faces.is_local);
+  free(mesh->faces.is_internal);
+  free(mesh->faces.vertex_offset);
+  free(mesh->faces.cell_offset);
+  free(mesh->faces.edge_offset);
+  free(mesh->faces.cell_ids);
+  free(mesh->faces.edge_ids);
+  free(mesh->faces.vertex_ids);
+  free(mesh->faces.area);
+  free(mesh->faces.centroid);
+  free(mesh->faces.normal);
+
+  free(mesh->closureSize);
+  ierr = TDyDeallocate_IntegerArray_2D(mesh->closure,
+            mesh->num_cells+mesh->num_faces+mesh->num_edges+mesh->num_vertices);
+  CHKERRQ(ierr);
+
+  free(mesh);
   PetscFunctionReturn(0);
 }
 

--- a/src/mpfao/tdympfao_th_ts.c
+++ b/src/mpfao/tdympfao_th_ts.c
@@ -153,7 +153,7 @@ PetscErrorCode TDyMPFAOIFunction_TH(TS ts,PetscReal t,Vec U,Vec U_t,Vec R,void *
   TDyCell       *cells = &mesh->cells;
   DM       dm;
   Vec      Ul;
-  PetscReal *p,*du_dt,*r,*temp,*u_p,*dp_dt,*dtemp_dt;
+  PetscReal *du_dt,*r,*u_p;
   PetscErrorCode ierr;
 
   PetscFunctionBegin;
@@ -217,11 +217,9 @@ PetscErrorCode TDyMPFAOIFunction_TH(TS ts,PetscReal t,Vec U,Vec U_t,Vec R,void *
 
   PetscInt c,cStart,cEnd;
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dtemp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&p);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&temp);CHKERRQ(ierr);
 
+  PetscReal p[cEnd-cStart], dp_dt[cEnd-cStart],
+            temp[cEnd-cStart], dtemp_dt[cEnd-cStart];
   ierr = VecGetArray(Ul,&u_p); CHKERRQ(ierr);
   for (c=0;c<cEnd-cStart;c++) {
     dp_dt[c]    = du_dt[c*2];
@@ -587,7 +585,7 @@ PetscErrorCode TDyMPFAOIJacobian_Accumulation_TH(Vec Ul,Vec Udotl,PetscReal shif
   TDyMesh       *mesh = mpfao->mesh;
   TDyCell       *cells = &mesh->cells;
   PetscInt icell;
-  PetscReal *dp_dt, *dT_dt, *du_dt, *temp, *u_p;
+  PetscReal *du_dt, *u_p;
   PetscErrorCode ierr;
 
   PetscReal porosity, dporosity_dP, dporosity_dT;
@@ -616,10 +614,8 @@ PetscErrorCode TDyMPFAOIJacobian_Accumulation_TH(Vec Ul,Vec Udotl,PetscReal shif
 
   PetscInt c,cStart,cEnd;
   ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dp_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&dT_dt);CHKERRQ(ierr);
-  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&temp);CHKERRQ(ierr);
 
+  PetscReal dp_dt[cEnd-cStart], dT_dt[cEnd-cStart], temp[cEnd-cStart];
   for (c=0;c<cEnd-cStart;c++) {
     dp_dt[c] = du_dt[c*2];
     dT_dt[c] = du_dt[c*2+1];

--- a/src/tdyconditions.c
+++ b/src/tdyconditions.c
@@ -18,6 +18,7 @@ PetscErrorCode ConditionsDestroy(Conditions* conditions) {
   ConditionsSetBoundaryPressure(conditions, NULL, NULL, NULL);
   ConditionsSetBoundaryTemperature(conditions, NULL, NULL, NULL);
   ConditionsSetBoundaryVelocity(conditions, NULL, NULL, NULL);
+  PetscFree(conditions);
   PetscFunctionReturn(0);
 }
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -346,7 +346,7 @@ PetscErrorCode TDyDestroy(TDy *_tdy) {
   if (!tdy) PetscFunctionReturn(0);
 
   if (tdy->regression) {
-    free(tdy->regression);
+    ierr = TDyRegressionDestroy(tdy);
   }
 
   // Destroy Jacobian data.
@@ -643,7 +643,7 @@ PetscErrorCode TDySetFromOptions(TDy tdy) {
     DM dm_dist;
     ierr = DMPlexDistribute(dm, 1, NULL, &dm_dist); CHKERRQ(ierr);
     if (dm_dist) {
-      DMDestroy(&dm); CHKERRQ(ierr);
+      ierr = DMDestroy(&dm); CHKERRQ(ierr);
       dm = dm_dist;
     }
     ierr = DMSetFromOptions(dm); CHKERRQ(ierr);
@@ -729,6 +729,7 @@ PetscErrorCode TDySetup(TDy tdy) {
     ierr = PetscSectionSetFieldName(section, DIAG_LIQUID_MASS, "LiquidMass");
     CHKERRQ(ierr);
     ierr = DMSetLocalSection(tdy->diag_dm, section); CHKERRQ(ierr);
+    ierr = PetscSectionDestroy(&section);
 
     // Create a Vec that can store the diagnostic fields.
     ierr = DMCreateGlobalVector(tdy->diag_dm, &tdy->diag_vec); CHKERRQ(ierr);

--- a/src/tdyregression.c
+++ b/src/tdyregression.c
@@ -269,3 +269,17 @@ PetscErrorCode TDyRegressionOutput(TDy tdy, Vec U) {
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);
 }
+
+PetscErrorCode TDyRegressionDestroy(TDy tdy) {
+  PetscFunctionBegin;
+  PetscErrorCode ierr;
+  ierr = VecScatterDestroy(&tdy->regression->scatter_cells_per_process_gtos); CHKERRQ(ierr);
+  ierr = VecDestroy(&tdy->regression->cells_per_process_vec); CHKERRQ(ierr);
+  int myrank;
+  MPI_Comm_rank(PetscObjectComm((PetscObject)tdy->dm),&myrank);
+  if (myrank == 0) {
+    ierr = PetscFree(tdy->regression->cells_per_process_natural_ids); CHKERRQ(ierr);
+  }
+  free(tdy->regression);
+  PetscFunctionReturn(0);
+}


### PR DESCRIPTION
I ran Valgrind on the dycore and saw quite a large number of reported leaks. Some leaks come from before our big refactor, and some were introduced by it!

This PR fixes all of the leaks except for one, which is related to the dycore's primary DM. I'm not sure what's going on with it at the moment, but I'd rather get these other fixes in now.

We can probably continue to improve our organization (and slim the FV mesh down a bit--it's got a lot of things at the moment), but this at least gives us a cleaner report from Valgrind.