### PR TITLE
Devised a new interface for allocating/freeing memory

### DIFF
--- a/include/private/tdyconditionsimpl.h
+++ b/include/private/tdyconditionsimpl.h
@@ -34,12 +34,12 @@ typedef struct Conditions {
   PetscErrorCode (*compute_boundary_velocity)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Context destructors.
-  void (*forcing_dtor)(void*);
-  void (*energy_forcing_dtor)(void*);
-  void (*boundary_pressure_dtor)(void*);
-  void (*boundary_pressure_type_dtor)(void*);
-  void (*boundary_temperature_dtor)(void*);
-  void (*boundary_velocity_dtor)(void*);
+  PetscErrorCode (*forcing_dtor)(void*);
+  PetscErrorCode (*energy_forcing_dtor)(void*);
+  PetscErrorCode (*boundary_pressure_dtor)(void*);
+  PetscErrorCode (*boundary_pressure_type_dtor)(void*);
+  PetscErrorCode (*boundary_temperature_dtor)(void*);
+  PetscErrorCode (*boundary_velocity_dtor)(void*);
 } Conditions;
 
 // conditions creation/destruction
@@ -47,12 +47,12 @@ PETSC_INTERN PetscErrorCode ConditionsCreate(Conditions**);
 PETSC_INTERN PetscErrorCode ConditionsDestroy(Conditions*);
 
 // conditions setup functions
-PETSC_INTERN PetscErrorCode ConditionsSetForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), void (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetEnergyForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), void (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressure(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), void (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressureType(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscInt*), void (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , void (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundaryVelocity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), void (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetEnergyForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressure(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressureType(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscInt*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundaryVelocity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 
 // conditions query functions
 PETSC_INTERN PetscBool ConditionsHasForcing(Conditions*);

--- a/include/private/tdymaterialpropertiesimpl.h
+++ b/include/private/tdymaterialpropertiesimpl.h
@@ -28,12 +28,12 @@ typedef struct {
   PetscErrorCode (*compute_soil_specific_heat)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Material property context destructors.
-  void (*porosity_dtor)(void*);
-  void (*permeability_dtor)(void*);
-  void (*thermal_conductivity_dtor)(void*);
-  void (*residual_saturation_dtor)(void*);
-  void (*soil_density_dtor)(void*);
-  void (*soil_specific_heat_dtor)(void*);
+  PetscErrorCode (*porosity_dtor)(void*);
+  PetscErrorCode (*permeability_dtor)(void*);
+  PetscErrorCode (*thermal_conductivity_dtor)(void*);
+  PetscErrorCode (*residual_saturation_dtor)(void*);
+  PetscErrorCode (*soil_density_dtor)(void*);
+  PetscErrorCode (*soil_specific_heat_dtor)(void*);
 
 } MaterialProp;
 
@@ -42,12 +42,12 @@ PETSC_INTERN PetscErrorCode MaterialPropCreate(PetscInt,MaterialProp**);
 PETSC_INTERN PetscErrorCode MaterialPropDestroy(MaterialProp*);
 
 // material model setup functions
-PETSC_INTERN PetscErrorCode MaterialPropSetPorosity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
-PETSC_INTERN PetscErrorCode MaterialPropSetPermeability(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
-PETSC_INTERN PetscErrorCode MaterialPropSetThermalConductivity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
-PETSC_INTERN PetscErrorCode MaterialPropSetResidualSaturation(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
-PETSC_INTERN PetscErrorCode MaterialPropSetSoilDensity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
-PETSC_INTERN PetscErrorCode MaterialPropSetSoilSpecificHeat(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),void(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetPorosity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetPermeability(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetThermalConductivity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetResidualSaturation(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetSoilDensity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetSoilSpecificHeat(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
 
 // material model query functions
 PETSC_INTERN PetscBool MaterialPropHasPorosity(MaterialProp*);

--- a/include/private/tdymemoryimpl.h
+++ b/include/private/tdymemoryimpl.h
@@ -4,6 +4,87 @@
 #include <petsc.h>
 #include <private/tdymeshimpl.h>
 
+PETSC_INTERN PetscErrorCode TDyAlloc(size_t,void**);
+PETSC_INTERN PetscErrorCode TDyFree(void*);
+PETSC_INTERN PetscErrorCode TDySetIntArray(size_t,PetscInt[],PetscInt);
+PETSC_INTERN PetscErrorCode TDySetRealArray(size_t,PetscReal[],PetscReal);
+
+/// @def TDY_DECLARE_2D_ARRAY
+/// Declares a 2D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's first component
+#define TDY_DECLARE_2D_ARRAY(type, array_var, storage, dim1, dim2) \
+type (*array_var)[dim2] = (void*)storage
+
+/// @def TDY_DECLARE_3D_ARRAY
+/// Declares a 3D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var.
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's second component
+/// @param dim3 The dimension of the array's third component
+#define TDY_DECLARE_3D_ARRAY(type, array_var, storage, dim1, dim2, dim3) \
+type (*array_var)[dim2][dim3] = (void*)storage
+
+/// @def TDY_DECLARE_4D_ARRAY
+/// Declares a 4D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's second component
+/// @param dim3 The dimension of the array's third component
+/// @param dim4 The dimension of the array's fourth component
+#define TDY_DECLARE_4D_ARRAY(type, array_var, storage, dim1, dim2, dim3, dim4) \
+type (*array_var)[dim2][dim3][dim4] = (void*)storage
+
+/// @def TDY_DECLARE_5D_ARRAY
+/// Declares a 5D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's second component
+/// @param dim3 The dimension of the array's third component
+/// @param dim4 The dimension of the array's fourth component
+/// @param dim5 The dimension of the array's fifth component
+#define TDY_DECLARE_5D_ARRAY(type, array_var, storage, dim1, dim2, dim3, dim4, dim5) \
+type (*array_var)[dim2][dim3][dim4][dim5] = (void*)storage
+
+/// @def TDY_DECLARE_6D_ARRAY
+/// Declares a 6D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's second component
+/// @param dim3 The dimension of the array's third component
+/// @param dim4 The dimension of the array's fourth component
+/// @param dim5 The dimension of the array's fifth component
+/// @param dim6 The dimension of the array's sixth component
+#define TDY_DECLARE_6D_ARRAY(type, array_var, storage, dim1, dim2, dim3, dim4, dim5, dim6) \
+type (*array_var)[dim2][dim3][dim4][dim5][dim6] = (void*)storage
+
+/// @def TDY_DECLARE_7D_ARRAY
+/// Declares a 7D array variable that uses specified storage
+/// @param type The (primitive) data type of the array
+/// @param array_var The declared multidimensional array
+/// @param storage A "flat" array with enough room to fit all the data in array_var
+/// @param dim1 The dimension of the array's first component
+/// @param dim2 The dimension of the array's second component
+/// @param dim3 The dimension of the array's third component
+/// @param dim4 The dimension of the array's fourth component
+/// @param dim5 The dimension of the array's fifth component
+/// @param dim6 The dimension of the array's sixth component
+/// @param dim7 The dimension of the array's seventh component
+#define TDY_DECLARE_7D_ARRAY(type, array_var, storage, dim1, dim2, dim3, dim4, dim5, dim6, dim7) \
+type (*array_var)[dim2][dim3][dim4][dim5][dim6][dim7] = (void*)storage
+
+// These functions will be removed in the future.
 PETSC_INTERN PetscErrorCode TDyInitialize_IntegerArray_1D(PetscInt*,PetscInt,PetscInt);
 PETSC_INTERN PetscErrorCode TDyInitialize_IntegerArray_2D(PetscInt**,PetscInt,PetscInt,PetscInt);
 PETSC_INTERN PetscErrorCode TDyInitialize_RealArray_1D(PetscReal*,PetscInt,PetscReal);

--- a/include/private/tdymemoryimpl.h
+++ b/include/private/tdymemoryimpl.h
@@ -4,7 +4,17 @@
 #include <petsc.h>
 #include <private/tdymeshimpl.h>
 
-PETSC_INTERN PetscErrorCode TDyAlloc(size_t,void**);
+/// @def TDyAlloc
+/// Allocates a chunk of zeroed memory of the given size (in bytes).
+/// @param [in] size The size of the requested allocation.
+/// @param [out] result A pointer to the requested memory chunk.
+#define TDyAlloc(size,result) PetscCalloc1(size,result)
+
+/// @def TDyRealloc
+/// Resizes the given chunk of memory to the new requested size.
+/// @param [in] size The size of the requested allocation.
+/// @param [inout] memory A pointer to a previously allocated memory chunk.
+#define TDyRealloc(size,memory) PetscRealloc(size,memory)
 PETSC_INTERN PetscErrorCode TDyFree(void*);
 PETSC_INTERN PetscErrorCode TDySetIntArray(size_t,PetscInt[],PetscInt);
 PETSC_INTERN PetscErrorCode TDySetRealArray(size_t,PetscReal[],PetscReal);

--- a/src/f90-mod/tdycoref.c
+++ b/src/f90-mod/tdycoref.c
@@ -4,6 +4,7 @@
 #include <tdycore.h>
 #include <private/tdycoreimpl.h>
 #include <private/tdymaterialpropertiesimpl.h>
+#include <private/tdymemoryimpl.h>
 #include <petsc/private/f90impl.h>
 
 #define PetscToPointer(a) (*(PetscFortranAddr *)(a))
@@ -373,11 +374,6 @@ static PetscErrorCode WrappedF90DiagonalTensorFunction(void *context, PetscInt n
   PetscFunctionReturn(0);
 }
 
-// Generic destructor for contexts that wrap F90 functions.
-static void DestroyContext(void* context) {
-  PetscFree(context);
-}
-
 //------------------------------------------------------------------------
 //                  Material properties and conditions
 //------------------------------------------------------------------------
@@ -392,7 +388,7 @@ PETSC_EXTERN PetscErrorCode f90_fn(TDy tdy, PetscInt id) { \
   ierr = DMGetDimension(((tdy->discretization)->tdydm)->dm, &dim); CHKERRQ(ierr); \
   void *context; \
   ierr = CreateF90SpatialFunctionContext(dim, id, &context); CHKERRQ(ierr); \
-  ierr = matprop_fn(tdy->matprop, context, wrapper_fn, DestroyContext); \
+  ierr = matprop_fn(tdy->matprop, context, wrapper_fn, TDyFree); \
   CHKERRQ(ierr); \
   PetscFunctionReturn(0); \
 } \
@@ -421,7 +417,7 @@ PETSC_EXTERN PetscErrorCode f90_fn(TDy tdy, PetscInt id) { \
   ierr = DMGetDimension(((tdy->discretization)->tdydm)->dm, &dim); CHKERRQ(ierr); \
   void *context; \
   ierr = CreateF90SpatialFunctionContext(dim, id, &context); CHKERRQ(ierr); \
-  ierr = condition_fn(tdy->conditions, context, wrapper_fn, DestroyContext); \
+  ierr = condition_fn(tdy->conditions, context, wrapper_fn, TDyFree); \
   CHKERRQ(ierr); \
   PetscFunctionReturn(0); \
 } \
@@ -434,7 +430,7 @@ PETSC_EXTERN PetscErrorCode f90_fn(TDy tdy, PetscInt id) { \
   ierr = DMGetDimension(((tdy->discretization)->tdydm)->dm, &dim); CHKERRQ(ierr); \
   void *context; \
   ierr = CreateF90IntegerSpatialFunctionContext(dim, id, &context); CHKERRQ(ierr); \
-  ierr = condition_fn(tdy->conditions, context, wrapper_fn, DestroyContext); \
+  ierr = condition_fn(tdy->conditions, context, wrapper_fn, TDyFree); \
   CHKERRQ(ierr); \
   PetscFunctionReturn(0); \
 } \

--- a/src/f90-mod/tdycoref.c
+++ b/src/f90-mod/tdycoref.c
@@ -295,7 +295,7 @@ static PetscErrorCode CreateF90SpatialFunctionContext(PetscInt dim,
   PetscErrorCode ierr;
   PetscFunctionBegin;
   F90SpatialFunctionWrapper *wrapper;
-  ierr = PetscMalloc(sizeof(F90SpatialFunctionWrapper), &wrapper); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(F90SpatialFunctionWrapper), &wrapper); CHKERRQ(ierr);
   wrapper->dim = dim;
   wrapper->id = id;
   *context = wrapper;
@@ -309,7 +309,7 @@ static PetscErrorCode CreateF90IntegerSpatialFunctionContext(PetscInt dim,
   PetscErrorCode ierr;
   PetscFunctionBegin;
   F90IntegerSpatialFunctionWrapper *wrapper;
-  ierr = PetscMalloc(sizeof(F90IntegerSpatialFunctionWrapper), &wrapper); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(F90IntegerSpatialFunctionWrapper), &wrapper); CHKERRQ(ierr);
   wrapper->dim = dim;
   wrapper->id = id;
   *context = wrapper;

--- a/src/fe/tdyfe.c
+++ b/src/fe/tdyfe.c
@@ -1,4 +1,5 @@
-#include "private/tdyfeimpl.h"
+#include <private/tdyfeimpl.h>
+#include <private/tdymemoryimpl.h>
 #include <tdytimers.h>
 
 const char *const TDyQuadratureTypes[] = {
@@ -26,7 +27,7 @@ PetscErrorCode CreateCellVertexMap(DM dm, PetscInt nv, PetscReal *X, PetscInt **
   ierr = SetQuadrature(quad,dim); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum(dm,0,&vStart,&vEnd); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc(nv*(cEnd-cStart)*sizeof(PetscInt),map); CHKERRQ(ierr);
+  ierr = TDyAlloc(nv*(cEnd-cStart)*sizeof(PetscInt),map); CHKERRQ(ierr);
 #if defined(PETSC_USE_DEBUG)
   for(c=0; c<nv*(cEnd-cStart); c++) { (*map)[c] = -1; }
 #endif
@@ -100,7 +101,7 @@ PetscErrorCode CreateCellVertexDirFaceMap(DM dm, PetscInt nv, PetscReal *X,
   }
   ierr = DMPlexGetHeightStratum(dm,1,&fStart,&fEnd); CHKERRQ(ierr);
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc(dim*nv*(cEnd-cStart)*sizeof(PetscInt),map); CHKERRQ(ierr);
+  ierr = TDyAlloc(dim*nv*(cEnd-cStart)*sizeof(PetscInt),map); CHKERRQ(ierr);
 #if defined(PETSC_USE_DEBUG)
   for(c=0; c<dim*nv*(cEnd-cStart); c++) { (*map)[c] = 0; }
 #endif
@@ -155,8 +156,8 @@ PetscErrorCode SetQuadrature(PetscQuadrature q,PetscInt dim) {
   PetscReal *x,*w;
   PetscInt d,nv=1;
   for(d=0; d<dim; d++) nv *= 2;
-  ierr = PetscMalloc1(nv*dim,&x); CHKERRQ(ierr);
-  ierr = PetscMalloc1(nv,&w); CHKERRQ(ierr);
+  ierr = TDyAlloc(nv*dim,&x); CHKERRQ(ierr);
+  ierr = TDyAlloc(nv,&w); CHKERRQ(ierr);
   switch(nv*dim) {
   case 2: /* line */
     x[0] = -1.0; w[0] = 1.0;

--- a/src/fv/fvtpf/tdyfvtpf.c
+++ b/src/fv/fvtpf/tdyfvtpf.c
@@ -17,7 +17,7 @@ PetscErrorCode TDyCreate_FVTPF(void **context) {
 
   // Allocate a new context for the FV-TPF method.
   TDyFVTPF* fvtpf;
-  ierr = PetscCalloc(sizeof(TDyFVTPF), &fvtpf); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(TDyFVTPF), &fvtpf); CHKERRQ(ierr);
   *context = fvtpf;
 
   // Initialize defaults and data.
@@ -34,20 +34,20 @@ PetscErrorCode TDyDestroy_FVTPF(void *context) {
   PetscFunctionBegin;
   TDyFVTPF* fvtpf = context;
 
-  if (fvtpf->vel   ) { ierr = PetscFree(fvtpf->vel); CHKERRQ(ierr); }
+  if (fvtpf->vel   ) { ierr = TDyFree(fvtpf->vel); CHKERRQ(ierr); }
 
-  ierr = PetscFree(fvtpf->V); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->X); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->N); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->rho); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->d2rho_dP2); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->vis); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->dvis_dP); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->d2vis_dP2); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->h); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->dh_dP); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->dh_dT); CHKERRQ(ierr);
-  ierr = PetscFree(fvtpf->dvis_dT); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->V); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->X); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->N); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->rho); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->d2rho_dP2); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->vis); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->dvis_dP); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->d2vis_dP2); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->h); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->dh_dP); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->dh_dT); CHKERRQ(ierr);
+  ierr = TDyFree(fvtpf->dvis_dT); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
 }
@@ -160,52 +160,51 @@ static PetscErrorCode InitMaterials(TDyFVTPF *fvtpf,
   PetscErrorCode ierr;
   PetscFunctionBegin;
 
-  // Allocate storage for material data and characteristic curves, and set to
-  // zero using PetscCalloc instead of PetscMalloc.
+  // Allocate storage for material data and characteristic curves.
   PetscInt nc = (fvtpf->mesh)->num_cells;
 
   // Material properties
-  ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(fvtpf->K)); CHKERRQ(ierr);
-  ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(fvtpf->K0)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->porosity)); CHKERRQ(ierr);
+  ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(fvtpf->K)); CHKERRQ(ierr);
+  ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(fvtpf->K0)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->porosity)); CHKERRQ(ierr);
   if (MaterialPropHasThermalConductivity(matprop)) {
-    ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(fvtpf->Kappa)); CHKERRQ(ierr);
-    ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(fvtpf->Kappa0)); CHKERRQ(ierr);
+    ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(fvtpf->Kappa)); CHKERRQ(ierr);
+    ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(fvtpf->Kappa0)); CHKERRQ(ierr);
   }
   if (MaterialPropHasSoilSpecificHeat(matprop)) {
-    ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->c_soil)); CHKERRQ(ierr);
+    ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->c_soil)); CHKERRQ(ierr);
   }
   if (MaterialPropHasSoilDensity(matprop)) {
-    ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->rho_soil)); CHKERRQ(ierr);
+    ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->rho_soil)); CHKERRQ(ierr);
   }
 
   // Characteristic curve values
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->Kr)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dKr_dS)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->S)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dS_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->d2S_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dS_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->Sr)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->Kr)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dKr_dS)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->S)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dS_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->d2S_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dS_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->Sr)); CHKERRQ(ierr);
 
   // 
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->pressure)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->pressure)); CHKERRQ(ierr);
 
   // Water properties
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->rho)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->drho_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->d2rho_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->vis)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dvis_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->d2vis_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->h)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dh_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dh_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->drho_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->u)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->du_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->du_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(fvtpf->dvis_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->rho)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->drho_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->d2rho_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->vis)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dvis_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->d2vis_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->h)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dh_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dh_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->drho_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->u)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->du_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->du_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(fvtpf->dvis_dT)); CHKERRQ(ierr);
 
   // Initialize characteristic curve parameters on all cells.
   PetscInt points[nc];
@@ -286,14 +285,14 @@ static PetscErrorCode AllocateMemoryForBoundaryValues(TDyFVTPF *fvtpf,
 
   nbnd_faces = mesh->num_boundary_faces;
 
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->Kr_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->dKr_dS_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->S_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->dS_dP_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->d2S_dP2_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->P_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->rho_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->vis_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->Kr_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->dKr_dS_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->S_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->dS_dP_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->d2S_dP2_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->P_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->rho_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->vis_bnd)); CHKERRQ(ierr);
 
   PetscInt i;
   PetscReal dden_dP, d2den_dP2, dmu_dP, d2mu_dP2;
@@ -317,7 +316,7 @@ static PetscErrorCode AllocateMemoryForSourceSinkValues(TDyFVTPF *fvtpf) {
 
   ncells = mesh->num_cells;
 
-  ierr = PetscMalloc(ncells*sizeof(PetscReal),&(fvtpf->source_sink)); CHKERRQ(ierr);
+  ierr = TDyAlloc(ncells*sizeof(PetscReal),&(fvtpf->source_sink)); CHKERRQ(ierr);
 
   PetscInt i;
   for (i=0;i<ncells;i++) fvtpf->source_sink[i] = 0.0;

--- a/src/fv/fvtpf/tdyfvtpf_snes.c
+++ b/src/fv/fvtpf/tdyfvtpf_snes.c
@@ -411,7 +411,7 @@ PetscErrorCode RichardsBCJacobian(TDyFVTPF *fvtpf, DM dm, MaterialProp *matprop,
     PetscReal dphi = fvtpf->P_bnd[cell_id_up] - fvtpf->pressure[cell_id_dn] - gravity_term;
     PetscReal dphi_dp_dn = -1.0 - dgravity_dden_dn * dden_ave_dp_dn;
 
-    PetscReal ukvr;
+    PetscReal ukvr = 0.0;
     PetscReal dukvr_dp_dn = 0.0;
 
     if (dphi >= 0.0) {

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -289,14 +289,14 @@ static PetscErrorCode AllocateMemoryForBoundaryValues(TDyMPFAO *mpfao,
 
   nbnd_faces = mesh->num_boundary_faces;
 
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->Kr_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->dKr_dS_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->S_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->dS_dP_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->d2S_dP2_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->P_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->rho_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->vis_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->Kr_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->dKr_dS_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->S_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->dS_dP_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->d2S_dP2_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->P_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->rho_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->vis_bnd)); CHKERRQ(ierr);
 
   PetscInt i;
   PetscReal dden_dP, d2den_dP2, dmu_dP, d2mu_dP2;
@@ -321,8 +321,8 @@ static PetscErrorCode AllocateMemoryForEnergyBoundaryValues(TDyMPFAO *mpfao,
 
   nbnd_faces = mesh->num_boundary_faces;
 
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->T_bnd)); CHKERRQ(ierr);
-  ierr = PetscMalloc(nbnd_faces*sizeof(PetscReal),&(mpfao->h_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->T_bnd)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(mpfao->h_bnd)); CHKERRQ(ierr);
 
   PetscInt i;
   PetscReal dh_dP, dh_dT;
@@ -346,7 +346,7 @@ static PetscErrorCode AllocateMemoryForSourceSinkValues(TDyMPFAO *mpfao) {
 
   ncells = mesh->num_cells;
 
-  ierr = PetscMalloc(ncells*sizeof(PetscReal),&(mpfao->source_sink)); CHKERRQ(ierr);
+  ierr = TDyAlloc(ncells*sizeof(PetscReal),&(mpfao->source_sink)); CHKERRQ(ierr);
 
   PetscInt i;
   for (i=0;i<ncells;i++) mpfao->source_sink[i] = 0.0;
@@ -366,7 +366,7 @@ static PetscErrorCode AllocateMemoryForEnergySourceSinkValues(TDyMPFAO *mpfao) {
 
   ncells = mesh->num_cells;
 
-  ierr = PetscMalloc(ncells*sizeof(PetscReal),&(mpfao->energy_source_sink)); CHKERRQ(ierr);
+  ierr = TDyAlloc(ncells*sizeof(PetscReal),&(mpfao->energy_source_sink)); CHKERRQ(ierr);
 
   PetscInt i;
   for (i=0;i<ncells;i++) mpfao->energy_source_sink[i] = 0.0;
@@ -403,7 +403,7 @@ PetscErrorCode TDyCreate_MPFAO(void **context) {
 
   // Allocate a new context for the MPFA-O method.
   TDyMPFAO* mpfao;
-  ierr = PetscCalloc(sizeof(TDyMPFAO), &mpfao); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(TDyMPFAO), &mpfao); CHKERRQ(ierr);
   *context = mpfao;
 
   // Initialize defaults and data.
@@ -426,48 +426,48 @@ PetscErrorCode TDyDestroy_MPFAO(void *context) {
   if (mpfao->vel) { ierr = TDyDeallocate_RealArray_1D(mpfao->vel); CHKERRQ(ierr); }
   if (mpfao->vel_count) { ierr = TDyDeallocate_IntegerArray_1D(mpfao->vel_count); CHKERRQ(ierr); }
 
-  if (mpfao->source_sink) { ierr = PetscFree(mpfao->source_sink); CHKERRQ(ierr); }
+  if (mpfao->source_sink) { ierr = TDyFree(mpfao->source_sink); CHKERRQ(ierr); }
   if (mpfao->energy_source_sink) {
-    ierr = PetscFree(mpfao->energy_source_sink); CHKERRQ(ierr);
+    ierr = TDyFree(mpfao->energy_source_sink); CHKERRQ(ierr);
   }
 
-  ierr = PetscFree(mpfao->V); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->X); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->N); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->Kr); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dKr_dS); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->S); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dS_dP); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->d2S_dP2); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dS_dT); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->Sr); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->V); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->X); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->N); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->Kr); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dKr_dS); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->S); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dS_dP); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->d2S_dP2); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dS_dT); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->Sr); CHKERRQ(ierr);
 
-  ierr = PetscFree(mpfao->rho); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->drho_dP); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->d2rho_dP2); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->vis); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dvis_dP); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->d2vis_dP2); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->h); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dh_dP); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dh_dT); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->drho_dT); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->u); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->du_dP); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->du_dT); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dvis_dT); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->rho); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->drho_dP); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->d2rho_dP2); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->vis); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dvis_dP); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->d2vis_dP2); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->h); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dh_dP); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dh_dT); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->drho_dT); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->u); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->du_dP); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->du_dT); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dvis_dT); CHKERRQ(ierr);
 
-  ierr = PetscFree(mpfao->Kr_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dKr_dS_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->S_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->dS_dP_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->d2S_dP2_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->P_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->rho_bnd); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->vis_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->Kr_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dKr_dS_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->S_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->dS_dP_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->d2S_dP2_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->P_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->rho_bnd); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->vis_bnd); CHKERRQ(ierr);
 
-  if (mpfao->T_bnd) { ierr = PetscFree(mpfao->T_bnd); CHKERRQ(ierr); }
-  if (mpfao->h_bnd) { ierr = PetscFree(mpfao->h_bnd); CHKERRQ(ierr); }
+  if (mpfao->T_bnd) { ierr = TDyFree(mpfao->T_bnd); CHKERRQ(ierr); }
+  if (mpfao->h_bnd) { ierr = TDyFree(mpfao->h_bnd); CHKERRQ(ierr); }
 
   // if (mpfao->subc_Gmatrix) { ierr = TDyDeallocate_RealArray_4D(&mpfao->subc_Gmatrix, mpfao->mesh->num_cells,
   //                                   nsubcells, nrow, ncol); CHKERRQ(ierr); }
@@ -501,23 +501,23 @@ PetscErrorCode TDyDestroy_MPFAO(void *context) {
   if (mpfao->Temp_P_vec       ) { ierr = VecDestroy(&mpfao->Temp_P_vec      ); CHKERRQ(ierr); }
   if (mpfao->Temp_TtimesP_vec ) { ierr = VecDestroy(&mpfao->Temp_TtimesP_vec); CHKERRQ(ierr); }
 
-  ierr = PetscFree(mpfao->K); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->K0); CHKERRQ(ierr);
-  ierr = PetscFree(mpfao->porosity); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->K); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->K0); CHKERRQ(ierr);
+  ierr = TDyFree(mpfao->porosity); CHKERRQ(ierr);
   if (mpfao->Kappa) {
-    ierr = PetscFree(mpfao->Kappa); CHKERRQ(ierr);
-    ierr = PetscFree(mpfao->Kappa0); CHKERRQ(ierr);
+    ierr = TDyFree(mpfao->Kappa); CHKERRQ(ierr);
+    ierr = TDyFree(mpfao->Kappa0); CHKERRQ(ierr);
   }
   if (mpfao->c_soil) {
-    ierr = PetscFree(mpfao->c_soil); CHKERRQ(ierr);
+    ierr = TDyFree(mpfao->c_soil); CHKERRQ(ierr);
   }
   if (mpfao->rho_soil) {
-    ierr = PetscFree(mpfao->rho_soil); CHKERRQ(ierr);
+    ierr = TDyFree(mpfao->rho_soil); CHKERRQ(ierr);
   }
 
   ierr = TDyMeshDestroy(mpfao->mesh);
 
-  PetscFree(mpfao);
+  TDyFree(mpfao);
 
   PetscFunctionReturn(0);
 }
@@ -588,51 +588,50 @@ static PetscErrorCode InitMaterials(TDyMPFAO *mpfao,
   MPI_Comm comm;
   ierr = PetscObjectGetComm((PetscObject)dm, &comm); CHKERRQ(ierr);
 
-  // Allocate storage for material data and characteristic curves, and set to
-  // zero using PetscCalloc instead of PetscMalloc.
+  // Allocate storage for material data and characteristic curves.
   PetscInt cStart, cEnd;
   ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
   PetscInt nc = cEnd-cStart;
 
   // Material properties
-  ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(mpfao->K)); CHKERRQ(ierr);
-  ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(mpfao->K0)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->porosity)); CHKERRQ(ierr);
+  ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(mpfao->K)); CHKERRQ(ierr);
+  ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(mpfao->K0)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->porosity)); CHKERRQ(ierr);
   if (MaterialPropHasThermalConductivity(matprop)) {
-    ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(mpfao->Kappa)); CHKERRQ(ierr);
-    ierr = PetscCalloc(9*nc*sizeof(PetscReal),&(mpfao->Kappa0)); CHKERRQ(ierr);
+    ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(mpfao->Kappa)); CHKERRQ(ierr);
+    ierr = TDyAlloc(9*nc*sizeof(PetscReal),&(mpfao->Kappa0)); CHKERRQ(ierr);
   }
   if (MaterialPropHasSoilSpecificHeat(matprop)) {
-    ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->c_soil)); CHKERRQ(ierr);
+    ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->c_soil)); CHKERRQ(ierr);
   }
   if (MaterialPropHasSoilDensity(matprop)) {
-    ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->rho_soil)); CHKERRQ(ierr);
+    ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->rho_soil)); CHKERRQ(ierr);
   }
 
   // Characteristic curve values
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->Kr)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dKr_dS)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->S)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dS_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->d2S_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dS_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->Sr)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->Kr)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dKr_dS)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->S)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dS_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->d2S_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dS_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->Sr)); CHKERRQ(ierr);
 
   // Water properties
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->rho)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->drho_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->d2rho_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->vis)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dvis_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->d2vis_dP2)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->h)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dh_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dh_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->drho_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->u)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->du_dP)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->du_dT)); CHKERRQ(ierr);
-  ierr = PetscCalloc(nc*sizeof(PetscReal),&(mpfao->dvis_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->rho)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->drho_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->d2rho_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->vis)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dvis_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->d2vis_dP2)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->h)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dh_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dh_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->drho_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->u)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->du_dP)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->du_dT)); CHKERRQ(ierr);
+  ierr = TDyAlloc(nc*sizeof(PetscReal),&(mpfao->dvis_dT)); CHKERRQ(ierr);
 
   // Initialize characteristic curve parameters on all cells.
   PetscInt points[nc];
@@ -1416,15 +1415,15 @@ static PetscErrorCode ComputeTransmissibilityMatrix_ForNonCornerVertex(
   ierr = TDyDeallocate_RealArray_2D(Cdn_32, nflux_neu_bc_dn); CHKERRQ(ierr);
   ierr = TDyDeallocate_RealArray_2D(Cdn_33, nflux_neu_bc_dn); CHKERRQ(ierr);
 
-  free(AinvB_1d);
-  free(CupInxIntimesAinvB_1d);
-  free(CupBCxIntimesAinvB_1d);
-  free(CdnBCxIntimesAinvB_1d);
-  free(AINBCxINBC_1d);
-  free(BINBCxCDBC_1d);
-  free(CupINBCxINBC_1d);
-  free(CupDBCxIn_1d);
-  free(CdnDBCxIn_1d);
+  TDyFree(AinvB_1d);
+  TDyFree(CupInxIntimesAinvB_1d);
+  TDyFree(CupBCxIntimesAinvB_1d);
+  TDyFree(CdnBCxIntimesAinvB_1d);
+  TDyFree(AINBCxINBC_1d);
+  TDyFree(BINBCxCDBC_1d);
+  TDyFree(CupINBCxINBC_1d);
+  TDyFree(CupDBCxIn_1d);
+  TDyFree(CdnDBCxIn_1d);
 
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);

--- a/src/fv/mpfao/tdyregion.c
+++ b/src/fv/mpfao/tdyregion.c
@@ -39,7 +39,7 @@ PetscErrorCode TDyRegionAddCells(PetscInt ncells, PetscInt ids[], TDyRegion *reg
 /// @returns 0 on success, or a non-zero error code on failure.
 PetscErrorCode TDyRegionDestroy(TDyRegion *region) {
   if (region->cell_ids != NULL) {
-    return PetscFree(region->cell_ids);
+    return TDyFree(region->cell_ids);
   }
   PetscFunctionReturn(0);
 }

--- a/src/fv/share/tdydm.c
+++ b/src/fv/share/tdydm.c
@@ -1,4 +1,5 @@
 #include <private/tdydmimpl.h>
+#include <private/tdymemoryimpl.h>
 #include <private/tdyugridimpl.h>
 
 /// Allocates memory and intializes a TDyDM struct
@@ -9,7 +10,7 @@ PetscErrorCode TDyDMCreate(TDyDM **tdydm) {
 
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(TDyDM), tdydm); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(TDyDM), tdydm); CHKERRQ(ierr);
 
   ierr = TDyUGDMCreate(&((*tdydm)->ugdm)); CHKERRQ(ierr);
   (*tdydm)->dmtype = PLEX_TYPE;
@@ -28,7 +29,7 @@ PetscErrorCode TDyDMDestroy(TDyDM *tdydm) {
   ierr = DMDestroy(&tdydm->dm); CHKERRQ(ierr);
   ierr = TDyUGDMDestroy(tdydm->ugdm); CHKERRQ(ierr);
 
-  free (tdydm);
+  TDyFree(tdydm);
 
   PetscFunctionReturn(0);
 }

--- a/src/fv/share/tdymesh.c
+++ b/src/fv/share/tdymesh.c
@@ -34,7 +34,7 @@ PetscErrorCode AllocateCells(
   ierr = TDyAllocate_IntegerArray_1D(&cells->global_id,num_cells); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&cells->natural_id,num_cells); CHKERRQ(ierr);
 
-   cells->is_local = (PetscBool *)malloc(num_cells*sizeof(PetscBool));
+  ierr = TDyAlloc(num_cells*sizeof(PetscBool), &cells->is_local); CHKERRQ(ierr);
 
   ierr = TDyAllocate_IntegerArray_1D(&cells->num_vertices,num_cells); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&cells->num_edges,num_cells); CHKERRQ(ierr);
@@ -105,7 +105,8 @@ PetscErrorCode AllocateSubcells(
   ierr = TDyAllocate_IntegerArray_1D(&subcells->num_nu_vectors,num_cells*num_subcells_per_cell          ); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&subcells->num_vertices,num_cells*num_subcells_per_cell          ); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&subcells->num_faces,num_cells*num_subcells_per_cell          ); CHKERRQ(ierr);
-  subcells->type = (TDySubcellType *)malloc(num_cells*num_subcells_per_cell*sizeof(TDySubcellType));
+  ierr = TDyAlloc(num_cells*num_subcells_per_cell*sizeof(TDySubcellType),
+                  &subcells->type); CHKERRQ(ierr);
 
   ierr = TDyAllocate_IntegerArray_1D(&subcells->nu_vector_offset,num_cells*num_subcells_per_cell+1); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&subcells->vertex_offset  ,num_cells*num_subcells_per_cell+1); CHKERRQ(ierr);
@@ -165,7 +166,7 @@ PetscErrorCode AllocateVertices(
   ierr = TDyAllocate_IntegerArray_1D(&vertices->num_faces         ,num_vertices); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&vertices->num_boundary_faces,num_vertices); CHKERRQ(ierr);
 
-  vertices->is_local = (PetscBool *)malloc(num_vertices*sizeof(PetscBool));
+  ierr = TDyAlloc(num_vertices*sizeof(PetscBool), &vertices->is_local); CHKERRQ(ierr);
 
   ierr = TDyAllocate_TDyCoordinate_1D(num_vertices, &vertices->coordinate); CHKERRQ(ierr);
 
@@ -227,8 +228,8 @@ PetscErrorCode AllocateEdges(
   ierr = TDyAllocate_IntegerArray_1D(&edges->num_cells,num_edges); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&edges->vertex_ids,num_edges*2); CHKERRQ(ierr);
 
-  edges->is_local = (PetscBool *)malloc(num_edges*sizeof(PetscBool));
-  edges->is_internal = (PetscBool *)malloc(num_edges*sizeof(PetscBool));
+  ierr = TDyAlloc(num_edges*sizeof(PetscBool), &edges->is_local); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_edges*sizeof(PetscBool), &edges->is_internal); CHKERRQ(ierr);
 
   ierr = TDyAllocate_IntegerArray_1D(&edges->cell_offset,num_edges+1); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&edges->cell_ids,num_edges*num_cells); CHKERRQ(ierr);
@@ -272,8 +273,8 @@ PetscErrorCode AllocateFaces(
   ierr = TDyAllocate_IntegerArray_1D(&faces->num_edges,num_faces); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&faces->num_cells,num_faces); CHKERRQ(ierr);
 
-  faces->is_local = (PetscBool *)malloc(num_faces*sizeof(PetscBool));
-  faces->is_internal = (PetscBool *)malloc(num_faces*sizeof(PetscBool));
+  ierr = TDyAlloc(num_faces*sizeof(PetscBool), &faces->is_local); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_faces*sizeof(PetscBool), &faces->is_internal); CHKERRQ(ierr);
 
   ierr = TDyAllocate_IntegerArray_1D(&faces->vertex_offset,num_faces+1); CHKERRQ(ierr);
   ierr = TDyAllocate_IntegerArray_1D(&faces->cell_offset,num_faces+1); CHKERRQ(ierr);
@@ -809,101 +810,101 @@ PetscErrorCode TDyMeshDestroy(TDyMesh *mesh) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
 
-  free(mesh->cells.id);
-  free(mesh->cells.global_id);
-  free(mesh->cells.natural_id);
-  free(mesh->cells.is_local);
-  free(mesh->cells.num_vertices);
-  free(mesh->cells.num_edges);
-  free(mesh->cells.num_faces);
-  free(mesh->cells.num_neighbors);
-  free(mesh->cells.num_subcells);
-  free(mesh->cells.vertex_offset);
-  free(mesh->cells.edge_offset);
-  free(mesh->cells.face_offset);
-  free(mesh->cells.neighbor_offset);
-  free(mesh->cells.vertex_ids);
-  free(mesh->cells.edge_ids);
-  free(mesh->cells.neighbor_ids);
-  free(mesh->cells.face_ids);
-  free(mesh->cells.centroid);
-  free(mesh->cells.volume);
+  ierr = TDyFree(mesh->cells.id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.global_id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.natural_id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.is_local); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.num_vertices); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.num_edges); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.num_faces); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.num_neighbors); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.num_subcells); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.vertex_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.edge_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.face_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.neighbor_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.vertex_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.edge_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.neighbor_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.face_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.centroid); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->cells.volume); CHKERRQ(ierr);
 
-  free(mesh->subcells.nu_vector);
-  free(mesh->subcells.nu_star_vector);
-  free(mesh->subcells.variable_continuity_coordinates);
-  free(mesh->subcells.face_centroid);
-  free(mesh->subcells.vertices_coordinates);
-  free(mesh->subcells.id);
-  free(mesh->subcells.num_nu_vectors);
-  free(mesh->subcells.num_vertices);
-  free(mesh->subcells.num_faces);
-  free(mesh->subcells.type);
-  free(mesh->subcells.nu_vector_offset);
-  free(mesh->subcells.vertex_offset);
-  free(mesh->subcells.face_offset);
-  free(mesh->subcells.face_ids);
-  free(mesh->subcells.is_face_up);
-  free(mesh->subcells.face_unknown_idx);
-  free(mesh->subcells.face_flux_idx);
-  free(mesh->subcells.face_area);
-  free(mesh->subcells.vertex_ids);
-  free(mesh->subcells.T);
+  ierr = TDyFree(mesh->subcells.nu_vector); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.nu_star_vector); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.variable_continuity_coordinates); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_centroid); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.vertices_coordinates); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.num_nu_vectors); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.num_vertices); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.num_faces); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.type); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.nu_vector_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.vertex_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.is_face_up); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_unknown_idx); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_flux_idx); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.face_area); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.vertex_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->subcells.T); CHKERRQ(ierr);
 
-  free(mesh->vertices.id);
-  free(mesh->vertices.global_id);
-  free(mesh->vertices.num_internal_cells);
-  free(mesh->vertices.num_edges);
-  free(mesh->vertices.num_faces);
-  free(mesh->vertices.num_boundary_faces);
-  free(mesh->vertices.is_local);
-  free(mesh->vertices.coordinate);
-  free(mesh->vertices.edge_offset);
-  free(mesh->vertices.face_offset);
-  free(mesh->vertices.internal_cell_offset);
-  free(mesh->vertices.subcell_offset);
-  free(mesh->vertices.boundary_face_offset);
-  free(mesh->vertices.edge_ids);
-  free(mesh->vertices.face_ids);
-  free(mesh->vertices.subface_ids);
-  free(mesh->vertices.internal_cell_ids);
-  free(mesh->vertices.subcell_ids);
-  free(mesh->vertices.boundary_face_ids);
+  ierr = TDyFree(mesh->vertices.id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.global_id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.num_internal_cells); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.num_edges); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.num_faces); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.num_boundary_faces); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.is_local); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.coordinate); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.edge_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.face_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.internal_cell_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.subcell_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.boundary_face_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.edge_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.face_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.subface_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.internal_cell_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.subcell_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->vertices.boundary_face_ids); CHKERRQ(ierr);
 
-  free(mesh->edges.id);
-  free(mesh->edges.global_id);
-  free(mesh->edges.num_cells);
-  free(mesh->edges.vertex_ids);
-  free(mesh->edges.is_local);
-  free(mesh->edges.is_internal);
-  free(mesh->edges.cell_offset);
-  free(mesh->edges.cell_ids);
-  free(mesh->edges.centroid);
-  free(mesh->edges.normal);
-  free(mesh->edges.length);
+  ierr = TDyFree(mesh->edges.id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.global_id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.num_cells); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.vertex_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.is_local); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.is_internal); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.cell_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.cell_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.centroid); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.normal); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->edges.length); CHKERRQ(ierr);
 
-  free(mesh->faces.id);
-  free(mesh->faces.num_vertices);
-  free(mesh->faces.num_edges);
-  free(mesh->faces.num_cells);
-  free(mesh->faces.is_local);
-  free(mesh->faces.is_internal);
-  free(mesh->faces.vertex_offset);
-  free(mesh->faces.cell_offset);
-  free(mesh->faces.edge_offset);
-  free(mesh->faces.cell_ids);
-  free(mesh->faces.edge_ids);
-  free(mesh->faces.vertex_ids);
-  free(mesh->faces.area);
-  free(mesh->faces.centroid);
-  free(mesh->faces.normal);
+  ierr = TDyFree(mesh->faces.id); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.num_vertices); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.num_edges); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.num_cells); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.is_local); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.is_internal); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.vertex_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.cell_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.edge_offset); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.cell_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.edge_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.vertex_ids); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.area); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.centroid); CHKERRQ(ierr);
+  ierr = TDyFree(mesh->faces.normal); CHKERRQ(ierr);
 
-  free(mesh->closureSize);
+  ierr = TDyFree(mesh->closureSize);
   ierr = TDyDeallocate_IntegerArray_2D(mesh->closure,
             mesh->num_cells+mesh->num_faces+mesh->num_edges+mesh->num_vertices);
   CHKERRQ(ierr);
 
-  free(mesh);
+  ierr = TDyFree(mesh); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/fv/share/tdymeshcustom.c
+++ b/src/fv/share/tdymeshcustom.c
@@ -611,7 +611,7 @@ static PetscErrorCode SetupMaps_C2F_F2C_F2V(TDyUGrid *ugrid, PetscInt **cell_to_
       face_count++;
     }
   }
-  free(vertex_ids);
+  TDyFree(vertex_ids);
 
   PetscFunctionReturn(0);
 }
@@ -780,7 +780,7 @@ static PetscErrorCode UpdateMapsC2F_F2C_F2V(TDyUGrid *ugrid, PetscInt **cell_to_
       }
     }
   }
-  free(tmp_int);
+  TDyFree(tmp_int);
 
   PetscFunctionReturn(0);
 }
@@ -1294,7 +1294,7 @@ PetscErrorCode TDyMeshCreateFromDiscretization(TDyDiscretizationType *discretiza
 
   PetscErrorCode ierr;
 
-  *mesh = malloc(sizeof(TDyMesh));
+  ierr = TDyAlloc(sizeof(TDyMesh), mesh); CHKERRQ(ierr);
 
   ierr = TDyMeshMapIndices(discretization, mesh); CHKERRQ(ierr);
   ierr = TDySetupCellsFromDiscretization(discretization, mesh); CHKERRQ(ierr);

--- a/src/fv/share/tdymeshcustom.c
+++ b/src/fv/share/tdymeshcustom.c
@@ -1161,7 +1161,7 @@ static PetscErrorCode ComputeGeoAttrOfUGridFaces(PetscInt **cell_to_face, TDyUGr
   ierr = TDyAllocate_RealArray_1D(&ugrid->face_area, ugrid->num_faces); CHKERRQ(ierr);
 
   PetscBool is_face_set[ugrid->num_faces];
-  for (PetscInt iface; iface<ugrid->num_faces; iface++) {
+  for (PetscInt iface = 0; iface<ugrid->num_faces; iface++) {
     is_face_set[iface] = PETSC_FALSE;
     for (PetscInt idim=0; idim<dim; idim++) {
       ugrid->face_centroid[iface][idim] = 0.0;

--- a/src/fv/share/tdymeshplex.c
+++ b/src/fv/share/tdymeshplex.c
@@ -3478,9 +3478,9 @@ static PetscErrorCode TDyMeshComputeGeometryFromPlex(PetscReal **X, PetscReal **
   ierr = DMPlexGetChart(dm,&pStart,&pEnd); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum(dm,0,&vStart,&vEnd); CHKERRQ(ierr);
   ierr = DMPlexGetDepthStratum(dm,1,&eStart,&eEnd); CHKERRQ(ierr);
-  ierr = PetscMalloc((pEnd-pStart)*sizeof(PetscReal),V); CHKERRQ(ierr);
-  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),X); CHKERRQ(ierr);
-  ierr = PetscMalloc(dim*(pEnd-pStart)*sizeof(PetscReal),N); CHKERRQ(ierr);
+  ierr = TDyAlloc((pEnd-pStart)*sizeof(PetscReal),V); CHKERRQ(ierr);
+  ierr = TDyAlloc(dim*(pEnd-pStart)*sizeof(PetscReal),X); CHKERRQ(ierr);
+  ierr = TDyAlloc(dim*(pEnd-pStart)*sizeof(PetscReal),N); CHKERRQ(ierr);
 
   PetscSection coordSection;
   Vec coordinates;
@@ -3695,7 +3695,7 @@ PetscErrorCode TDyMeshCreateFromPlex(DM dm, PetscReal **volumes, PetscReal **coo
     SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"MPFA-O only supports 3D meshes");
   }
 
-  *mesh = malloc(sizeof(TDyMesh));
+  ierr = TDyAlloc(sizeof(TDyMesh), mesh); CHKERRQ(ierr);
 
   // Determine the number of cells, edges, and vertices of the mesh
   PetscInt c_start, c_end;

--- a/src/fv/share/tdyugdm.c
+++ b/src/fv/share/tdyugdm.c
@@ -14,7 +14,7 @@ PetscErrorCode TDyUGDMCreate(TDyUGDM **ugdm){
   PetscFunctionBegin;
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(TDyUGDM), ugdm); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(TDyUGDM), ugdm); CHKERRQ(ierr);
 
   (*ugdm)->IS_GhostedCells_in_LocalOrder = NULL;
   (*ugdm)->IS_GhostedCells_in_GlobalOrder = NULL;
@@ -95,7 +95,7 @@ PetscErrorCode TDyUGDMDestroy(TDyUGDM *ugdm){
     ISLocalToGlobalMappingDestroy(&ugdm->Mapping_LocalCells_to_GhostedCells);
   }
 
-  free(ugdm);
+  TDyFree(ugdm);
 
   PetscFunctionReturn(0);
 }

--- a/src/fv/share/tdyugrid.c
+++ b/src/fv/share/tdyugrid.c
@@ -18,7 +18,7 @@ PetscErrorCode TDyUGridCreate(TDyUGrid **ugrid) {
 
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(TDyUGrid), ugrid); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(TDyUGrid), ugrid); CHKERRQ(ierr);
 
   (*ugrid)->num_cells_global = 0;
   (*ugrid)->num_cells_local = 0;
@@ -728,7 +728,7 @@ static PetscErrorCode UpdateNaturalCellIDs(PetscInt stride, PetscInt dual_offset
   }
 
   PetscInt rank; MPI_Comm_rank(PETSC_COMM_WORLD,&rank);
-  free(ugrid->cell_ids_natural);
+  TDyFree(ugrid->cell_ids_natural);
   ierr = TDyAllocate_IntegerArray_1D(&ugrid->cell_ids_natural, ngmax); CHKERRQ(ierr);
 
   for (PetscInt ilocal=0; ilocal<nlmax; ilocal++) {

--- a/src/materials/tdycharacteristiccurves.c
+++ b/src/materials/tdycharacteristiccurves.c
@@ -17,7 +17,7 @@ PetscErrorCode CharacteristicCurvesCreate(CharacteristicCurves **cc) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
 
-  ierr = PetscMalloc(sizeof(CharacteristicCurves), cc); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(CharacteristicCurves), cc); CHKERRQ(ierr);
   ierr = SaturationCreate(&((*cc)->saturation)); CHKERRQ(ierr);
   ierr = RelativePermeabilityCreate(&((*cc)->rel_perm)); CHKERRQ(ierr);
 
@@ -32,7 +32,7 @@ PetscErrorCode CharacteristicCurvesDestroy(CharacteristicCurves *cc) {
 
   ierr = RelativePermeabilityDestroy(cc->rel_perm); CHKERRQ(ierr);
   ierr = SaturationDestroy(cc->saturation); CHKERRQ(ierr);
-  ierr = PetscFree(cc); CHKERRQ(ierr);
+  ierr = TDyFree(cc); CHKERRQ(ierr);
 
   PetscFunctionReturn(0);
 }
@@ -42,7 +42,7 @@ PetscErrorCode SaturationCreate(Saturation **sat) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(Saturation), sat); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(Saturation), sat); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -54,7 +54,7 @@ PetscErrorCode SaturationDestroy(Saturation *sat) {
   for (int type = 0; type < num_types; ++type) {
     SaturationSetType(sat, type, 0, NULL, NULL);
   }
-  ierr = PetscFree(sat); CHKERRQ(ierr);
+  ierr = TDyFree(sat); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -87,8 +87,8 @@ PetscErrorCode SaturationSetType(Saturation *sat, SaturationType type,
   // If we're changing the number of points for this type, free storage.
   if (sat->num_points[type] != num_points) {
     if (sat->points[type]) {
-      ierr = PetscFree(sat->points[type]); CHKERRQ(ierr);
-      ierr = PetscFree(sat->parameters[type]); CHKERRQ(ierr);
+      ierr = TDyFree(sat->points[type]); CHKERRQ(ierr);
+      ierr = TDyFree(sat->parameters[type]); CHKERRQ(ierr);
     }
   }
 
@@ -103,11 +103,11 @@ PetscErrorCode SaturationSetType(Saturation *sat, SaturationType type,
   }
 
   sat->num_points[type] = num_points;
-  ierr = PetscMalloc(num_points*sizeof(PetscInt),
-                     &(sat->points[type])); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_points*sizeof(PetscInt),
+                  &(sat->points[type])); CHKERRQ(ierr);
   memcpy(sat->points[type], points, num_points*sizeof(PetscInt));
-  ierr = PetscMalloc(num_params*num_points*sizeof(PetscReal),
-                     &(sat->parameters[type])); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_params*num_points*sizeof(PetscReal),
+                  &(sat->parameters[type])); CHKERRQ(ierr);
   memcpy(sat->parameters[type], parameters, num_params*num_points*sizeof(PetscReal));
   PetscFunctionReturn(0);
 }
@@ -240,7 +240,7 @@ PetscErrorCode RelativePermeabilityCreate(RelativePermeability **rel_perm) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(RelativePermeability), rel_perm); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(RelativePermeability), rel_perm); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -252,7 +252,7 @@ PetscErrorCode RelativePermeabilityDestroy(RelativePermeability *rel_perm) {
   for (int type = 0; type < num_types; ++type) {
     RelativePermeabilitySetType(rel_perm, type, 0, NULL, NULL);
   }
-  ierr = PetscFree(rel_perm); CHKERRQ(ierr);
+  ierr = TDyFree(rel_perm); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -299,17 +299,17 @@ PetscErrorCode RelativePermeabilitySetType(RelativePermeability *rel_perm,
   // If we're changing the number of points for this type, free storage.
   if (rel_perm->num_points[type] != num_points) {
     if (rel_perm->points[type]) {
-      ierr = PetscFree(rel_perm->points[type]); CHKERRQ(ierr);
-      ierr = PetscFree(rel_perm->parameters[type]); CHKERRQ(ierr);
+      ierr = TDyFree(rel_perm->points[type]); CHKERRQ(ierr);
+      ierr = TDyFree(rel_perm->parameters[type]); CHKERRQ(ierr);
     }
   }
 
   rel_perm->num_points[type] = num_points;
-  ierr = PetscMalloc(num_points*sizeof(PetscInt),
-                     &(rel_perm->points[type])); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_points*sizeof(PetscInt),
+                  &(rel_perm->points[type])); CHKERRQ(ierr);
   memcpy(rel_perm->points[type], points, num_points*sizeof(PetscInt));
-  ierr = PetscMalloc(num_params*num_points*sizeof(PetscReal),
-                     &(rel_perm->parameters[type])); CHKERRQ(ierr);
+  ierr = TDyAlloc(num_params*num_points*sizeof(PetscReal),
+                  &(rel_perm->parameters[type])); CHKERRQ(ierr);
   memcpy(rel_perm->parameters[type], parameters,
          num_params*num_points*sizeof(PetscReal));
   PetscFunctionReturn(0);

--- a/src/materials/tdymaterialproperties.c
+++ b/src/materials/tdymaterialproperties.c
@@ -14,7 +14,7 @@ PetscErrorCode MaterialPropCreate(PetscInt dim, MaterialProp **matprop) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
 
-  ierr = PetscCalloc(sizeof(MaterialProp), matprop); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(MaterialProp), matprop); CHKERRQ(ierr);
   (*matprop)->dim = dim;
 
   PetscFunctionReturn(0);
@@ -23,6 +23,7 @@ PetscErrorCode MaterialPropCreate(PetscInt dim, MaterialProp **matprop) {
 /// Destroys the given instance (and any context pointers managed by it).
 /// @param [inout] matprop A MaterialProp instance
 PetscErrorCode MaterialPropDestroy(MaterialProp *matprop) {
+  PetscErrorCode ierr;
   PetscFunctionBegin;
   MaterialPropSetPorosity(matprop, NULL, NULL, NULL);
   MaterialPropSetPermeability(matprop, NULL, NULL, NULL);
@@ -30,7 +31,7 @@ PetscErrorCode MaterialPropDestroy(MaterialProp *matprop) {
   MaterialPropSetResidualSaturation(matprop, NULL, NULL, NULL);
   MaterialPropSetSoilDensity(matprop, NULL, NULL, NULL);
   MaterialPropSetSoilSpecificHeat(matprop, NULL, NULL, NULL);
-  PetscFree(matprop);
+  ierr = TDyFree(matprop); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -303,7 +304,7 @@ static PetscErrorCode CreateConstantContext(PetscInt dim, PetscReal value[9],
   PetscErrorCode ierr;
   PetscFunctionBegin;
   WrapperStruct *wrapper;
-  ierr = PetscMalloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
   wrapper->dim = dim;
   memcpy(wrapper->value, value, 9*sizeof(PetscReal));
   wrapper->func = NULL;
@@ -318,7 +319,7 @@ static PetscErrorCode CreateSpatialContext(PetscInt dim,
   PetscErrorCode ierr;
   PetscFunctionBegin;
   WrapperStruct *wrapper;
-  ierr = PetscMalloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
+  ierr = TDyAlloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
   wrapper->dim = dim;
   memset(wrapper->value, 0, 9*sizeof(PetscReal));
   wrapper->func = func;

--- a/src/tdydiscretization.c
+++ b/src/tdydiscretization.c
@@ -1,13 +1,14 @@
 #include <private/tdycoreimpl.h>
 #include <private/tdydmimpl.h>
 #include <private/tdydiscretizationimpl.h>
+#include <private/tdymemoryimpl.h>
 
 PetscErrorCode TDyDiscretizationCreate(TDyDiscretizationType **discretization) {
 
   PetscErrorCode ierr;
 
   TDyDiscretizationType *discretization_ptr;
-  discretization_ptr = (TDyDiscretizationType*) malloc(sizeof(TDyDiscretizationType));
+  ierr = TDyAlloc(sizeof(TDyDiscretizationType), &discretization_ptr); CHKERRQ(ierr);
   *discretization = discretization_ptr;
 
   ierr = TDyDMCreate(&((*discretization)->tdydm)); CHKERRQ(ierr);
@@ -34,10 +35,10 @@ PetscErrorCode TDyDiscretizationDestroy(TDyDiscretizationType *discretization) {
 
   PetscErrorCode ierr;
 
-  discretization = malloc(sizeof(TDyDiscretization));
+  ierr = TDyAlloc(sizeof(TDyDiscretization), &discretization); CHKERRQ(ierr);
 
   ierr = TDyDMDestroy (discretization->tdydm); CHKERRQ(ierr);
-  free(discretization);
+  TDyFree(discretization);
 
   PetscFunctionReturn(0);
 

--- a/src/tdymemory.c
+++ b/src/tdymemory.c
@@ -1,12 +1,5 @@
 #include <private/tdymemoryimpl.h>
 
-/// Allocates a chunk of zeroed memory of the given size (in bytes).
-/// @param [in] size The size of the requested allocation.
-/// @param [out] result A pointer to the requested memory chunk.
-PetscErrorCode TDyAlloc(size_t size, void **result) {
-  return PetscCalloc1(size, result);
-}
-
 /// Frees memory allocated by TDyAlloc.
 /// @param [out] memory The pointer to the memory to be freed.
 PetscErrorCode TDyFree(void *memory) {

--- a/src/tdymemory.c
+++ b/src/tdymemory.c
@@ -1,5 +1,42 @@
 #include <private/tdymemoryimpl.h>
 
+/// Allocates a chunk of zeroed memory of the given size (in bytes).
+/// @param [in] size The size of the requested allocation.
+/// @param [out] result A pointer to the requested memory chunk.
+PetscErrorCode TDyAlloc(size_t size, void **result) {
+  return PetscCalloc1(size, result);
+}
+
+/// Frees memory allocated by TDyAlloc.
+/// @param [out] memory The pointer to the memory to be freed.
+PetscErrorCode TDyFree(void *memory) {
+  return PetscFree(memory);
+}
+
+/// Sets all values in the given memory block to the given integer value.
+/// @param size The number of integers in the array
+/// @param array The array whose values are to be set
+/// @param value The value to which the array's values is set
+PetscErrorCode TDySetIntArray(size_t size, PetscInt array[size], PetscInt value) {
+  PetscFunctionBegin;
+  for (size_t i = 0; i < size; ++i) {
+    array[i] = value;
+  }
+  PetscFunctionReturn(0);
+}
+
+/// Sets all values in the given memory block to the given real value.
+/// @param size The number of real numbers in the array
+/// @param array The array whose values are to be set
+/// @param value The value to which the array's values is set
+PetscErrorCode TDySetRealArray(size_t size, PetscReal array[size], PetscReal value) {
+  PetscFunctionBegin;
+  for (size_t i = 0; i < size; ++i) {
+    array[i] = value;
+  }
+  PetscFunctionReturn(0);
+}
+
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyInitialize_IntegerArray_1D(PetscInt *array_1D, PetscInt ndim_1,
     PetscInt init_value) {

--- a/src/tdymemory.c
+++ b/src/tdymemory.c
@@ -9,7 +9,7 @@ PetscErrorCode TDyFree(void *memory) {
 /// Sets all values in the given memory block to the given integer value.
 /// @param size The number of integers in the array
 /// @param array The array whose values are to be set
-/// @param value The value to which the array's values is set
+/// @param value The value to which the array's values are set
 PetscErrorCode TDySetIntArray(size_t size, PetscInt array[size], PetscInt value) {
   PetscFunctionBegin;
   for (size_t i = 0; i < size; ++i) {
@@ -21,7 +21,7 @@ PetscErrorCode TDySetIntArray(size_t size, PetscInt array[size], PetscInt value)
 /// Sets all values in the given memory block to the given real value.
 /// @param size The number of real numbers in the array
 /// @param array The array whose values are to be set
-/// @param value The value to which the array's values is set
+/// @param value The value to which the array's values are set
 PetscErrorCode TDySetRealArray(size_t size, PetscReal array[size], PetscReal value) {
   PetscFunctionBegin;
   for (size_t i = 0; i < size; ++i) {
@@ -118,10 +118,9 @@ PetscErrorCode TDyInitialize_RealArray_4D(PetscReal ****array_4D, PetscInt ndim_
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_IntegerArray_1D(PetscInt **array_1D, PetscInt ndim_1) {
-
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  *array_1D = (PetscInt *)malloc(ndim_1*sizeof(PetscInt));
+  ierr = TDyAlloc(ndim_1*sizeof(PetscInt), array_1D); CHKERRQ(ierr);
   ierr = TDyInitialize_IntegerArray_1D(*array_1D, ndim_1, -1); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
@@ -133,9 +132,9 @@ PetscErrorCode TDyAllocate_IntegerArray_2D(PetscInt ***array_2D, PetscInt ndim_1
   PetscInt i;
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  *array_2D = (PetscInt **)malloc(ndim_1*sizeof(PetscInt *));
+  ierr = TDyAlloc(ndim_1*sizeof(PetscInt *), array_2D); CHKERRQ(ierr);
   for(i=0; i<ndim_1; i++) {
-    (*array_2D)[i] = (PetscInt *)malloc(ndim_2*sizeof(PetscInt ));
+    ierr = TDyAlloc(ndim_2*sizeof(PetscInt ), &((*array_2D)[i])); CHKERRQ(ierr);
   }
   ierr = TDyInitialize_IntegerArray_2D(*array_2D, ndim_1, ndim_2, -1); CHKERRQ(ierr);
   PetscFunctionReturn(0);
@@ -143,12 +142,7 @@ PetscErrorCode TDyAllocate_IntegerArray_2D(PetscInt ***array_2D, PetscInt ndim_1
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_RealArray_1D(PetscReal **array_1D, PetscInt ndim_1) {
-
-  PetscErrorCode ierr;
-  PetscFunctionBegin;
-  *array_1D = (PetscReal *)malloc(ndim_1*sizeof(PetscReal ));
-  ierr = TDyInitialize_RealArray_1D(*array_1D, ndim_1, 0.0); CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(PetscReal), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
@@ -158,11 +152,10 @@ PetscErrorCode TDyAllocate_RealArray_2D(PetscReal ***array_2D, PetscInt ndim_1,
   PetscInt i;
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  *array_2D = (PetscReal **)malloc(ndim_1*sizeof(PetscReal *));
+  ierr = TDyAlloc(ndim_1*sizeof(PetscReal *), array_2D); CHKERRQ(ierr);
   for(i=0; i<ndim_1; i++) {
-    (*array_2D)[i] = (PetscReal *)malloc(ndim_2*sizeof(PetscReal ));
+    ierr = TDyAlloc(ndim_2*sizeof(PetscReal ), &((*array_2D)[i])); CHKERRQ(ierr);
   }
-  ierr = TDyInitialize_RealArray_2D(*array_2D, ndim_1, ndim_2, 0.0); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -173,14 +166,13 @@ PetscErrorCode TDyAllocate_RealArray_3D(PetscReal ****array_3D, PetscInt ndim_1,
   PetscInt i,j;
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  *array_3D = (PetscReal ***)malloc(ndim_1*sizeof(PetscReal **));
+  ierr = TDyAlloc(ndim_1*sizeof(PetscReal **), array_3D); CHKERRQ(ierr);
   for(i=0; i<ndim_1; i++) {
-    (*array_3D)[i] = (PetscReal **)malloc(ndim_2*sizeof(PetscReal *));
+    ierr = TDyAlloc(ndim_2*sizeof(PetscReal *), &((*array_3D)[i])); CHKERRQ(ierr);
     for(j=0; j<ndim_2; j++) {
-      (*array_3D)[i][j] = (PetscReal *)malloc(ndim_3*sizeof(PetscReal));
+      ierr = TDyAlloc(ndim_3*sizeof(PetscReal), &((*array_3D)[i][j])); CHKERRQ(ierr);
     }
   }
-  ierr = TDyInitialize_RealArray_3D(*array_3D, ndim_1, ndim_2, ndim_3, 0.0);
   CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
@@ -193,13 +185,13 @@ PetscErrorCode TDyAllocate_RealArray_4D(PetscReal *****array_4D, PetscInt ndim_1
   PetscInt i,j,k;
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  *array_4D = (PetscReal ****)malloc(ndim_1*sizeof(PetscReal ***));
+  ierr = TDyAlloc(ndim_1*sizeof(PetscReal ***), array_4D); CHKERRQ(ierr);
   for(i=0; i<ndim_1; i++) {
-    (*array_4D)[i] = (PetscReal ***)malloc(ndim_2*sizeof(PetscReal **));
+    ierr = TDyAlloc(ndim_2*sizeof(PetscReal **), &((*array_4D)[i])); CHKERRQ(ierr);
     for(j=0; j<ndim_2; j++) {
-      (*array_4D)[i][j] = (PetscReal **)malloc(ndim_3*sizeof(PetscReal *));
+      ierr = TDyAlloc(ndim_3*sizeof(PetscReal *), &((*array_4D)[i][j])); CHKERRQ(ierr);
       for(k=0; k<ndim_3; k++) {
-        (*array_4D)[i][j][k] = (PetscReal *)malloc(ndim_4*sizeof(PetscReal));
+        ierr = TDyAlloc(ndim_4*sizeof(PetscReal), &((*array_4D)[i][j][k])); CHKERRQ(ierr);
       }
     }
   }
@@ -210,129 +202,106 @@ PetscErrorCode TDyAllocate_RealArray_4D(PetscReal *****array_4D, PetscInt ndim_1
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_RealArray_1D(PetscReal *array_1D) {
-
-  PetscFunctionBegin;
-  free(array_1D);
-  PetscFunctionReturn(0);
+  return TDyFree(array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_IntegerArray_1D(PetscInt *array_1D) {
-
-  PetscFunctionBegin;
-  free(array_1D);
-  PetscFunctionReturn(0);
+  return TDyFree(array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_IntegerArray_2D(PetscInt **array_2D, PetscInt ndim_1) {
 
+  PetscErrorCode ierr;
   PetscInt i;
   PetscFunctionBegin;
   for(i=0; i<ndim_1; i++) {
-    free(array_2D[i]);
+    ierr = TDyFree(array_2D[i]); CHKERRQ(ierr);
   }
-  free(array_2D);
+  ierr = TDyFree(array_2D); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_RealArray_2D(PetscReal **array_2D, PetscInt ndim_1) {
 
+  PetscErrorCode ierr;
   PetscInt i;
   PetscFunctionBegin;
   for(i=0; i<ndim_1; i++) {
-    free(array_2D[i]);
+    ierr = TDyFree(array_2D[i]); CHKERRQ(ierr);
   }
-  free(array_2D);
+  ierr = TDyFree(array_2D); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_RealArray_3D(PetscReal ***array_3D, PetscInt ndim_1, PetscInt ndim_2) {
 
+  PetscErrorCode ierr;
   PetscInt i,j;
   PetscFunctionBegin;
   for(i=0; i<ndim_1; i++) {
     for(j=0; j<ndim_2; j++) {
-      free(array_3D[i][j]);
+      ierr = TDyFree(array_3D[i][j]); CHKERRQ(ierr);
     }
-    free(array_3D[i]);
+    ierr = TDyFree(array_3D[i]); CHKERRQ(ierr);
   }
-  free(array_3D);
+  ierr = TDyFree(array_3D); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyDeallocate_RealArray_4D(PetscReal ****array_4D, PetscInt ndim_1, PetscInt ndim_2, PetscInt ndim_3) {
 
+  PetscErrorCode ierr;
   PetscInt i,j,k;
   PetscFunctionBegin;
   for(i=0; i<ndim_1; i++) {
     for(j=0; j<ndim_2; j++) {
       for(k=0; k<ndim_3; k++) {
-        free(array_4D[i][j][k]);
+        ierr = TDyFree(array_4D[i][j][k]); CHKERRQ(ierr);
       }
-      free(array_4D[i][j]);
+      ierr = TDyFree(array_4D[i][j]); CHKERRQ(ierr);
     }
-    free(array_4D[i]);
+    ierr = TDyFree(array_4D[i]); CHKERRQ(ierr);
   }
-  free(array_4D);
+  ierr = TDyFree(array_4D); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyCell_1D(PetscInt ndim_1, TDyCell **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyCell *)malloc(ndim_1*sizeof(TDyCell));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyCell), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyVertex_1D(PetscInt ndim_1, TDyVertex **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyVertex *)malloc(ndim_1*sizeof(TDyVertex));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyVertex), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyEdge_1D(PetscInt ndim_1, TDyEdge **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyEdge *)malloc(ndim_1*sizeof(TDyEdge));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyEdge), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyFace_1D(PetscInt ndim_1, TDyFace **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyFace *)malloc(ndim_1*sizeof(TDyFace));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyFace), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDySubcell_1D(PetscInt ndim_1, TDySubcell **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDySubcell *)malloc(ndim_1*sizeof(TDySubcell));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDySubcell), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyVector_1D(PetscInt ndim_1, TDyVector **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyVector *)malloc(ndim_1*sizeof(TDyVector));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyVector), array_1D);
 }
 
 /* ---------------------------------------------------------------- */
 PetscErrorCode TDyAllocate_TDyCoordinate_1D(PetscInt ndim_1, TDyCoordinate **array_1D) {
-
-  PetscFunctionBegin;
-  *array_1D = (TDyCoordinate *)malloc(ndim_1*sizeof(TDyCoordinate));
-  PetscFunctionReturn(0);
+  return TDyAlloc(ndim_1*sizeof(TDyCoordinate), array_1D);
 }

--- a/src/tdyti.c
+++ b/src/tdyti.c
@@ -1,4 +1,5 @@
 #include <private/tdycoreimpl.h>
+#include <private/tdymemoryimpl.h>
 #include <tdycore.h>
 #include <private/tdyioimpl.h>
 #include <tdytimers.h>
@@ -9,7 +10,7 @@ PetscErrorCode TDyTimeIntegratorCreate(TDyTimeIntegrator *_ti) {
   char time_integration_method[32];
   PetscErrorCode ierr;
   PetscFunctionBegin;
-  ti = (TDyTimeIntegrator)malloc(sizeof(struct _p_TDyTimeIntegrator));
+  ierr = TDyAlloc(sizeof(struct _p_TDyTimeIntegrator), &ti); CHKERRQ(ierr);
   *_ti =ti;
 
   ti->time_integration_method = TDySNES;
@@ -213,7 +214,7 @@ PetscErrorCode TDyTimeIntegratorDestroy(TDyTimeIntegrator *ti) {
         TSDestroy(&((*ti)->ts));
         break;
     }
-    free(*ti);
+    TDyFree(*ti);
   }
   ti = PETSC_NULL;
   PetscFunctionReturn(0);


### PR DESCRIPTION
This PR introduces three functions (some are actually macros):

* `TDyAlloc`, which allocates memory of a given number of bytes, setting all bytes to zero. This macro replaces calls to `malloc`, `PetscMalloc`, `PetscMalloc1`, `PetscCalloc`, and `PetscCalloc1`.
* `TDyRealloc`, which resizes an existing block of memory efficiently. This replaces calls to `realloc` and `PetscRealloc`.
* `TDyFree`, which frees an allocated block of memory. This replaces calls to `free` and `PetscFree`.

With this, we don't have to remember which of the several different functions to call to allocate or free memory. Just call the appropriate one of these three. :-)

