### PR TITLE
Commit-by-commit port of Rosie's salinity PR to new code structure

### DIFF
--- a/demo/makefile
+++ b/demo/makefile
@@ -1,4 +1,4 @@
-TARGETS = build-steady build-transient build-richards build-th
+TARGETS = build-steady build-transient build-richards build-th build-salinity
 
 ifdef codecov
   MYFLAGS += -fprofile-arcs -ftest-coverage
@@ -34,4 +34,7 @@ build-th:
 
 build-transient:
 	@cd transient; make
+
+build-salinity:
+	@cd salinity; make
 

--- a/demo/salinity/makefile
+++ b/demo/salinity/makefile
@@ -1,0 +1,29 @@
+TARGETS = salinity
+
+ifdef codecov
+  MYFLAGS += -fprofile-arcs -ftest-coverage
+  LIBS    += -lgcov
+endif
+
+# These flags are supplemental to the PETSc flags
+CFLAGS   = ${LIBS}
+FFLAGS   = ${LIBS}
+CPPFLAGS = ${MYFLAGS}
+FPPFLAGS = ${MYFLAGS}
+
+ALL: $(TARGETS)
+clean::
+	-@$(RM) $(TARGETS) *.gcov *.regression *.old *.stdout *.bin *.bin.info
+
+topdir := $(shell cd ../.. && pwd)
+TDYCORE_DIR ?= $(topdir)
+include $(TDYCORE_DIR)/lib/tdycore/conf/variables
+include $(TDYCORE_DIR)/lib/tdycore/conf/rules
+
+build:
+	@cd ../; make
+
+salinity: salinity.o
+	$(CLINKER) -o $@ $< $(TDYCORE_LIB) $(LIBS)
+	$(RM) -f $<
+

--- a/demo/salinity/makefile
+++ b/demo/salinity/makefile
@@ -7,7 +7,7 @@ endif
 
 # These flags are supplemental to the PETSc flags
 CFLAGS   = ${LIBS}
-FFLAGS   = ${LIBS}
+FFLAGS   = ${LIBS} -ffree-line-length-0
 CPPFLAGS = ${MYFLAGS}
 FPPFLAGS = ${MYFLAGS}
 

--- a/demo/salinity/salinity.c
+++ b/demo/salinity/salinity.c
@@ -1,0 +1,79 @@
+#include <tdycore.h>
+#include <private/tdycoreimpl.h>
+#include <tdyio.h>
+
+int main(int argc, char **argv) {
+  /* Initialize */
+  PetscErrorCode ierr;
+  PetscInt successful_exit_code;
+  PetscMPIInt rank, size;
+  MPI_Comm comm = PETSC_COMM_WORLD;
+  TDy tdy = PETSC_NULL;
+  TDyIOFormat format = PetscViewerASCIIFormat;
+  Vec U;
+  PetscReal *soln;
+  PetscInt ncells,c;
+  PetscInt local_size;
+
+  ierr = TDyInit(argc, argv); CHKERRQ(ierr);
+  ierr = TDyCreate(comm, &tdy); CHKERRQ(ierr);
+  ierr = TDySetMode(tdy,SALINITY); CHKERRQ(ierr);
+  ierr = TDySetDiscretization(tdy,MPFA_O); CHKERRQ(ierr);
+
+  ierr = MPI_Comm_rank(PETSC_COMM_WORLD,&rank); CHKERRQ(ierr);
+  ierr = MPI_Comm_size(PETSC_COMM_WORLD,&size); CHKERRQ(ierr);
+  PetscPrintf(PETSC_COMM_WORLD,"Beginning salinity simulation.\n");
+  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
+                           CHKERRQ(ierr);
+  ierr = PetscOptionsInt("-successful_exit_code",
+                         "Code passed on successful completion","",
+                         successful_exit_code,&successful_exit_code,NULL);
+                         CHKERRQ(ierr);
+  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+
+  ierr = TDySetWaterDensityType(tdy,WATER_DENSITY_BATZLE_AND_WANG);
+  ierr = TDySetWaterViscosityType(tdy,WATER_VISCOSITY_BATZLE_AND_WANG);
+  ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);
+
+  ierr = TDyDriverInitializeTDy(tdy); CHKERRQ(ierr);
+  DM dm;
+  ierr = TDyGetDM(tdy, &dm); CHKERRQ(ierr);
+
+  // default mode and method must be set prior to TDySetFromOptions()
+  ncells = 5;
+  //ierr = VecGetLocalSize(tdy->solution,&ncells); CHKERRQ(ierr);
+  PetscRandom rand;
+  ierr = PetscRandomCreate(PETSC_COMM_WORLD,&rand); CHKERRQ(ierr);
+  ierr = DMCreateGlobalVector(dm,&U); CHKERRQ(ierr);
+  ierr = VecGetArray(U,&soln);
+  for (c=0; c<(ncells*2); c+=2){
+    soln[c] = 201325.;
+  }
+  soln[1] = 1.0;
+  for (c=3; c<=(ncells*2); c+=2){
+  soln[c] = 0.000001;
+  // printf("soln  %f",soln[c]);
+  }
+  ierr = VecRestoreArray(U,&soln);
+
+  ierr = TDySetInitialCondition(tdy,U);
+
+  if (!rank) {
+    ierr = TDyIOSetIOProcess(tdy->io, PETSC_TRUE); CHKERRQ(ierr);
+  }
+  PetscPrintf(PETSC_COMM_WORLD,"--\n");
+  if (size == 1) {
+    ierr = TDyIOSetMode(tdy,format);CHKERRQ(ierr);
+    ierr = TDyIOWriteVec(tdy); CHKERRQ(ierr);
+  }
+  ierr = TDyTimeIntegratorRunToTime(tdy,tdy->ti->final_time); 
+         CHKERRQ(ierr);
+  if (size == 1) {ierr = TDyIOWriteVec(tdy); CHKERRQ(ierr);}
+  ierr = TDyOutputRegression(tdy,tdy->soln); CHKERRQ(ierr);
+  ierr = TDyDestroy(&tdy); CHKERRQ(ierr);
+
+  PetscPrintf(PETSC_COMM_WORLD,"--\n");
+  PetscPrintf(PETSC_COMM_WORLD,"Simulation complete.\n");
+  ierr = TDyFinalize(); CHKERRQ(ierr);
+  return(successful_exit_code);
+}

--- a/include/private/tdyconditionsimpl.h
+++ b/include/private/tdyconditionsimpl.h
@@ -7,13 +7,14 @@
 typedef struct Conditions {
 
   /// Contexts provided for condition-related functions.
+  void* boundary_pressure_context;
   void* forcing_context;
   void* energy_forcing_context;
   void* salinity_source_context;
-  void* boundary_pressure_context;
   void* boundary_pressure_type_context;
-  void* boundary_temperature_context;
   void* boundary_velocity_context;
+  void* boundary_temperature_context;
+  void* boundary_salinity_context;
 
   /// Compute momentum source/sink contributions at a set of given points.
   PetscErrorCode (*compute_forcing)(void*,PetscInt,PetscReal*,PetscReal*);
@@ -30,21 +31,25 @@ typedef struct Conditions {
   /// Set the pressure at a set of given points on the boundary.
   PetscErrorCode (*assign_boundary_pressure_type)(void*,PetscInt,PetscReal*,PetscInt*);
 
-  /// Compute the temperature at a set of given points on the boundary.
-  PetscErrorCode (*compute_boundary_temperature)(void*,PetscInt,PetscReal*,PetscReal*);
-
   /// Compute the components of the component of the velocity normal to a given
   /// set of points on the boundary.
   PetscErrorCode (*compute_boundary_velocity)(void*,PetscInt,PetscReal*,PetscReal*);
+
+  /// Compute the temperature at a set of given points on the boundary.
+  PetscErrorCode (*compute_boundary_temperature)(void*,PetscInt,PetscReal*,PetscReal*);
+
+  /// Compute the salinity (concentration) at a set of given points on the boundary.
+  PetscErrorCode (*compute_boundary_salinity)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Context destructors.
   PetscErrorCode (*forcing_dtor)(void*);
   PetscErrorCode (*energy_forcing_dtor)(void*);
   PetscErrorCode (*salinity_source_dtor)(void*);
+  PetscErrorCode (*boundary_velocity_dtor)(void*);
   PetscErrorCode (*boundary_pressure_dtor)(void*);
   PetscErrorCode (*boundary_pressure_type_dtor)(void*);
   PetscErrorCode (*boundary_temperature_dtor)(void*);
-  PetscErrorCode (*boundary_velocity_dtor)(void*);
+  PetscErrorCode (*boundary_salinity_dtor)(void*);
 } Conditions;
 
 // conditions creation/destruction
@@ -57,8 +62,9 @@ PETSC_INTERN PetscErrorCode ConditionsSetEnergyForcing(Conditions*, void*, Petsc
 PETSC_INTERN PetscErrorCode ConditionsSetSalinitySource(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressure(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressureType(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscInt*), PetscErrorCode (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryVelocity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundarySalinity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 
 // conditions query functions
 PETSC_INTERN PetscBool ConditionsHasForcing(Conditions*);
@@ -66,24 +72,27 @@ PETSC_INTERN PetscBool ConditionsHasEnergyForcing(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasSalinitySource(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryPressure(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryPressureType(Conditions*);
-PETSC_INTERN PetscBool ConditionsHasBoundaryTemperature(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryVelocity(Conditions*);
+PETSC_INTERN PetscBool ConditionsHasBoundaryTemperature(Conditions*);
+PETSC_INTERN PetscBool ConditionsHasBoundarySalinity(Conditions*);
 
 // conditions computation
-// TODO: Change to PETSC_INTERN when we fix demo/steady steady.c
+// TODO: Change to PETSC_INTERN when we fix demo/steady/steady.c
 PETSC_EXTERN PetscErrorCode ConditionsComputeForcing(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode ConditionsComputeEnergyForcing(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode ConditionsComputeSalinitySource(Conditions*,PetscInt,PetscReal*,PetscReal*);
-// TODO: Change to PETSC_INTERN when we fix demo/steady steady.c
+// TODO: Change to PETSC_INTERN when we fix demo/steady/steady.c
 PETSC_EXTERN PetscErrorCode ConditionsComputeBoundaryPressure(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_EXTERN PetscErrorCode ConditionsAssignBoundaryPressureType(Conditions*,PetscInt,PetscReal*,PetscInt*);
-PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryTemperature(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryVelocity(Conditions*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryTemperature(Conditions*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode ConditionsComputeBoundarySalinity(Conditions*,PetscInt,PetscReal*,PetscReal*);
 
 // convenience functions
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryPressure(Conditions*,PetscReal);
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryVelocity(Conditions*,PetscReal);
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryTemperature(Conditions*,PetscReal);
+PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundarySalinity(Conditions*,PetscReal);
 
 #endif
 

--- a/include/private/tdyconditionsimpl.h
+++ b/include/private/tdyconditionsimpl.h
@@ -9,16 +9,20 @@ typedef struct Conditions {
   /// Contexts provided for condition-related functions.
   void* forcing_context;
   void* energy_forcing_context;
+  void* salinity_source_context;
   void* boundary_pressure_context;
   void* boundary_pressure_type_context;
   void* boundary_temperature_context;
   void* boundary_velocity_context;
 
-  /// Compute momentum source contributions at a set of given points.
+  /// Compute momentum source/sink contributions at a set of given points.
   PetscErrorCode (*compute_forcing)(void*,PetscInt,PetscReal*,PetscReal*);
 
-  /// Compute energy source contributions at a set of given points.
+  /// Compute energy source/sink contributions at a set of given points.
   PetscErrorCode (*compute_energy_forcing)(void*,PetscInt,PetscReal*,PetscReal*);
+
+  /// Compute salinity source/sink contributions at a set of given points.
+  PetscErrorCode (*compute_salinity_source)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Compute the pressure at a set of given points on the boundary.
   PetscErrorCode (*compute_boundary_pressure)(void*,PetscInt,PetscReal*,PetscReal*);
@@ -36,6 +40,7 @@ typedef struct Conditions {
   /// Context destructors.
   PetscErrorCode (*forcing_dtor)(void*);
   PetscErrorCode (*energy_forcing_dtor)(void*);
+  PetscErrorCode (*salinity_source_dtor)(void*);
   PetscErrorCode (*boundary_pressure_dtor)(void*);
   PetscErrorCode (*boundary_pressure_type_dtor)(void*);
   PetscErrorCode (*boundary_temperature_dtor)(void*);
@@ -49,6 +54,7 @@ PETSC_INTERN PetscErrorCode ConditionsDestroy(Conditions*);
 // conditions setup functions
 PETSC_INTERN PetscErrorCode ConditionsSetForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetEnergyForcing(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetSalinitySource(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressure(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressureType(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscInt*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , PetscErrorCode (*)(void*));
@@ -57,6 +63,7 @@ PETSC_INTERN PetscErrorCode ConditionsSetBoundaryVelocity(Conditions*, void*, Pe
 // conditions query functions
 PETSC_INTERN PetscBool ConditionsHasForcing(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasEnergyForcing(Conditions*);
+PETSC_INTERN PetscBool ConditionsHasSalinitySource(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryPressure(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryPressureType(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryTemperature(Conditions*);
@@ -66,6 +73,7 @@ PETSC_INTERN PetscBool ConditionsHasBoundaryVelocity(Conditions*);
 // TODO: Change to PETSC_INTERN when we fix demo/steady steady.c
 PETSC_EXTERN PetscErrorCode ConditionsComputeForcing(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode ConditionsComputeEnergyForcing(Conditions*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode ConditionsComputeSalinitySource(Conditions*,PetscInt,PetscReal*,PetscReal*);
 // TODO: Change to PETSC_INTERN when we fix demo/steady steady.c
 PETSC_EXTERN PetscErrorCode ConditionsComputeBoundaryPressure(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_EXTERN PetscErrorCode ConditionsAssignBoundaryPressureType(Conditions*,PetscInt,PetscReal*,PetscInt*);
@@ -74,8 +82,8 @@ PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryVelocity(Conditions*,PetscI
 
 // convenience functions
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryPressure(Conditions*,PetscReal);
-PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryTemperature(Conditions*,PetscReal);
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryVelocity(Conditions*,PetscReal);
+PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryTemperature(Conditions*,PetscReal);
 
 #endif
 

--- a/include/private/tdyconditionsimpl.h
+++ b/include/private/tdyconditionsimpl.h
@@ -14,7 +14,7 @@ typedef struct Conditions {
   void* boundary_pressure_type_context;
   void* boundary_velocity_context;
   void* boundary_temperature_context;
-  void* boundary_salinity_context;
+  void* boundary_saline_conc_context;
 
   /// Compute momentum source/sink contributions at a set of given points.
   PetscErrorCode (*compute_forcing)(void*,PetscInt,PetscReal*,PetscReal*);
@@ -38,8 +38,8 @@ typedef struct Conditions {
   /// Compute the temperature at a set of given points on the boundary.
   PetscErrorCode (*compute_boundary_temperature)(void*,PetscInt,PetscReal*,PetscReal*);
 
-  /// Compute the salinity (concentration) at a set of given points on the boundary.
-  PetscErrorCode (*compute_boundary_salinity)(void*,PetscInt,PetscReal*,PetscReal*);
+  /// Compute the saline concentration at a set of given points on the boundary.
+  PetscErrorCode (*compute_boundary_saline_conc)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Context destructors.
   PetscErrorCode (*forcing_dtor)(void*);
@@ -49,7 +49,7 @@ typedef struct Conditions {
   PetscErrorCode (*boundary_pressure_dtor)(void*);
   PetscErrorCode (*boundary_pressure_type_dtor)(void*);
   PetscErrorCode (*boundary_temperature_dtor)(void*);
-  PetscErrorCode (*boundary_salinity_dtor)(void*);
+  PetscErrorCode (*boundary_saline_conc_dtor)(void*);
 } Conditions;
 
 // conditions creation/destruction
@@ -64,7 +64,7 @@ PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressure(Conditions*, void*, Pe
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryPressureType(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscInt*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryVelocity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 PETSC_INTERN PetscErrorCode ConditionsSetBoundaryTemperature(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*) , PetscErrorCode (*)(void*));
-PETSC_INTERN PetscErrorCode ConditionsSetBoundarySalinity(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
+PETSC_INTERN PetscErrorCode ConditionsSetBoundarySalineConcentration(Conditions*, void*, PetscErrorCode(*)(void*,PetscInt,PetscReal*,PetscReal*), PetscErrorCode (*)(void*));
 
 // conditions query functions
 PETSC_INTERN PetscBool ConditionsHasForcing(Conditions*);
@@ -74,7 +74,7 @@ PETSC_INTERN PetscBool ConditionsHasBoundaryPressure(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryPressureType(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryVelocity(Conditions*);
 PETSC_INTERN PetscBool ConditionsHasBoundaryTemperature(Conditions*);
-PETSC_INTERN PetscBool ConditionsHasBoundarySalinity(Conditions*);
+PETSC_INTERN PetscBool ConditionsHasBoundarySalineConcentration(Conditions*);
 
 // conditions computation
 // TODO: Change to PETSC_INTERN when we fix demo/steady/steady.c
@@ -86,13 +86,13 @@ PETSC_EXTERN PetscErrorCode ConditionsComputeBoundaryPressure(Conditions*,PetscI
 PETSC_EXTERN PetscErrorCode ConditionsAssignBoundaryPressureType(Conditions*,PetscInt,PetscReal*,PetscInt*);
 PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryVelocity(Conditions*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode ConditionsComputeBoundaryTemperature(Conditions*,PetscInt,PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode ConditionsComputeBoundarySalinity(Conditions*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode ConditionsComputeBoundarySalineConcentration(Conditions*,PetscInt,PetscReal*,PetscReal*);
 
 // convenience functions
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryPressure(Conditions*,PetscReal);
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryVelocity(Conditions*,PetscReal);
 PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundaryTemperature(Conditions*,PetscReal);
-PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundarySalinity(Conditions*,PetscReal);
+PETSC_INTERN PetscErrorCode ConditionsSetConstantBoundarySalineConcentration(Conditions*,PetscReal);
 
 #endif
 

--- a/include/private/tdycoreimpl.h
+++ b/include/private/tdycoreimpl.h
@@ -18,6 +18,7 @@
 
 #define VAR_PRESSURE 0
 #define VAR_TEMPERATURE 1
+#define VAR_SALINE_CONCENTRATION 2
 
 // Diagnostic field names
 #define DIAG_LIQUID_SATURATION 0

--- a/include/private/tdyeosimpl.h
+++ b/include/private/tdyeosimpl.h
@@ -9,7 +9,7 @@ typedef struct EOS {
   PetscInt enthalpy_type;
 } EOS;
 
-PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode EOSComputeWaterEnthalpy(EOS*,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
 PETSC_EXTERN PetscErrorCode EOSComputeSalinityFraction(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);

--- a/include/private/tdyeosimpl.h
+++ b/include/private/tdyeosimpl.h
@@ -10,7 +10,7 @@ typedef struct EOS {
 } EOS;
 
 PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode EOSComputeWaterEnthalpy(EOS*,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
 PETSC_EXTERN PetscErrorCode EOSComputeSalinityFraction(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
 

--- a/include/private/tdyeosimpl.h
+++ b/include/private/tdyeosimpl.h
@@ -3,23 +3,17 @@
 
 #include <petsc.h>
 
-typedef enum {
-  WATER_VISCOSITY_CONSTANT=0,
-} WaterViscosityType;
-
-typedef enum {
-  WATER_ENTHALPY_CONSTANT=0,
-} WaterEnthalpyType;
-
 typedef struct EOS {
   TDyWaterDensityType density_type;
   PetscInt viscosity_type;
   PetscInt enthalpy_type;
 } EOS;
 
-PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal*,PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode EOSComputeWaterEnthalpy(EOS*,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
+PETSC_EXTERN PetscErrorCode EOSComputeSalinityFraction(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
+
 
 #endif
 

--- a/include/private/tdyeosimpl.h
+++ b/include/private/tdyeosimpl.h
@@ -9,10 +9,10 @@ typedef struct EOS {
   PetscInt enthalpy_type;
 } EOS;
 
-PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
-PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterDensity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode EOSComputeWaterViscosity(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode EOSComputeWaterEnthalpy(EOS*,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
-PETSC_EXTERN PetscErrorCode EOSComputeSalinityFraction(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscReal*);
+PETSC_EXTERN PetscErrorCode EOSComputeSalinityFraction(EOS*,PetscReal,PetscReal,PetscReal,PetscReal*);
 
 
 #endif

--- a/include/private/tdymaterialpropertiesimpl.h
+++ b/include/private/tdymaterialpropertiesimpl.h
@@ -18,6 +18,8 @@ typedef struct {
   void *residual_saturation_context;
   void *soil_density_context;
   void *soil_specific_heat_context;
+  void *saline_diffusivity_context;
+  void *saline_molecular_weight_context;
 
   /// Material property functions.
   PetscErrorCode (*compute_porosity)(void*,PetscInt,PetscReal*,PetscReal*);
@@ -26,6 +28,8 @@ typedef struct {
   PetscErrorCode (*compute_residual_saturation)(void*,PetscInt,PetscReal*,PetscReal*);
   PetscErrorCode (*compute_soil_density)(void*,PetscInt,PetscReal*,PetscReal*);
   PetscErrorCode (*compute_soil_specific_heat)(void*,PetscInt,PetscReal*,PetscReal*);
+  PetscErrorCode (*compute_saline_diffusivity)(void*,PetscInt,PetscReal*,PetscReal*);
+  PetscErrorCode (*compute_saline_molecular_weight)(void*,PetscInt,PetscReal*,PetscReal*);
 
   /// Material property context destructors.
   PetscErrorCode (*porosity_dtor)(void*);
@@ -34,6 +38,8 @@ typedef struct {
   PetscErrorCode (*residual_saturation_dtor)(void*);
   PetscErrorCode (*soil_density_dtor)(void*);
   PetscErrorCode (*soil_specific_heat_dtor)(void*);
+  PetscErrorCode (*saline_diffusivity_dtor)(void*);
+  PetscErrorCode (*saline_molecular_weight_dtor)(void*);
 
 } MaterialProp;
 
@@ -48,6 +54,8 @@ PETSC_INTERN PetscErrorCode MaterialPropSetThermalConductivity(MaterialProp*, vo
 PETSC_INTERN PetscErrorCode MaterialPropSetResidualSaturation(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
 PETSC_INTERN PetscErrorCode MaterialPropSetSoilDensity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
 PETSC_INTERN PetscErrorCode MaterialPropSetSoilSpecificHeat(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetSalineDiffusivity(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
+PETSC_INTERN PetscErrorCode MaterialPropSetSalineMolecularWeight(MaterialProp*, void*, PetscErrorCode (*)(void*,PetscInt,PetscReal*,PetscReal*),PetscErrorCode(*)(void*));
 
 // material model query functions
 PETSC_INTERN PetscBool MaterialPropHasPorosity(MaterialProp*);
@@ -56,6 +64,8 @@ PETSC_INTERN PetscBool MaterialPropHasThermalConductivity(MaterialProp*);
 PETSC_INTERN PetscBool MaterialPropHasResidualSaturation(MaterialProp*);
 PETSC_INTERN PetscBool MaterialPropHasSoilDensity(MaterialProp*);
 PETSC_INTERN PetscBool MaterialPropHasSoilSpecificHeat(MaterialProp*);
+PETSC_INTERN PetscBool MaterialPropHasSalineDiffusivity(MaterialProp*);
+PETSC_INTERN PetscBool MaterialPropHasSalineMolecularWeight(MaterialProp*);
 
 // material quantity computation
 PETSC_INTERN PetscErrorCode MaterialPropComputePorosity(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
@@ -64,6 +74,8 @@ PETSC_INTERN PetscErrorCode MaterialPropComputeThermalConductivity(MaterialProp*
 PETSC_INTERN PetscErrorCode MaterialPropComputeResidualSaturation(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode MaterialPropComputeSoilDensity(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
 PETSC_INTERN PetscErrorCode MaterialPropComputeSoilSpecificHeat(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode MaterialPropComputeSalineDiffusivity(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
+PETSC_INTERN PetscErrorCode MaterialPropComputeSalineMolecularWeight(MaterialProp*,PetscInt,PetscReal*,PetscReal*);
 
 // convenience functions
 PETSC_INTERN PetscErrorCode MaterialPropSetConstantPorosity(MaterialProp*, PetscReal);
@@ -83,6 +95,13 @@ PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousDiagonalThermalConductiv
 PETSC_INTERN PetscErrorCode MaterialPropSetConstantTensorThermalConductivity(MaterialProp*, PetscReal[9]);
 PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousTensorThermalConductivity(MaterialProp*, TDyTensorSpatialFunction);
 
+PETSC_INTERN PetscErrorCode MaterialPropSetConstantIsotropicSalineDiffusivity(MaterialProp*, PetscReal);
+PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousIsotropicSalineDiffusivity(MaterialProp*, TDyScalarSpatialFunction);
+PETSC_INTERN PetscErrorCode MaterialPropSetConstantDiagonalSalineDiffusivity(MaterialProp*, PetscReal[3]);
+PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousDiagonalSalineDiffusivity(MaterialProp*, TDyVectorSpatialFunction);
+PETSC_INTERN PetscErrorCode MaterialPropSetConstantTensorSalineDiffusivity(MaterialProp*, PetscReal[9]);
+PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousTensorSalineDiffusivity(MaterialProp*, TDyTensorSpatialFunction);
+
 PETSC_INTERN PetscErrorCode MaterialPropSetConstantResidualSaturation(MaterialProp*, PetscReal);
 PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousResidualSaturation(MaterialProp*, TDyScalarSpatialFunction);
 
@@ -92,5 +111,7 @@ PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousSoilDensity(MaterialProp
 PETSC_INTERN PetscErrorCode MaterialPropSetConstantSoilSpecificHeat(MaterialProp*, PetscReal);
 PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousSoilSpecificHeat(MaterialProp*, TDyScalarSpatialFunction);
 
+PETSC_INTERN PetscErrorCode MaterialPropSetConstantSalineMolecularWeight(MaterialProp*, PetscReal);
+PETSC_INTERN PetscErrorCode MaterialPropSetHeterogeneousSalineMolecularWeight(MaterialProp*, TDyTensorSpatialFunction);
 #endif
 

--- a/include/private/tdympfaoimpl.h
+++ b/include/private/tdympfaoimpl.h
@@ -45,47 +45,68 @@ typedef struct TDyMPFAO {
   // the face. For 3D+hex, vel_count = 4
   PetscInt *vel_count;
 
-  // For temperature -- here for now, may factor this out further.
+  // For TH (here for now, may factor out)
   PetscReal ****Temp_subc_Gmatrix; // Gmatrix for subcells
   PetscReal ***Temp_Trans;
   Mat Temp_Trans_mat;
   Vec Temp_P_vec, Temp_TtimesP_vec;
 
-  // Material property data
-  PetscReal *K, *K0; // permeability per cell
-  PetscReal *porosity; // porosity per cell
-  PetscReal *Kappa, *Kappa0; // thermal conductivity per cell
-  PetscReal *rho_soil; // soil density per cell
-  PetscReal *c_soil; // soil specific heat per cell
+  // For salinity (here for now, may factor out)
+  PetscReal ****Psi_subc_Gmatrix; // Gmatrix for subcells
+  Mat Psi_Trans_mat;
+  Vec Psi_vec, TtimesPsi_vec;
 
-  // Characteristic curve data
-  PetscReal *Kr, *dKr_dS; // relative permeability and derivative per cell
-  PetscReal *S, *dS_dP, *d2S_dP2, *dS_dT; // saturation and derivatives per cell
-  PetscReal *Sr; // residual saturation
+  //-----------------------------------
+  // Material property data (per cell)
+  //-----------------------------------
+  PetscReal *K, *K0; // permeability
+  PetscReal *porosity; // porosity
+  PetscReal *Kappa, *Kappa0; // thermal conductivity
+  PetscReal *rho_soil; // soil density
+  PetscReal *c_soil; // soil specific heat
 
-  // boundary pressure and auxillary variables that depend on boundary pressure
-  PetscReal *P_bnd; // pressure [Pa]
-  PetscReal *T_bnd; // temperature [K]
+  //--------------------------------------
+  // Characteristic curve data (per cell)
+  //--------------------------------------
+  PetscReal *Kr, *dKr_dS;                 // relative permeability
+  PetscReal *S, *dS_dP, *d2S_dP2, *dS_dT; // saturation
+  PetscReal *Sr;                          // residual saturation
+
+  // boundary pressure and dependent auxillary variables
+  PetscReal *P_bnd;   // pressure [Pa]
+  PetscReal *T_bnd;   // temperature [K]
+  PetscReal *Psi_bnd; // salinity concentration [?]
   PetscReal *rho_bnd; // water density [kg m-3]
   PetscReal *vis_bnd; // water viscosity [Pa s]
-  PetscReal *h_bnd; // water enthalpy
+  PetscReal *h_bnd;   // water enthalpy [?]
 
   PetscReal *Kr_bnd, *dKr_dS_bnd; // boundary rel perm and derivative
   PetscReal *S_bnd, *dS_dP_bnd, *d2S_dP2_bnd; // saturation and derivatives
   PetscReal *source_sink;         // flow equation source sink
   PetscReal *energy_source_sink;  // energy equation source sink
 
-  /* non-linear function of liquid pressure */
-  PetscReal  *rho, *drho_dP, *d2rho_dP2;       /* density of water [kg m-3]*/
-  PetscReal  *vis, *dvis_dP, *d2vis_dP2;       /* viscosity of water [Pa s] */
-  PetscReal  *h, *dh_dP, *dh_dT;               /* enthalpy of water */
-  PetscReal  *u, *du_dP, *du_dT;               /* internal energy of water */
-  PetscReal  *drho_dT, *dvis_dT;
+  //-----------------------------------------
+  // non-linear functions of liquid pressure
+  //-----------------------------------------
 
-  /* problem constants */
-  PetscReal  gravity[3]; /* vector of gravity [m s-2] */
-  PetscReal  Pref;       /* reference pressure */
-  PetscReal  Tref;       /* reference temperature */
+  // density of water [kg m-3]
+  PetscReal  *rho, *drho_dP, *d2rho_dP2, *drho_dT, *drho_dPsi;
+
+  // viscosity of water [Pa s]
+  PetscReal  *vis, *dvis_dP, *d2vis_dP2, *dvis_dT, *dvis_dPsi;
+
+  // enthalpy of water [?]
+  PetscReal  *h, *dh_dP, *dh_dT;
+
+  // internal energy of water [?]
+  PetscReal  *u, *du_dP, *du_dT;
+
+  //-------------------
+  // problem constants
+  //-------------------
+  PetscReal  gravity[3]; // vector of gravity [m s-2]
+  PetscReal  Pref;       // reference pressure
+  PetscReal  Tref;       // reference temperature
 
 } TDyMPFAO;
 

--- a/include/private/tdympfaoimpl.h
+++ b/include/private/tdympfaoimpl.h
@@ -58,8 +58,6 @@ typedef struct TDyMPFAO {
   Mat Psi_Trans_mat;
   Vec Psi_vec, TtimesPsi_vec;
   PetscReal *m_nacl;
-  PetscReal *dm_nacl;
-  PetscReal *d2m_nacl;
 
   //-----------------------------------
   // Material property data (per cell)
@@ -98,10 +96,10 @@ typedef struct TDyMPFAO {
   //-----------------------------------------
 
   // density of water [kg m-3]
-  PetscReal  *rho, *drho_dP, *d2rho_dP2, *drho_dT, *drho_dPsi;
+  PetscReal  *rho, *drho_dP, *d2rho_dP2, *drho_dT;
 
   // viscosity of water [Pa s]
-  PetscReal  *vis, *dvis_dP, *d2vis_dP2, *dvis_dT, *dvis_dPsi;
+  PetscReal  *vis, *dvis_dP, *d2vis_dP2, *dvis_dT;
 
   // enthalpy of water [?]
   PetscReal  *h, *dh_dP, *dh_dT;
@@ -153,14 +151,15 @@ PETSC_INTERN PetscErrorCode TDyMPFAOComputeSystem_BoundaryVertices_NotSharedWith
 PETSC_INTERN PetscErrorCode TDyMPFAOIFunction(TS,PetscReal,Vec,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOIJacobian_TH(TS,PetscReal,Vec,Vec,PetscReal,Mat,Mat,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_TH(TS,PetscReal,Vec,Vec,Vec,void*);
-PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_Salinity(TS,PetscReal,Vec,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOIJacobian(TS,PetscReal,Vec,Vec,PetscReal,Mat,Mat,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_DAE(TS,PetscReal,Vec,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOTransientVariable(TS,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_TransientVariable(TS,PetscReal,Vec,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOSNESFunction(SNES,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOSNESJacobian(SNES,Vec,Mat,Mat,void*);
+PETSC_INTERN PetscErrorCode TDyMPFAOSNESFunction_Salinity(SNES,Vec,Vec,void*);
 PETSC_INTERN PetscErrorCode TDyMPFAOSNESPreSolve(TDy);
+PETSC_INTERN PetscErrorCode TDyMPFAOSNESPreSolve_Salinity(TDy);
 
 // Utils
 PETSC_INTERN PetscErrorCode ExtractSubGmatrix(TDyMPFAO*,PetscInt,PetscInt,PetscInt,PetscReal**);

--- a/include/private/tdympfaoimpl.h
+++ b/include/private/tdympfaoimpl.h
@@ -171,7 +171,7 @@ PETSC_INTERN PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_NotSharedWi
 PETSC_INTERN PetscErrorCode TDyMPFAORecoverVelocity_BoundaryVertices_SharedWithInternalVertices(TDy,Vec,PetscReal*,PetscInt*);
 PETSC_INTERN PetscErrorCode TDyMPFAO_SetBoundaryPressure(TDy,Vec);
 PETSC_INTERN PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy,Vec);
-PETSC_INTERN PetscErrorCode TDyMPFAO_SetBoundarySalinity(TDy,Vec);
+PETSC_INTERN PetscErrorCode TDyMPFAO_SetBoundarySalineConcentration(TDy,Vec);
 PETSC_INTERN PetscErrorCode ComputeGtimesZ(PetscReal*,PetscReal*,PetscInt,PetscReal*);
 
 #endif

--- a/include/private/tdympfaosalinitytsimpl.h
+++ b/include/private/tdympfaosalinitytsimpl.h
@@ -1,0 +1,14 @@
+#if !defined(TDYMPFAO_SALINITY_TS_IMPL_H)
+#define TDYMPFAO_SALINITY_TS_IMPL_H
+
+#include <petsc.h>
+
+ PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_InternalVertices_Salinity(Vec,Vec,void*);
+ PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_SharedWithInternalVertices_Salinity(Vec,Vec,void*);
+ PETSC_INTERN PetscErrorCode TDyMPFAOIFunction_BoundaryVertices_NotSharedWithInternalVertices_Salinity(Vec,Vec,void*);
+ PETSC_INTERN PetscErrorCode TDyMPFAOIJacobian_InternalVertices_Salinity(Vec, Mat,void*);
+ PETSC_INTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_SharedWithInternalVertices_Salinity(Vec, Mat,void*);
+ PETSC_INTERN PetscErrorCode TDyMPFAOIJacobian_BoundaryVertices_NotSharedWithInternalVertices_Salinity(Vec, Mat,void*);
+
+#endif
+

--- a/include/private/tdyoptions.h
+++ b/include/private/tdyoptions.h
@@ -14,7 +14,7 @@ typedef struct {
 
   // EOS settings
   TDyWaterDensityType rho_type;
-  PetscInt mu_type;
+  TDyWaterViscosityType mu_type;
   PetscInt enthalpy_type;
 
   // Constant material properties
@@ -24,6 +24,8 @@ typedef struct {
   PetscReal residual_saturation;
   PetscReal soil_density;
   PetscReal soil_specific_heat;
+  PetscReal saline_diffusivity;
+  PetscReal saline_molecular_weight;
 
   // Characteristic curve parameters
   PetscReal gardner_n;

--- a/include/private/tdysalinityimpl.h
+++ b/include/private/tdysalinityimpl.h
@@ -1,0 +1,16 @@
+#if !defined(TDYSALINITYIMPL_H)
+#define TDYSALINITYIMPL_H
+
+#include <petsc.h>
+#include <tdycore.h>
+
+PETSC_INTERN PetscErrorCode TDySalinityInitialize(TDy);
+PETSC_INTERN PetscErrorCode TDySalinityTSPostStep(TS);
+PETSC_INTERN PetscErrorCode TDySalinitySNESPostCheck(SNESLineSearch,Vec,Vec,Vec,
+                                                     PetscBool*,PetscBool*,
+                                                     void*);
+PETSC_INTERN PetscErrorCode TDySalinityConvergenceTest(SNES,PetscInt,PetscReal,
+                                                       PetscReal,PetscReal,
+                                                       SNESConvergedReason*,void*);
+
+#endif

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -198,13 +198,13 @@ PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureFunction(TDy,TDyScalarSpatialF
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureTypeFunction(TDy,TDyScalarSpatialIntegerFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryVelocityFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryTemperatureFunction(TDy,TDyScalarSpatialFunction);
-PETSC_EXTERN PetscErrorCode TDySetBoundarySalinityFunction(TDy,TDyScalarSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetBoundarySalineConcentrationFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySelectForcingFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectEnergyForcingFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectBoundaryVelocityFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectBoundaryPressureFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectBoundaryTemperatureFunction(TDy,const char*);
-PETSC_EXTERN PetscErrorCode TDySelectBoundarySalinityFunction(TDy,const char*);
+PETSC_EXTERN PetscErrorCode TDySelectBoundarySalineConcentrationFunction(TDy,const char*);
 
 PETSC_EXTERN PetscErrorCode TDyUpdateState(TDy,PetscReal*,PetscInt);
 PETSC_EXTERN PetscErrorCode TDyComputeErrorNorms(TDy,Vec,PetscReal*,PetscReal*);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -12,7 +12,9 @@ typedef enum {
   /// Richards equation
   RICHARDS=0,
   /// Non-isothermal flows
-  TH
+  TH,
+  /// Flows with salinity
+  SALINITY,
 } TDyMode;
 
 PETSC_EXTERN const char *const TDyModes[];
@@ -98,7 +100,8 @@ typedef struct _p_TDy *TDy;
 
 typedef enum {
   WATER_DENSITY_CONSTANT=0,
-  WATER_DENSITY_EXPONENTIAL=1
+  WATER_DENSITY_EXPONENTIAL=1,
+  WATER_DENSITY_BATZLEWANG=2
 } TDyWaterDensityType;
 
 PETSC_EXTERN const char *const TDyWaterDensityTypes[];

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -115,7 +115,7 @@ PETSC_EXTERN const char *const TDyWaterViscosityTypes[];
 
 typedef enum {
   WATER_ENTHALPY_CONSTANT=0,
-} WaterEnthalpyType;
+} TDyWaterEnthalpyType;
 
 PETSC_EXTERN const char *const TDyWaterEnthalpyTypes[];
 
@@ -152,6 +152,7 @@ PETSC_EXTERN PetscErrorCode TDyRestoreBoundaryFaces(TDy,PetscInt*, const PetscIn
 // Set material properties: via PETSc operations
 PETSC_EXTERN PetscErrorCode TDySetWaterDensityType(TDy,TDyWaterDensityType);
 PETSC_EXTERN PetscErrorCode TDySetWaterViscosityType(TDy,TDyWaterViscosityType);
+PETSC_EXTERN PetscErrorCode TDySetWaterEnthalpyType(TDy,TDyWaterEnthalpyType);
 
 PETSC_EXTERN PetscErrorCode TDySetConstantPorosity(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetPorosityFunction(TDy,TDyScalarSpatialFunction);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -101,10 +101,23 @@ typedef struct _p_TDy *TDy;
 typedef enum {
   WATER_DENSITY_CONSTANT=0,
   WATER_DENSITY_EXPONENTIAL=1,
-  WATER_DENSITY_BATZLEWANG=2
+  WATER_DENSITY_BATZLE_AND_WANG=2
 } TDyWaterDensityType;
 
 PETSC_EXTERN const char *const TDyWaterDensityTypes[];
+
+typedef enum {
+  WATER_VISCOSITY_CONSTANT=0,
+  WATER_VISCOSITY_BATZLE_AND_WANG=1,
+} TDyWaterViscosityType;
+
+PETSC_EXTERN const char *const TDyWaterViscosityTypes[];
+
+typedef enum {
+  WATER_ENTHALPY_CONSTANT=0,
+} WaterEnthalpyType;
+
+PETSC_EXTERN const char *const TDyWaterEnthalpyTypes[];
 
 PETSC_EXTERN PetscClassId TDY_CLASSID;
 
@@ -138,30 +151,48 @@ PETSC_EXTERN PetscErrorCode TDyRestoreBoundaryFaces(TDy,PetscInt*, const PetscIn
 
 // Set material properties: via PETSc operations
 PETSC_EXTERN PetscErrorCode TDySetWaterDensityType(TDy,TDyWaterDensityType);
+PETSC_EXTERN PetscErrorCode TDySetWaterViscosityType(TDy,TDyWaterViscosityType);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantPorosity(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetPorosityFunction(TDy,TDyScalarSpatialFunction);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantIsotropicPermeability(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetIsotropicPermeabilityFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetConstantDiagonalPermeability(TDy,PetscReal[]);
 PETSC_EXTERN PetscErrorCode TDySetDiagonalPermeabilityFunction(TDy,TDyVectorSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetConstantTensorPermeability(TDy,PetscReal[]);
 PETSC_EXTERN PetscErrorCode TDySetTensorPermeabilityFunction(TDy,TDyTensorSpatialFunction);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantIsotropicThermalConductivity(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetIsotropicThermalConductivityFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetConstantDiagonalThermalConductivity(TDy,PetscReal[]);
 PETSC_EXTERN PetscErrorCode TDySetDiagonalThermalConductivityFunction(TDy,TDyVectorSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetConstantTensorThermalConductivity(TDy,PetscReal[]);
 PETSC_EXTERN PetscErrorCode TDySetTensorThermalConductivityFunction(TDy,TDyTensorSpatialFunction);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantResidualSaturation(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetResidualSaturationFunction(TDy,TDyScalarSpatialFunction);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantSoilDensity(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetSoilDensityFunction(TDy,TDyScalarSpatialFunction);
+
 PETSC_EXTERN PetscErrorCode TDySetConstantSoilSpecificHeat(TDy,PetscReal);
 PETSC_EXTERN PetscErrorCode TDySetSoilSpecificHeatFunction(TDy,TDyScalarSpatialFunction);
+
+PETSC_EXTERN PetscErrorCode TDySetConstantIsotropicSalineDiffusivity(TDy,PetscReal);
+PETSC_EXTERN PetscErrorCode TDySetIsotropicSalineDiffusivityFunction(TDy,TDyScalarSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetConstantDiagonalSalineDiffusivity(TDy,PetscReal[]);
+PETSC_EXTERN PetscErrorCode TDySetDiagonalSalineDiffusivityFunction(TDy,TDyVectorSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetConstantTensorSalineDiffusivity(TDy,PetscReal[]);
+PETSC_EXTERN PetscErrorCode TDySetTensorSalineDiffusivityFunction(TDy,TDyTensorSpatialFunction);
+
+PETSC_EXTERN PetscErrorCode TDySetConstantSalineMolecularWeight(TDy,PetscReal);
+PETSC_EXTERN PetscErrorCode TDySetSalineMolecularWeightFunction(TDy,TDyScalarSpatialFunction);
 
 // Set boundary conditions and sources/sinks
 PETSC_EXTERN PetscErrorCode TDySetForcingFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetEnergyForcingFunction(TDy,TDyScalarSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetSalinitySourceFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureTypeFunction(TDy,TDyScalarSpatialIntegerFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryTemperatureFunction(TDy,TDyScalarSpatialFunction);

--- a/include/tdycore.h
+++ b/include/tdycore.h
@@ -196,13 +196,15 @@ PETSC_EXTERN PetscErrorCode TDySetEnergyForcingFunction(TDy,TDyScalarSpatialFunc
 PETSC_EXTERN PetscErrorCode TDySetSalinitySourceFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryPressureTypeFunction(TDy,TDyScalarSpatialIntegerFunction);
-PETSC_EXTERN PetscErrorCode TDySetBoundaryTemperatureFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySetBoundaryVelocityFunction(TDy,TDyScalarSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetBoundaryTemperatureFunction(TDy,TDyScalarSpatialFunction);
+PETSC_EXTERN PetscErrorCode TDySetBoundarySalinityFunction(TDy,TDyScalarSpatialFunction);
 PETSC_EXTERN PetscErrorCode TDySelectForcingFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectEnergyForcingFunction(TDy,const char*);
+PETSC_EXTERN PetscErrorCode TDySelectBoundaryVelocityFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectBoundaryPressureFunction(TDy,const char*);
 PETSC_EXTERN PetscErrorCode TDySelectBoundaryTemperatureFunction(TDy,const char*);
-PETSC_EXTERN PetscErrorCode TDySelectBoundaryVelocityFunction(TDy,const char*);
+PETSC_EXTERN PetscErrorCode TDySelectBoundarySalinityFunction(TDy,const char*);
 
 PETSC_EXTERN PetscErrorCode TDyUpdateState(TDy,PetscReal*,PetscInt);
 PETSC_EXTERN PetscErrorCode TDyComputeErrorNorms(TDy,Vec,PetscReal*,PetscReal*);

--- a/src/fv/fvtpf/tdyfvtpf.c
+++ b/src/fv/fvtpf/tdyfvtpf.c
@@ -295,14 +295,14 @@ static PetscErrorCode AllocateMemoryForBoundaryValues(TDyFVTPF *fvtpf,
   ierr = TDyAlloc(nbnd_faces*sizeof(PetscReal),&(fvtpf->vis_bnd)); CHKERRQ(ierr);
 
   PetscInt i;
-  PetscReal dden_dP, dden_dPsi, d2den_dP2, dmu_dP, dmu_dPsi, d2mu_dP2;
+  PetscReal dden_dP, d2den_dP2, dmu_dP, d2mu_dP2;
   for (i=0;i<nbnd_faces;i++) {
     ierr = EOSComputeWaterDensity(eos,
-      fvtpf->Pref, fvtpf->Tref, 0.0, 0.0, 0.0,
-      &(fvtpf->rho_bnd[i]), &dden_dP, &dden_dPsi, &d2den_dP2); CHKERRQ(ierr);
+      fvtpf->Pref, fvtpf->Tref, 0.0,
+      &(fvtpf->rho_bnd[i]), &dden_dP, &d2den_dP2); CHKERRQ(ierr);
     ierr = EOSComputeWaterViscosity(eos,
       fvtpf->Pref, fvtpf->Tref, 0.0,
-      &(fvtpf->vis_bnd[i]), &dmu_dP, &dmu_dPsi, &d2mu_dP2); CHKERRQ(ierr);
+      &(fvtpf->vis_bnd[i]), &dmu_dP, &d2mu_dP2); CHKERRQ(ierr);
   }
 
   TDY_STOP_FUNCTION_TIMER()
@@ -516,13 +516,11 @@ PetscErrorCode TDyUpdateState_Richards_FVTPF(void *context, DM dm,
 
     // Also update water properties.
     PetscReal P = fvtpf->Pref - Pc[c]; // pressure
-    PetscReal drho_dPsi;
-    ierr = EOSComputeWaterDensity(eos, P, fvtpf->Tref, 0.0, 0.0, 0.0,
-      &(fvtpf->rho[c]), &(fvtpf->drho_dP[c]), &drho_dPsi,
+    ierr = EOSComputeWaterDensity(eos, P, fvtpf->Tref, 0.0,
+      &(fvtpf->rho[c]), &(fvtpf->drho_dP[c]),
       &(fvtpf->d2rho_dP2[c])); CHKERRQ(ierr);
-    PetscReal dvis_dPsi;
     ierr = EOSComputeWaterViscosity(eos, P, fvtpf->Tref, 0.0,
-      &(fvtpf->vis[c]), &(fvtpf->dvis_dP[c]), &dvis_dPsi,
+      &(fvtpf->vis[c]), &(fvtpf->dvis_dP[c]),
       &(fvtpf->d2vis_dP2[c])); CHKERRQ(ierr);
   }
 

--- a/src/fv/fvtpf/tdyfvtpf.c
+++ b/src/fv/fvtpf/tdyfvtpf.c
@@ -298,10 +298,10 @@ static PetscErrorCode AllocateMemoryForBoundaryValues(TDyFVTPF *fvtpf,
   PetscReal dden_dP, dden_dPsi, d2den_dP2, dmu_dP, dmu_dPsi, d2mu_dP2;
   for (i=0;i<nbnd_faces;i++) {
     ierr = EOSComputeWaterDensity(eos,
-      fvtpf->Pref, fvtpf->Tref, fvtpf->S_bnd[i],
+      fvtpf->Pref, fvtpf->Tref, 0.0, 0.0, 0.0,
       &(fvtpf->rho_bnd[i]), &dden_dP, &dden_dPsi, &d2den_dP2); CHKERRQ(ierr);
     ierr = EOSComputeWaterViscosity(eos,
-      fvtpf->Pref, fvtpf->Tref, fvtpf->S_bnd[i],
+      fvtpf->Pref, fvtpf->Tref, 0.0,
       &(fvtpf->vis_bnd[i]), &dmu_dP, &dmu_dPsi, &d2mu_dP2); CHKERRQ(ierr);
   }
 
@@ -517,11 +517,11 @@ PetscErrorCode TDyUpdateState_Richards_FVTPF(void *context, DM dm,
     // Also update water properties.
     PetscReal P = fvtpf->Pref - Pc[c]; // pressure
     PetscReal drho_dPsi;
-    ierr = EOSComputeWaterDensity(eos, P, fvtpf->Tref, fvtpf->S[c],
+    ierr = EOSComputeWaterDensity(eos, P, fvtpf->Tref, 0.0, 0.0, 0.0,
       &(fvtpf->rho[c]), &(fvtpf->drho_dP[c]), &drho_dPsi,
       &(fvtpf->d2rho_dP2[c])); CHKERRQ(ierr);
     PetscReal dvis_dPsi;
-    ierr = EOSComputeWaterViscosity(eos, P, fvtpf->Tref, fvtpf->S[c],
+    ierr = EOSComputeWaterViscosity(eos, P, fvtpf->Tref, 0.0,
       &(fvtpf->vis[c]), &(fvtpf->dvis_dP[c]), &dvis_dPsi,
       &(fvtpf->d2vis_dP2[c])); CHKERRQ(ierr);
   }

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -322,11 +322,14 @@ static PetscErrorCode AllocateMemoryForBoundaryValues(TDyMPFAO *mpfao,
   PetscInt i;
   PetscReal dden_dP, dden_dPsi, d2den_dP2, dmu_dP, dmu_dPsi, d2mu_dP2;
   for (i=0;i<nbnd_faces;i++) {
+    PetscReal m_nacl = mpfao->m_nacl[0];
+    PetscReal dm_nacl = mpfao->dm_nacl[0];
+    PetscReal d2m_nacl = mpfao->d2m_nacl[0];
     ierr = EOSComputeWaterDensity(eos,
-      mpfao->Pref, mpfao->Tref, mpfao->S_bnd[i],
+      mpfao->Pref, mpfao->Tref, m_nacl, dm_nacl, d2m_nacl,
       &(mpfao->rho_bnd[i]), &dden_dP, &dden_dPsi, &d2den_dP2); CHKERRQ(ierr);
     ierr = EOSComputeWaterViscosity(eos,
-      mpfao->Pref, mpfao->Tref, mpfao->S_bnd[i],
+      mpfao->Pref, mpfao->Tref, m_nacl,
       &(mpfao->vis_bnd[i]), &dmu_dP, &dmu_dPsi, &d2mu_dP2); CHKERRQ(ierr);
   }
 
@@ -2578,11 +2581,11 @@ PetscErrorCode TDyUpdateState_Richards_MPFAO(void *context, DM dm,
     PetscReal P = mpfao->Pref - Pc[c]; // pressure
     PetscReal drho_dPsi;
     ierr = EOSComputeWaterDensity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c], mpfao->dm_nacl[c], mpfao->d2m_nacl[c],
       &(mpfao->rho[c]), &(mpfao->drho_dP[c]), &drho_dPsi,
       &(mpfao->d2rho_dP2[c])); CHKERRQ(ierr);
     ierr = EOSComputeWaterViscosity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c],
       &(mpfao->vis[c]), &(mpfao->dvis_dP[c]), &(mpfao->dvis_dPsi[c]),
       &(mpfao->d2vis_dP2[c])); CHKERRQ(ierr);
   }
@@ -2648,12 +2651,12 @@ PetscErrorCode TDyUpdateState_TH_MPFAO(void *context, DM dm,
     PetscReal P = mpfao->Pref - Pc[c]; // pressure
     PetscReal drho_dPsi;
     ierr = EOSComputeWaterDensity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c], mpfao->dm_nacl[c], mpfao->d2m_nacl[c],
       &(mpfao->rho[c]), &(mpfao->drho_dP[c]), &drho_dPsi,
       &(mpfao->d2rho_dP2[c])); CHKERRQ(ierr);
     PetscReal dvis_dPsi;
     ierr = EOSComputeWaterViscosity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c],
       &(mpfao->vis[c]), &(mpfao->dvis_dP[c]), &dvis_dPsi,
       &(mpfao->d2vis_dP2[c])); CHKERRQ(ierr);
 
@@ -2737,11 +2740,11 @@ PetscErrorCode TDyUpdateState_Salinity_MPFAO(void *context, DM dm,
       &(mpfao->m_nacl[c]),&(mpfao->dm_nacl[c]),
       &(mpfao->d2m_nacl[c])); CHKERRQ(ierr);
     ierr = EOSComputeWaterDensity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c], mpfao->dm_nacl[c], mpfao->d2m_nacl[c],
       &(mpfao->rho[c]), &(mpfao->drho_dP[c]), &(mpfao->drho_dPsi[c]),
       &(mpfao->d2rho_dP2[c])); CHKERRQ(ierr);
     ierr = EOSComputeWaterViscosity(eos,
-      P, mpfao->Tref, mpfao->S[c],
+      P, mpfao->Tref, mpfao->m_nacl[c],
       &(mpfao->vis[c]), &(mpfao->dvis_dP[c]), &(mpfao->dvis_dPsi[c]),
       &(mpfao->d2vis_dP2[c])); CHKERRQ(ierr);
   }

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -438,7 +438,7 @@ PetscErrorCode TDyCreate_MPFAO(void **context) {
 
   // Initialize defaults and data.
   mpfao->gmatrix_method = MPFAO_GMATRIX_DEFAULT;
-  mpfao->bc_type = DIRICHLET_BC;
+  mpfao->bc_type = NEUMANN_BC;
   mpfao->Pref = 101325;
   mpfao->Tref = 25;
   mpfao->gravity[0] = 0; mpfao->gravity[1] = 0; mpfao->gravity[2] = 0;

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -436,7 +436,7 @@ PetscErrorCode TDyCreate_MPFAO(void **context) {
 
   // Initialize defaults and data.
   mpfao->gmatrix_method = MPFAO_GMATRIX_DEFAULT;
-  mpfao->bc_type = NEUMANN_BC;
+  mpfao->bc_type = DIRICHLET_BC;
   mpfao->Pref = 101325;
   mpfao->Tref = 25;
   mpfao->gravity[0] = 0; mpfao->gravity[1] = 0; mpfao->gravity[2] = 0;
@@ -866,7 +866,7 @@ PetscErrorCode TDySetDMFields_Salinity_MPFAO(void *context, DM dm) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
   // Set up the section, 2 dofs per cell.
-  ierr = SetFields(dm, 2, (const char*[2]){"LiquidPressure", "Concentration"},
+  ierr = SetFields(dm, 2, (const char*[2]){"LiquidPressure", "SalineConcentration"},
                    (PetscInt[2]){1, 1}); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -487,6 +487,8 @@ PetscErrorCode TDyDestroy_MPFAO(void *context) {
                                       mpfao->mesh->num_cells, 8, 3);
     CHKERRQ(ierr);
   }
+
+  // TH
   if (mpfao->Temp_subc_Gmatrix) {
     ierr = TDyDeallocate_RealArray_4D(mpfao->Temp_subc_Gmatrix,
                                       mpfao->mesh->num_cells, 8, 3);
@@ -501,13 +503,21 @@ PetscErrorCode TDyDestroy_MPFAO(void *context) {
   if (mpfao->Temp_P_vec       ) { ierr = VecDestroy(&mpfao->Temp_P_vec      ); CHKERRQ(ierr); }
   if (mpfao->Temp_TtimesP_vec ) { ierr = VecDestroy(&mpfao->Temp_TtimesP_vec); CHKERRQ(ierr); }
 
-  ierr = TDyFree(mpfao->K); CHKERRQ(ierr);
-  ierr = TDyFree(mpfao->K0); CHKERRQ(ierr);
-  ierr = TDyFree(mpfao->porosity); CHKERRQ(ierr);
-  if (mpfao->Kappa) {
-    ierr = TDyFree(mpfao->Kappa); CHKERRQ(ierr);
-    ierr = TDyFree(mpfao->Kappa0); CHKERRQ(ierr);
+  // SALINITY
+  if (mpfao->Psi_subc_Gmatrix) {
+    ierr = TDyDeallocate_RealArray_4D(mpfao->Psi_subc_Gmatrix,
+                                      mpfao->mesh->num_cells, 8, 3);
+    CHKERRQ(ierr);
   }
+  if (mpfao->Psi_Trans) {
+    ierr = TDyDeallocate_RealArray_3D(mpfao->Psi_Trans, mpfao->mesh->num_vertices,
+                                      mpfao->nfv);
+    CHKERRQ(ierr);
+  }
+  if (mpfao->Psi_Trans_mat) { ierr = MatDestroy(&mpfao->Psi_Trans_mat   ); CHKERRQ(ierr); }
+  if (mpfao->Psi_vec      ) { ierr = VecDestroy(&mpfao->Psi_vec      ); CHKERRQ(ierr); }
+  if (mpfao->TtimesPsi_vec) { ierr = VecDestroy(&mpfao->TtimesPsi_vec); CHKERRQ(ierr); }
+
   if (mpfao->c_soil) {
     ierr = TDyFree(mpfao->c_soil); CHKERRQ(ierr);
   }
@@ -766,6 +776,12 @@ PetscErrorCode TDyGetNumDMFields_TH_MPFAO(void *context) {
   PetscFunctionReturn(ndof);
 }
 
+PetscErrorCode TDyGetNumDMFields_Salinity_MPFAO(void *context) {
+  PetscFunctionBegin;
+  PetscInt ndof = 2; // LiquidPressure, LiquidTemperature
+  PetscFunctionReturn(ndof);
+}
+
 PetscErrorCode TDySetDMFields_Richards_MPFAO(void *context, DM dm) {
   PetscFunctionBegin;
   PetscErrorCode ierr;
@@ -790,6 +806,15 @@ PetscErrorCode TDySetDMFields_TH_MPFAO(void *context, DM dm) {
   PetscErrorCode ierr;
   // Set up the section, 2 dofs per cell.
   ierr = SetFields(dm, 2, (const char*[2]){"LiquidPressure", "LiquidTemperature"},
+                   (PetscInt[2]){1, 1}); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySetDMFields_Salinity_MPFAO(void *context, DM dm) {
+  PetscFunctionBegin;
+  PetscErrorCode ierr;
+  // Set up the section, 2 dofs per cell.
+  ierr = SetFields(dm, 2, (const char*[2]){"LiquidPressure", "Concentration"},
                    (PetscInt[2]){1, 1}); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
@@ -1699,6 +1724,9 @@ static PetscErrorCode UpdateTransmissibilityMatrix(TDyMPFAO *mpfao) {
           if (mpfao->Temp_subc_Gmatrix) { // TH
             ierr = MatZeroRows(mpfao->Temp_Trans_mat,1,row,0.0,0,0); CHKERRQ(ierr);
           }
+          if (mpfao->Psi_subc_Gmatrix) { // SALINITY
+            ierr = MatZeroRows(mpfao->Psi_Trans_mat,1,row,0.0,0,0); CHKERRQ(ierr);
+          }
         }
       }
     }
@@ -1748,6 +1776,11 @@ static PetscErrorCode ComputeTransmissibilityMatrix(TDyMPFAO *mpfao, DM dm) {
   if (mpfao->Temp_subc_Gmatrix) { // TH
     ierr = MatAssemblyBegin(mpfao->Temp_Trans_mat,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
     ierr = MatAssemblyEnd(mpfao->Temp_Trans_mat,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+  }
+
+  if (mpfao->Psi_subc_Gmatrix) { // SALINITY
+    ierr = MatAssemblyBegin(mpfao->Psi_Trans_mat,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(mpfao->Psi_Trans_mat,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
   }
 
   TDyRegion *region = &mesh->region_connected;
@@ -2353,6 +2386,75 @@ PetscErrorCode TDySetup_TH_MPFAO(void *context, TDyDiscretizationType *discretiz
   PetscFunctionReturn(0);
 }
 
+// Setup function for SALINITY + MPFA-O
+PetscErrorCode TDySetup_Salinity_MPFAO(void *context,
+                                       TDyDiscretizationType *discretization,
+                                       EOS *eos,
+                                       MaterialProp *matprop,
+                                       CharacteristicCurves *cc,
+                                       Conditions* conditions) {
+  PetscFunctionBegin;
+
+  PetscErrorCode ierr;
+  TDyMPFAO* mpfao = context;
+  DM dm;
+  ierr = TDyDiscretizationGetDM(discretization,&dm); CHKERRQ(ierr);
+
+  ierr = TDyMeshCreateFromPlex(dm, &mpfao->V, &mpfao->X, &mpfao->N, &mpfao->mesh);
+  ierr = TDyMeshGetMaxVertexConnectivity(mpfao->mesh, &mpfao->ncv, &mpfao->nfv);
+
+  ierr = TDyAllocate_RealArray_1D(&(mpfao->vel), mpfao->mesh->num_faces); CHKERRQ(ierr);
+  ierr = TDyAllocate_IntegerArray_1D(&(mpfao->vel_count), mpfao->mesh->num_faces); CHKERRQ(ierr);
+
+  ierr = InitMaterials(mpfao, dm, matprop, cc); CHKERRQ(ierr);
+
+  // Gather mesh data.
+  PetscInt nLocalCells, nFaces, nNonLocalFaces, nNonInternalFaces;
+  PetscInt nrow, ncol, nz;
+
+  nFaces = mpfao->mesh->num_faces;
+  nLocalCells = mpfao->mesh->num_cells_local;
+  nNonLocalFaces = TDyMeshGetNumberOfNonLocalFaces(mpfao->mesh);
+  nNonInternalFaces = TDyMeshGetNumberOfNonInternalFaces(mpfao->mesh);
+
+  nrow = 4*nFaces;
+  ncol = nLocalCells + nNonLocalFaces + nNonInternalFaces;
+  nz   = mpfao->nfv;
+  ierr = TDyAllocate_RealArray_3D(&mpfao->Trans, mpfao->mesh->num_vertices,
+                                  mpfao->nfv, mpfao->nfv + mpfao->ncv); CHKERRQ(ierr);
+  ierr = MatCreateSeqAIJ(PETSC_COMM_SELF,nrow,ncol,nz,NULL,&mpfao->Trans_mat); CHKERRQ(ierr);
+  ierr = MatSetOption(mpfao->Trans_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+  ierr = VecCreateSeq(PETSC_COMM_SELF,ncol,&mpfao->P_vec);
+  ierr = VecCreateSeq(PETSC_COMM_SELF,nrow,&mpfao->TtimesP_vec);
+  ierr = VecCreateSeq(PETSC_COMM_SELF,nrow,&mpfao->GravDisVec);
+  ierr = VecZeroEntries(mpfao->GravDisVec);
+
+  ierr = TDyAllocate_RealArray_3D(&mpfao->Psi_Trans, mpfao->mesh->num_vertices,
+                                  mpfao->nfv, mpfao->nfv); CHKERRQ(ierr);
+  ierr = MatCreateSeqAIJ(PETSC_COMM_SELF,nrow,ncol,nz,NULL,&mpfao->Psi_Trans_mat); CHKERRQ(ierr);
+  ierr = MatSetOption(mpfao->Psi_Trans_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+  ierr = VecCreateSeq(PETSC_COMM_SELF,ncol,&mpfao->Psi_vec);
+  ierr = VecCreateSeq(PETSC_COMM_SELF,nrow,&mpfao->TtimesPsi_vec);
+
+  PetscInt nsubcells = 8;
+  ierr = TDyAllocate_RealArray_4D(&mpfao->subc_Gmatrix, mpfao->mesh->num_cells,
+                                  nsubcells, 3, 3); CHKERRQ(ierr);
+  ierr = TDyAllocate_RealArray_4D(&mpfao->Psi_subc_Gmatrix, mpfao->mesh->num_cells,
+                                  nsubcells, 3, 3); CHKERRQ(ierr);
+
+  // Compute matrices for our discretization.
+  ierr = ComputeGMatrix(mpfao, dm, matprop); CHKERRQ(ierr);
+  ierr = ComputeTransmissibilityMatrix(mpfao, dm); CHKERRQ(ierr);
+  ierr = ComputeGravityDiscretization(mpfao, dm, matprop); CHKERRQ(ierr);
+
+  ierr = AllocateMemoryForBoundaryValues(mpfao, eos); CHKERRQ(ierr);
+  ierr = AllocateMemoryForSourceSinkValues(mpfao); CHKERRQ(ierr);
+  ierr = AllocateMemoryForEnergyBoundaryValues(mpfao, eos); CHKERRQ(ierr);
+  ierr = AllocateMemoryForEnergySourceSinkValues(mpfao); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
 //-----------------------
 // UpdateState functions
 //-----------------------
@@ -2503,6 +2605,80 @@ PetscErrorCode TDyUpdateState_TH_MPFAO(void *context, DM dm,
     t_vec_ptr[c] = temp[c];
   }
   ierr = VecRestoreArray(mpfao->Temp_P_vec, &t_vec_ptr); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDyUpdateState_Salinity_MPFAO(void *context, DM dm,
+                                             EOS *eos, MaterialProp *matprop,
+                                             CharacteristicCurves *cc,
+                                             PetscInt num_cells, PetscReal *U) {
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+
+  TDyMPFAO *mpfao = context;
+
+  PetscInt dim = 3;
+  PetscInt dim2 = dim*dim;
+  PetscInt cStart = 0, cEnd = num_cells;
+  PetscInt nc = cEnd - cStart;
+
+  // Obtain the capillary pressure and the salinity concentration on all cells.
+  PetscReal Pc[nc], Psi[nc];
+  for (PetscInt c=0;c<cEnd-cStart;c++) {
+    Pc[c] = mpfao->Pref - U[2*c];
+    Psi[c] = U[2*c+1];
+  }
+
+  // Compute the saturation and its derivatives.
+  ierr = SaturationCompute(cc->saturation, mpfao->Sr, Pc, mpfao->S, mpfao->dS_dP,
+                           mpfao->d2S_dP2);
+
+  // Compute the effective saturation on cells.
+  PetscReal Se[nc];
+  for (PetscInt c=0;c<nc;c++) {
+    Se[c] = (mpfao->S[c] - mpfao->Sr[c])/(1.0 - mpfao->Sr[c]);
+  }
+
+  // Compute the relative permeability and its derivative (w.r.t. Se).
+  ierr = RelativePermeabilityCompute(cc->rel_perm, Se, mpfao->Kr, mpfao->dKr_dS);
+
+  // Correct dKr/dS using the chain rule, and update the permeability.
+  for (PetscInt c=0;c<nc;c++) {
+    PetscReal dSe_dS = 1.0/(1.0 - mpfao->Sr[c]);
+    mpfao->dKr_dS[c] *= dSe_dS; // correct dKr/dS
+
+    for(PetscInt j=0; j<dim2; j++) {
+      mpfao->K[c*dim2+j] = mpfao->K0[c*dim2+j] * mpfao->Kr[c];
+    }
+
+    // Also update water properties.
+    PetscReal P = mpfao->Pref - Pc[c]; // pressure
+    ierr = EOSComputeWaterDensity(eos, P, &(mpfao->rho[c]),
+                                  &(mpfao->drho_dP[c]),
+                                  &(mpfao->d2rho_dP2[c])); CHKERRQ(ierr);
+    ierr = EOSComputeWaterViscosity(eos, P, &(mpfao->vis[c]),
+                                    &(mpfao->dvis_dP[c]),
+                                    &(mpfao->d2vis_dP2[c])); CHKERRQ(ierr);
+  }
+
+  PetscReal *p_vec_ptr, gz;
+  TDyMesh *mesh = mpfao->mesh;
+  TDyCell *cells = &mesh->cells;
+
+  ierr = VecGetArray(mpfao->P_vec,&p_vec_ptr); CHKERRQ(ierr);
+  for (PetscInt c=0; c<nc; c++) {
+    ierr = ComputeGtimesZ(mpfao->gravity,cells->centroid[c].X,dim,&gz);
+    PetscReal P = mpfao->Pref - Pc[c]; // pressure
+    p_vec_ptr[c] = P;
+  }
+  ierr = VecRestoreArray(mpfao->P_vec,&p_vec_ptr); CHKERRQ(ierr);
+
+  PetscReal *psi_vec_ptr;
+  ierr = VecGetArray(mpfao->Psi_vec, &t_vec_ptr); CHKERRQ(ierr);
+  for (PetscInt c=0; c<nc; c++) {
+    psi_vec_ptr[c] = Psi[c];
+  }
+  ierr = VecRestoreArray(mpfao->Psi_vec, &t_vec_ptr); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/fv/mpfao/tdympfao_salinity_ts.c
+++ b/src/fv/mpfao/tdympfao_salinity_ts.c
@@ -1,0 +1,317 @@
+#include <tdytimers.h>
+#include <private/tdycoreimpl.h>
+#include <private/tdymeshimpl.h>
+#include <private/tdyutils.h>
+#include <private/tdymemoryimpl.h>
+#include <petscblaslapack.h>
+#include <private/tdympfaoimpl.h>
+#include <private/tdympfaosalinitytsimpl.h>
+#include <private/tdydiscretizationimpl.h>
+
+//#define DEBUG
+#if defined(DEBUG)
+PetscInt icount_f = 0;
+PetscInt icount_j = 0;
+PetscInt max_count = 5;
+#endif
+
+/* -------------------------------------------------------------------------- */
+PetscErrorCode TDyMPFAOIFunction_Vertices_Salinity(Vec Ul, Vec R, void *ctx) {
+
+  TDy tdy = (TDy)ctx;
+  TDyMPFAO *mpfao = tdy->context;
+  TDyMesh *mesh = mpfao->mesh;
+  TDyCell *cells = &mesh->cells;
+  TDyFace *faces = &mesh->faces;
+  TDyVertex *vertices = &mesh->vertices;
+  PetscReal *r;
+  PetscInt ivertex;
+  PetscInt dim;
+  PetscInt irow;
+  PetscInt cell_id_up, cell_id_dn;
+  PetscInt npitf_bc, nflux_in;
+  PetscReal den,fluxm,ukvr,fluxt,flow_rate;
+  PetscScalar *TtimesP_vec_ptr, *TtimesPsi_vec_ptr;
+  PetscErrorCode ierr;
+  PetscScalar *GravDis_ptr;
+
+  PetscFunctionBegin;
+  TDY_START_FUNCTION_TIMER()
+
+  DM dm;
+  ierr = TDyGetDM(tdy, &dm); CHKERRQ(ierr);
+  ierr = DMGetDimension(dm,&dim); CHKERRQ(ierr);
+
+  ierr = VecGetArray(R,&r); CHKERRQ(ierr);
+  ierr = VecGetArray(mpfao->TtimesP_vec,&TtimesP_vec_ptr); CHKERRQ(ierr);
+  ierr = VecGetArray(mpfao->TtimesPsi_vec,&TtimesPsi_vec_ptr); CHKERRQ(ierr); //CHANGE
+  ierr = VecGetArray(mpfao->GravDisVec, &GravDis_ptr); CHKERRQ(ierr);
+
+  for (ivertex=0; ivertex<mesh->num_vertices; ivertex++) {
+
+    if (!vertices->is_local[ivertex]) continue;
+
+    PetscInt *face_ids, num_faces;
+    PetscInt *subface_ids, num_subfaces;
+    ierr = TDyMeshGetVertexFaces(mesh, ivertex, &face_ids, &num_faces); CHKERRQ(ierr);
+    ierr = TDyMeshGetVertexSubfaces(mesh, ivertex, &subface_ids, &num_subfaces); CHKERRQ(ierr);
+
+    npitf_bc = vertices->num_boundary_faces[ivertex];
+    nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
+
+    PetscScalar TtimesP[nflux_in + npitf_bc], TtimesPsi[nflux_in + npitf_bc];
+
+    // Compute = T*P
+    for (irow=0; irow<nflux_in + npitf_bc; irow++) {
+
+      PetscInt face_id = face_ids[irow];
+      PetscInt subface_id = subface_ids[irow];
+      PetscInt num_subfaces = 4;
+
+      if (!faces->is_local[face_id]) continue;
+
+      TtimesP[irow] = TtimesP_vec_ptr[face_id*num_subfaces + subface_id];
+      TtimesPsi[irow] = TtimesPsi_vec_ptr[face_id*num_subfaces + subface_id];
+
+
+      //
+      // fluxm_ij = rho_ij * (kr/mu)_{ij,upwind} * [ T ] *  [ P+rho*g*z ]^T
+      // where
+      //      rho_ij = 0.5*(rho_i + rho_j)
+      //      (kr/mu)_{ij,upwind} = (kr/mu)_{i} if velocity is from i to j
+      //                          = (kr/mu)_{j} otherwise
+      //      T includes product of K and A_{ij}
+      PetscInt *cell_ids, num_cells;
+      ierr = TDyMeshGetFaceCells(mesh, face_id, &cell_ids, &num_cells); CHKERRQ(ierr);
+
+      cell_id_up = cell_ids[0];
+      cell_id_dn = cell_ids[1];
+
+      if (TtimesP[irow] < 0.0) { // up ---> dn
+                                 // Is the cell_id_up an internal or boundary cell?
+        if (cell_id_up >= 0) {
+          ukvr = mpfao->Kr[cell_id_up]/mpfao->vis[cell_id_up]; //vis based on salinity
+        }
+        else {
+          ukvr = mpfao->Kr_bnd[-cell_id_up-1]/mpfao->vis_bnd[-cell_id_up-1];
+        }
+      }
+      else {
+        // Is the cell_id_dn an internal or boundary cell?
+        if (cell_id_dn >= 0) {
+          ukvr = mpfao->Kr[cell_id_dn]/mpfao->vis[cell_id_dn];
+        }
+        else {
+          ukvr = mpfao->Kr_bnd[-cell_id_dn-1]/mpfao->vis_bnd[-cell_id_dn-1];
+        }
+      }
+
+      PetscReal den_aveg = 0.0;
+      if (cell_id_up>=0) {
+        den_aveg += mpfao->rho[cell_id_up];
+      } else {
+        den_aveg += mpfao->rho_bnd[-cell_id_up-1];
+      }
+
+      if (cell_id_dn>=0) {
+        den_aveg += mpfao->rho[cell_id_dn];
+      } else {
+        den_aveg += mpfao->rho_bnd[-cell_id_dn-1];
+      }
+
+      den_aveg *= 0.5;
+
+      PetscReal G = GravDis_ptr[face_id*num_subfaces + subface_id];
+
+      flow_rate = ukvr*(-TtimesP[irow]); // flow_rate is darcy flux times area
+
+      fluxm = 0.0; //den_aveg*flow_rate;
+      fluxt = den_aveg*flow_rate;  //Advection term
+
+      // Diffusion term in transport equation?
+      fluxt += -TtimesPsi[irow];
+      fluxm += - pow(den_aveg,2.0) * ukvr * G;
+
+      // fluxm > 0 implies flow is from 'up' to 'dn'
+      if (cell_id_up >= 0 && cells->is_local[cell_id_up]) {
+        r[cell_id_up*2]   += fluxm;   //check index here
+        r[cell_id_up*2+1] += fluxt;
+      }
+      if (cell_id_dn >=0 && cells->is_local[cell_id_dn]) {
+        r[cell_id_dn*2]   -= fluxm;
+        r[cell_id_dn*2+1] -= fluxt;
+      }
+    }
+  }
+
+  ierr = VecRestoreArray(R,&r); CHKERRQ(ierr);
+  ierr = VecRestoreArray(mpfao->TtimesP_vec,&TtimesP_vec_ptr); CHKERRQ(ierr);
+  ierr = VecRestoreArray(mpfao->TtimesPsi_vec,&TtimesPsi_vec_ptr); CHKERRQ(ierr);
+  ierr = VecRestoreArray(mpfao->GravDisVec, &GravDis_ptr); CHKERRQ(ierr);
+
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(0);
+}
+
+/* -------------------------------------------------------------------------- */
+PetscErrorCode TDyMPFAOIFunction_Salinity(TS ts,PetscReal t,Vec U,Vec U_t,Vec R,void *ctx) {
+
+  TDy       tdy   = (TDy)ctx;
+  TDyMPFAO *mpfao = tdy->context;
+  TDyMesh  *mesh  = mpfao->mesh;
+  TDyCell  *cells = &mesh->cells;
+  DM        dm;
+  Vec       Ul;
+  PetscReal *du_dt,*r,*u_p;
+  PetscErrorCode ierr;
+
+  PetscFunctionBegin;
+  TDY_START_FUNCTION_TIMER()
+
+  ierr = TSGetDM(ts,&dm); CHKERRQ(ierr);
+
+  //#if defined(DEBUG)
+  PetscViewer viewer;
+  // char word[32];
+  // sprintf(word,"U%d.vec",icount_f);
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"U2.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(U,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+  //#endif
+
+  ierr = DMGetLocalVector(dm,&Ul); CHKERRQ(ierr);
+  ierr = TDyGlobalToLocal(tdy,U,Ul); CHKERRQ(ierr);
+
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"Ul.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(Ul,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+
+  ierr = VecZeroEntries(R); CHKERRQ(ierr);
+
+  // Update the auxillary variables based on the current iterate
+  ierr = VecGetArray(Ul,&u_p); CHKERRQ(ierr);
+  ierr = TDyUpdateState(tdy,u_p, mesh->num_cells); CHKERRQ(ierr);
+  //  ierr = VecRestoreArray(Ul,&U_p); CHKERRQ(ierr);
+
+  ierr = TDyMPFAO_SetBoundaryPressure(tdy,Ul); CHKERRQ(ierr);
+  ierr = TDyMPFAO_SetBoundarySalinity(tdy,Ul); CHKERRQ(ierr); //write concentration
+  ierr = TDyMPFAOUpdateBoundaryState(tdy); CHKERRQ(ierr);
+  ierr = MatMult(mpfao->Trans_mat,mpfao->P_vec,mpfao->TtimesP_vec);
+  ierr = MatMult(mpfao->Psi_Trans_mat,mpfao->Psi_vec,mpfao->TtimesPsi_vec); // TODO: multiply in sat
+
+  //#if 0
+  // PetscViewer viewer;
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"Psi_Trans_mat.mat",&viewer); CHKERRQ(ierr);
+  ierr = MatView(mpfao->Psi_Trans_mat,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"Psi_TtimesP_vec.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(mpfao->TtimesPsi_vec,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"Psi_vec.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(mpfao->Psi_vec,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"P_vec.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(mpfao->P_vec,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+  //#endif
+
+  // Fluxes
+  ierr = TDyMPFAOIFunction_Vertices_Salinity(Ul,R,ctx); CHKERRQ(ierr);
+
+  ierr = VecGetArray(U_t,&du_dt); CHKERRQ(ierr);
+  ierr = VecGetArray(R,&r); CHKERRQ(ierr);
+
+  PetscInt c,cStart,cEnd;
+  ierr = DMPlexGetHeightStratum(dm,0,&cStart,&cEnd); CHKERRQ(ierr);
+  PetscReal p[cEnd-cStart], dp_dt[cEnd-cStart],
+            Psi[cEnd-cStart], dPsi_dt[cEnd-cStart];
+
+  for (c=0;c<cEnd-cStart;c++) {
+    dp_dt[c]    = du_dt[c*2];
+    p[c]        = u_p[c*2];
+    dPsi_dt[c] = du_dt[c*2+1];
+    Psi[c]     = u_p[c*2+1];
+  }
+
+  MaterialProp *matprop = tdy->matprop;
+
+  PetscReal dporosity_dP = 0.0;
+  PetscReal dporosity_dPsi = 0.0;
+  PetscReal dS_dPsi = 0.0;
+  PetscReal dPsi_dP = 0.0;
+  PetscReal dmass_dP,dmass_dPsi;
+  PetscInt icell;
+
+  // Accumulation and source/sink contributions
+  for (icell=0;icell<mesh->num_cells;icell++){
+
+    if (!cells->is_local[icell]) break;
+
+    // A_M = d(rho*phi*s)/dP * dP_dtime * Vol + d(rho*phi*s)/dT * dT_dtime * Vol //change
+    dmass_dP = mpfao->rho[icell]       * dporosity_dP           * mpfao->S[icell] +
+               mpfao->drho_dP[icell]   * mpfao->porosity[icell] * mpfao->S[icell] +
+               mpfao->rho[icell]       * mpfao->porosity[icell] * mpfao->dS_dP[icell];
+    dmass_dPsi = mpfao->rho[icell]       * dporosity_dPsi         * mpfao->S[icell] +
+                 mpfao->drho_dPsi[icell] * mpfao->porosity[icell] * mpfao->S[icell] +
+                 mpfao->rho[icell]       * mpfao->porosity[icell] * dS_dPsi;
+
+    //CHANGE
+    // A_E = [d(rho*phi*s*U)/dP + d(rho*(1-phi)*T)/dP] * dP_dtime *Vol + //change
+    //       [d(rho*phi*s*U)/dT + d(rho*(1-phi)*T)/dT] * dT_dtime *Vol
+    // denergy_dP = dden_dP     * por        * sat     * u     + &
+    //              den         * dpor_dP    * sat     * u     + &
+    //              den         * por        * dsat_dP * u     + &
+    //              den         * por        * sat     * du_dP + &
+    //              rock_dencpr * (-dpor_dP) * temp
+
+    // denergy_dt = dden_dt     * por        * sat     * u     + &
+    //              den         * dpor_dt    * sat     * u     + &
+    //              den         * por        * dsat_dt * u     + &
+    //              den         * por        * sat     * du_dt + &
+    //              rock_dencpr * (-dpor_dt) * temp            + &
+    //              rock_dencpr * (1-por)
+
+    PetscReal dtrans_dP, dtrans_dPsi;
+
+    dtrans_dP =
+      mpfao->drho_dP[icell] * mpfao->porosity[icell] * mpfao->S[icell]     * Psi[icell] +
+      mpfao->rho[icell]     * dporosity_dP           * mpfao->S[icell]     * Psi[icell] +
+      mpfao->rho[icell]     * mpfao->porosity[icell] * mpfao->dS_dP[icell] * Psi[icell] +
+      mpfao->rho[icell]     * mpfao->porosity[icell] * mpfao->S[icell]     * dPsi_dP;
+    dtrans_dPsi =
+      mpfao->drho_dPsi[icell] * mpfao->porosity[icell] * mpfao->S[icell] * Psi[icell] +
+      mpfao->rho[icell]       * dporosity_dPsi         * mpfao->S[icell] * Psi[icell] +
+      mpfao->rho[icell]       * mpfao->porosity[icell] * dS_dPsi         * Psi[icell] +
+      mpfao->rho[icell]       * 0.1                    * 1.0;
+    //                          mpfao->porosity[icell]   mpfao->S[icell]
+
+    r[icell*2]   += dmass_dP * dp_dt[icell] * cells->volume[icell] + dmass_dPsi * dPsi_dt[icell] * cells->volume[icell];
+    r[icell*2+1] += dtrans_dP * dp_dt[icell] * cells->volume[icell] + dtrans_dPsi * dPsi_dt[icell] * cells->volume[icell];
+    r[icell*2]   -= mpfao->source_sink[icell] * cells->volume[icell];
+    r[icell*2+1] -= mpfao->salinity_source_sink[icell] * cells->volume[icell];
+  }
+
+  /* Cleanup */
+  ierr = VecRestoreArray(Ul,&u_p); CHKERRQ(ierr); //chck
+  ierr = VecRestoreArray(U_t,&du_dt); CHKERRQ(ierr); //check
+  ierr = VecRestoreArray(R,&r); CHKERRQ(ierr);
+  ierr = DMRestoreLocalVector(dm,&Ul); CHKERRQ(ierr);
+
+  //PetscViewer viewer;
+  // sprintf(word,"Function%d.vec");
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"Function.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(R,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"dudt.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(U_t,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+  //  icount_f++;
+
+  TDY_STOP_FUNCTION_TIMER()
+  PetscFunctionReturn(0);
+}
+

--- a/src/fv/mpfao/tdympfao_snes_salinity.c
+++ b/src/fv/mpfao/tdympfao_snes_salinity.c
@@ -252,7 +252,7 @@ PetscErrorCode TDyMPFAOSNESFunction_Salinity(SNES snes,Vec U,Vec R,void *ctx) {
   ierr = TDyUpdateState(tdy, soln, mesh->num_cells); CHKERRQ(ierr);
 
   ierr = TDyMPFAO_SetBoundaryPressure(tdy,Ul); CHKERRQ(ierr);
-  ierr = TDyMPFAO_SetBoundarySalinity(tdy,Ul); CHKERRQ(ierr);
+  ierr = TDyMPFAO_SetBoundarySalineConcentration(tdy,Ul); CHKERRQ(ierr);
   ierr = TDyMPFAOUpdateBoundaryState(tdy); CHKERRQ(ierr);
   ierr = MatMult(mpfao->Trans_mat,mpfao->P_vec,mpfao->TtimesP_vec);
   ierr = MatMult(mpfao->Psi_Trans_mat,mpfao->Psi_vec,mpfao->TtimesPsi_vec);

--- a/src/fv/mpfao/tdympfao_th_ts.c
+++ b/src/fv/mpfao/tdympfao_th_ts.c
@@ -57,7 +57,7 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_TH(Vec Ul, Vec R, void *ctx) {
     npitf_bc = vertices->num_boundary_faces[ivertex];
     nflux_in = vertices->num_faces[ivertex] - vertices->num_boundary_faces[ivertex];
 
-     PetscScalar TtimesP[nflux_in + npitf_bc], Temp_TtimesP[nflux_in + npitf_bc];
+    PetscScalar TtimesP[nflux_in + npitf_bc], Temp_TtimesP[nflux_in + npitf_bc];
 
     // Compute = T*P
     for (irow=0; irow<nflux_in + npitf_bc; irow++) {
@@ -147,10 +147,10 @@ PetscErrorCode TDyMPFAOIFunction_Vertices_TH(Vec Ul, Vec R, void *ctx) {
 /* -------------------------------------------------------------------------- */
 PetscErrorCode TDyMPFAOIFunction_TH(TS ts,PetscReal t,Vec U,Vec U_t,Vec R,void *ctx) {
 
-  TDy      tdy = (TDy)ctx;
-  TDyMPFAO *mpfao = tdy->context;
-  TDyMesh       *mesh = mpfao->mesh;
-  TDyCell       *cells = &mesh->cells;
+  TDy        tdy = (TDy)ctx;
+  TDyMPFAO  *mpfao = tdy->context;
+  TDyMesh   *mesh = mpfao->mesh;
+  TDyCell   *cells = &mesh->cells;
   PetscReal *du_dt,*r,*u_p;
   PetscErrorCode ierr;
 

--- a/src/fv/mpfao/tdympfao_utils.c
+++ b/src/fv/mpfao/tdympfao_utils.c
@@ -815,6 +815,59 @@ PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
   PetscFunctionReturn(0);
 }
 
+/* -------------------------------------------------------------------------- */
+PetscErrorCode TDyMPFAO_SetBoundaryConcentration(TDy tdy, Vec Ul) {
+
+  TDyMesh *mesh = tdy->mesh;
+  TDyFace *faces = &mesh->faces;
+  PetscErrorCode ierr;
+  PetscInt dim, ncells;
+  PetscInt psi_bnd_idx, cell_id, iface;
+  PetscReal *psi, *psi_vec_ptr, *u_p;
+  PetscInt c, cStart, cEnd;
+
+  PetscFunctionBegin;
+
+  ierr = DMPlexGetHeightStratum(tdy->dm,0,&cStart,&cEnd); CHKERRQ(ierr);
+  ierr = PetscMalloc((cEnd-cStart)*sizeof(PetscReal),&psi);CHKERRQ(ierr);
+
+  ierr = VecGetArray(Ul,&u_p); CHKERRQ(ierr);
+  ierr = VecGetArray(tdy->Psi_vec,&psi_vec_ptr); CHKERRQ(ierr);
+
+  for (c=0;c<cEnd-cStart;c++) {
+    psi[c] = u_p[c*2+1];
+  }
+
+  ncells = mesh->num_cells;
+
+  ierr = DMGetDimension(tdy->dm, &dim); CHKERRQ(ierr);
+
+  for (iface=0; iface<mesh->num_faces; iface++) {
+
+    if (faces->is_internal[iface]) continue;
+
+    PetscInt *cell_ids, num_cells;
+    ierr = TDyMeshGetFaceCells(mesh, iface, &cell_ids, &num_cells); CHKERRQ(ierr);
+
+    if (cell_ids[0] >= 0) {
+      cell_id = cell_ids[0];
+      psi_bnd_idx = -cell_ids[1] - 1;
+    } else {
+      cell_id = cell_ids[1];
+      psi_bnd_idx = -cell_ids[0] - 1;
+    }
+
+    tdy->Psi_BND[t_bnd_idx] = psi[cell_id];
+
+    psi_vec_ptr[t_bnd_idx + ncells] = tdy->Psi_BND[t_bnd_idx];
+  }
+
+  ierr = VecRestoreArray(Ul,&u_p); CHKERRQ(ierr);
+  ierr = VecRestoreArray(tdy->Psi_vec,&psi_vec_ptr); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode ExtractSubGmatrix(TDyMPFAO *mpfao, PetscInt cell_id,
                                  PetscInt sub_cell_id, PetscInt dim,
                                  PetscReal **Gmatrix) {

--- a/src/fv/mpfao/tdympfao_utils.c
+++ b/src/fv/mpfao/tdympfao_utils.c
@@ -864,7 +864,14 @@ PetscErrorCode TDyMPFAO_SetBoundarySalinity(TDy tdy, Vec Ul) {
       psi_bnd_idx = -cell_ids[0] - 1;
     }
 
-    mpfao->Psi_bnd[psi_bnd_idx] = psi[cell_id];
+    if (ConditionsHasBoundarySalinity(tdy->conditions)) {
+      ierr = ConditionsComputeBoundarySalinity(tdy->conditions, 1,
+                                               (faces->centroid[iface].X),
+                                               &(mpfao->Psi_bnd[psi_bnd_idx]));
+      CHKERRQ(ierr);
+    } else {
+      mpfao->Psi_bnd[psi_bnd_idx] = psi[cell_id];
+    }
 
     psi_vec_ptr[psi_bnd_idx + ncells] = mpfao->Psi_bnd[psi_bnd_idx];
   }

--- a/src/fv/mpfao/tdympfao_utils.c
+++ b/src/fv/mpfao/tdympfao_utils.c
@@ -820,7 +820,7 @@ PetscErrorCode TDyMPFAO_SetBoundaryTemperature(TDy tdy, Vec Ul) {
 }
 
 /* -------------------------------------------------------------------------- */
-PetscErrorCode TDyMPFAO_SetBoundarySalinity(TDy tdy, Vec Ul) {
+PetscErrorCode TDyMPFAO_SetBoundarySalineConcentration(TDy tdy, Vec Ul) {
 
   TDyMPFAO *mpfao = tdy->context;
   TDyMesh *mesh = mpfao->mesh;
@@ -864,10 +864,10 @@ PetscErrorCode TDyMPFAO_SetBoundarySalinity(TDy tdy, Vec Ul) {
       psi_bnd_idx = -cell_ids[0] - 1;
     }
 
-    if (ConditionsHasBoundarySalinity(tdy->conditions)) {
-      ierr = ConditionsComputeBoundarySalinity(tdy->conditions, 1,
-                                               (faces->centroid[iface].X),
-                                               &(mpfao->Psi_bnd[psi_bnd_idx]));
+    if (ConditionsHasBoundarySalineConcentration(tdy->conditions)) {
+      ierr = ConditionsComputeBoundarySalineConcentration(tdy->conditions, 1,
+                                                          (faces->centroid[iface].X),
+                                                          &(mpfao->Psi_bnd[psi_bnd_idx]));
       CHKERRQ(ierr);
     } else {
       mpfao->Psi_bnd[psi_bnd_idx] = psi[cell_id];

--- a/src/materials/tdyeos.c
+++ b/src/materials/tdyeos.c
@@ -43,7 +43,6 @@ static PetscErrorCode ComputeWaterDensity_BatzleWang(
   PetscFunctionBegin;
 
   PetscReal pw;
-  PetscReal dpw_drho;
   PetscReal Pa_to_MPa = 1.e-6;
 
   pw = 1 + 1.e-6*(-80.*T - 3.3 * pow(T,2) +0.00175*pow(T,3)+489. * P*Pa_to_MPa - 2.*T *P*Pa_to_MPa + 0.016 *P*Pa_to_MPa *pow(T,2) -
@@ -104,7 +103,9 @@ static PetscErrorCode ComputeWaterViscosity_BatzleWang(
 
   PetscFunctionBegin;
 
-  *vis = 0.1 + 0.333 * S + (1.65 + 91.9 *pow(S,3))*exp((-0.42*pow((pow(S,0.8)-0.17),2)+0.45)*pow(T,0.8));
+  *vis = 0.1 +
+         0.333 * S +
+         (1.65 + 91.9 *pow(S,3))*exp((-0.42*pow((pow(S,0.8)-0.17),2)+0.045)*pow(T,0.8));
   *vis *= 1e-3;
 
   PetscFunctionReturn(0);

--- a/src/materials/tdyeos.c
+++ b/src/materials/tdyeos.c
@@ -6,7 +6,7 @@ static PetscErrorCode ComputeWaterDensity_Constant(PetscReal p, PetscReal *den, 
 
   PetscFunctionBegin;
 
-  *den = 997.205;
+  *den = 998.0;
   *dden_dP = 0.0;
   *d2den_dP2 = 0.0;
 

--- a/src/materials/tdyeos.c
+++ b/src/materials/tdyeos.c
@@ -50,21 +50,25 @@ static PetscErrorCode ComputeWaterDensity_BatzleWang(
 
   pw = 1 + 1.e-6*(-80.*T - 3.3 * pow(T,2) +0.00175*pow(T,3)+489. * P*Pa_to_MPa - 2.*T *P*Pa_to_MPa + 0.016 *P*Pa_to_MPa *pow(T,2) -
 		  1.3e-5*pow(T,3)*P*Pa_to_MPa - 0.333 * pow(P*Pa_to_MPa,2) - 0.002*T *pow(P*Pa_to_MPa,2));
-  pw = pw * 1000.;
+  pw *= 1000.;
+
   *den = pw + S*(0.668 + 0.44*S + 1e-6 * (300. *P*Pa_to_MPa - 2400.*P*Pa_to_MPa*S +T*(80.*3.*T-3300.*S -
  						       13.*P*Pa_to_MPa + 47.*P*Pa_to_MPa*S)))*1000.;
-  // *den = 998.;
 
   dpw_drho = 1.6e-6 * (489. - 2.*T + 0.016 * pow(T,2) - 1.3e-5 * pow(T,3) - 2. *0.333 * P * Pa_to_MPa - 0.0002 * 2 *T * P);
   dpw_drho = dpw_drho * 1000.;
 
   *dden_dP = dpw_drho + 1000. * S * 1e-6 * (300. - 2400. * S - T * 13. + T * 47. * S)*Pa_to_MPa;
 
-  *dden_dPsi = (0.668 + 0.44 * d2S + 1e-6 * 300 * P*Pa_to_MPa -
+  *dden_dPsi = (0.668 * dS +
+                0.44 * d2S +
+                1e-6 * 300 * P*Pa_to_MPa * dS -
                 1e-6 * 2400. * P*Pa_to_MPa * d2S +
-                1e-6 * pow(T,2) * 3. - d2S * 1e-6 * T * 3300. -
-                1e-6 * T * 13. * P*Pa_to_MPa +
-                d2S * 1e-6 * 47 * T * P*Pa_to_MPa) * 1000.;
+                1e-6 * 80 * T * dS +
+                1e-6 * 3 * pow(T,2) * dS -
+                1e-6 * 3300. * T * d2S -
+                1e-6 * 13. * T * P*Pa_to_MPa * dS +
+                1e-6 * 47 * T * P*Pa_to_MPa) * 1000. * d2S;
   *d2den_dP2 = 0.0;
   PetscFunctionReturn(0);
 }
@@ -115,8 +119,8 @@ static PetscErrorCode ComputeWaterViscosity_Constant(PetscReal p,
 }
 
 static PetscErrorCode ComputeWaterViscosity_BatzleWang(
-    PetscReal p, PetscReal T, PetscReal S, PetscReal *vis,
-    PetscReal *dvis_dP, PetscReal *dvis_dPsi,
+    PetscReal p, PetscReal T, PetscReal S, PetscReal dS,
+    PetscReal *vis, PetscReal *dvis_dP, PetscReal *dvis_dPsi,
     PetscReal *d2vis_dP2) {
 
   PetscFunctionBegin;
@@ -132,7 +136,7 @@ static PetscErrorCode ComputeWaterViscosity_BatzleWang(
 
 // FIXME: S here seems to mean "saline concentration", not "saturation".
 PetscErrorCode EOSComputeWaterViscosity(EOS *eos,
-  PetscReal p, PetscReal T, PetscReal S,
+  PetscReal p, PetscReal T, PetscReal S, PetscReal dS,
   PetscReal *vis, PetscReal *dvis_dP, PetscReal *dvis_dPsi,
   PetscReal *d2vis_dP2) {
 

--- a/src/materials/tdyeos.c
+++ b/src/materials/tdyeos.c
@@ -37,9 +37,39 @@ static PetscErrorCode ComputeWaterDensity_Exponential(PetscReal p, PetscReal *de
 }
 
 /* ---------------------------------------------------------------- */
-PetscErrorCode EOSComputeWaterDensity(EOS *eos, PetscReal p,
-                                      PetscReal *den, PetscReal *dden_dP,
-                                      PetscReal *d2den_dP2) {
+static PetscErrorCode ComputeWaterDensity_BatzleWang(
+  PetscReal P, PetscReal T, PetscReal S,
+  PetscReal dS, PetscReal d2S, PetscReal *den, PetscReal *dden_dP,
+  PetscReal *dden_dPsi, PetscReal *d2den_dP2) {
+
+  PetscFunctionBegin;
+
+  PetscReal pw;
+  PetscReal dpw_drho;
+  PetscReal Pa_to_MPa = 1.e-6;
+
+  pw = 1 + 1.e-6*(-80.*T - 3.3 * pow(T,2) +0.00175*pow(T,3)+489. * P*Pa_to_MPa - 2.*T *P*Pa_to_MPa + 0.016 *P*Pa_to_MPa *pow(T,2) -
+		  1.3e-5*pow(T,3)*P*Pa_to_MPa - 0.333 * pow(P*Pa_to_MPa,2) - 0.002*T *pow(P*Pa_to_MPa,2));
+  pw = pw * 1000.;
+  *den = pw + S*(0.668 + 0.44*S + 1e-6 * (300. *P*Pa_to_MPa - 2400.*P*Pa_to_MPa*S +T*(80.*3.*T-3300.*S -
+ 						       13.*P*Pa_to_MPa + 47.*P*Pa_to_MPa*S)))*1000.;
+  // *den = 998.;
+
+  dpw_drho = 1.6e-6 * (489. - 2.*T + 0.016 * pow(T,2) - 1.3e-5 * pow(T,3) - 2. *0.333 * P * Pa_to_MPa - 0.0002 * 2 *T * P);
+  dpw_drho = dpw_drho * 1000.;
+
+  *dden_dP = dpw_drho + 1000. * S * 1e-6 * (300. - 2400. * S + T * 13. + T * 47. * S);
+
+  *dden_dPsi = (0.668 + 0.44 * d2S + 1e-6 * 300 * P - 1e-6 * 2400. * P * d2S + 1e-6 * pow(T,2) * 80. * 3. - d2S * 1e-6 * T * 3300. - 1e-6 * T * 13. * P + d2S * 1e-6 * 47 * T * P) * 1000.;
+  *d2den_dP2 = 0.0;
+  PetscFunctionReturn(0);
+}
+
+/* ---------------------------------------------------------------- */
+PetscErrorCode EOSComputeWaterDensity(EOS *eos,
+  PetscReal p, PetscReal T, PetscReal S,
+  PetscReal *den, PetscReal *dden_dP, PetscReal *dden_dPsi,
+  PetscReal *d2den_dP2) {
 
   PetscErrorCode ierr;
 
@@ -48,9 +78,16 @@ PetscErrorCode EOSComputeWaterDensity(EOS *eos, PetscReal p,
   switch (eos->density_type) {
     case WATER_DENSITY_CONSTANT :
       ierr = ComputeWaterDensity_Constant(p,den,dden_dP,d2den_dP2); CHKERRQ(ierr);
+      *dden_dPsi = 0.0;
       break;
     case WATER_DENSITY_EXPONENTIAL :
       ierr = ComputeWaterDensity_Exponential(p,den,dden_dP,d2den_dP2); CHKERRQ(ierr);
+      *dden_dPsi = 0.0;
+      break;
+    case WATER_DENSITY_BATZLE_AND_WANG :
+//      ierr = ComputeWaterDensity_BatzleWang(p,T,S,dS,d2S,den,dden_dP,dden_dPsi,d2den_dP2); CHKERRQ(ierr);
+      ierr = ComputeWaterDensity_Constant(p,den,dden_dP,d2den_dP2); CHKERRQ(ierr);
+      *dden_dPsi = 0.0;
       break;
     default:
       SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"Unknown water density function");
@@ -74,8 +111,26 @@ static PetscErrorCode ComputeWaterViscosity_Constant(PetscReal p,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode EOSComputeWaterViscosity(EOS *eos, PetscReal p, PetscReal *vis,
-                                        PetscReal *dvis_dP, PetscReal *d2vis_dP2) {
+static PetscErrorCode ComputeWaterViscosity_BatzleWang(
+    PetscReal p, PetscReal T, PetscReal S, PetscReal *vis,
+    PetscReal *dvis_dP, PetscReal *dvis_dPsi,
+    PetscReal *d2vis_dP2) {
+
+  PetscFunctionBegin;
+
+  *vis = 0.1 + 0.333 * S + (1.65 + 91.9 *pow(S,3))*exp((-0.42*pow((pow(S,0.8)-0.17),2)+0.45)*pow(T,0.8));
+  *vis = *vis * 1e-3;
+  *dvis_dP = 0.0;
+  *dvis_dPsi = 0.0;
+  *d2vis_dP2 = 0.0;
+
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode EOSComputeWaterViscosity(EOS *eos,
+  PetscReal p, PetscReal T, PetscReal S,
+  PetscReal *vis, PetscReal *dvis_dP, PetscReal *dvis_dPsi,
+  PetscReal *d2vis_dP2) {
 
   PetscErrorCode ierr;
 
@@ -84,6 +139,9 @@ PetscErrorCode EOSComputeWaterViscosity(EOS *eos, PetscReal p, PetscReal *vis,
   switch (eos->viscosity_type) {
     case WATER_VISCOSITY_CONSTANT :
       ierr = ComputeWaterViscosity_Constant(p,vis,dvis_dP,d2vis_dP2); CHKERRQ(ierr);
+      break;
+    case WATER_VISCOSITY_BATZLE_AND_WANG :
+      ierr = ComputeWaterViscosity_BatzleWang(p,T,S,vis,dvis_dP,dvis_dPsi,d2vis_dP2); CHKERRQ(ierr);
       break;
     default:
       SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"Unknown water viscosity function");
@@ -123,6 +181,18 @@ PetscErrorCode EOSComputeWaterEnthalpy(EOS *eos, PetscReal t, PetscReal p,
       SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"Unknown water enthalpy function");
       break;
   }
+
+  PetscFunctionReturn(0);
+}
+
+/* ---------------------------------------------------------------- */
+PetscErrorCode EOSComputeSalinityFraction(EOS* eos, PetscReal Psi, PetscReal mw, PetscReal den, PetscReal *m_nacl, PetscReal *dm_nacl, PetscReal *d2m_nacl) {
+
+  PetscFunctionBegin;
+
+  *m_nacl = (Psi * mw) / ((Psi*mw) + 999.);
+  *dm_nacl = (999. * mw) / pow(((Psi*mw) + 999.),2);
+  *d2m_nacl = (1998. * Psi * pow(mw,2)) / pow(((Psi*mw) + 999.),3);
 
   PetscFunctionReturn(0);
 }

--- a/src/materials/tdyeos.c
+++ b/src/materials/tdyeos.c
@@ -186,7 +186,9 @@ PetscErrorCode EOSComputeWaterEnthalpy(EOS *eos, PetscReal t, PetscReal p,
 }
 
 /* ---------------------------------------------------------------- */
-PetscErrorCode EOSComputeSalinityFraction(EOS* eos, PetscReal Psi, PetscReal mw, PetscReal den, PetscReal *m_nacl, PetscReal *dm_nacl, PetscReal *d2m_nacl) {
+PetscErrorCode EOSComputeSalinityFraction(EOS* eos,
+  PetscReal Psi, PetscReal mw, PetscReal den,
+  PetscReal *m_nacl, PetscReal *dm_nacl, PetscReal *d2m_nacl) {
 
   PetscFunctionBegin;
 

--- a/src/tdyconditions.c
+++ b/src/tdyconditions.c
@@ -19,7 +19,7 @@ PetscErrorCode ConditionsDestroy(Conditions* conditions) {
   ConditionsSetBoundaryPressure(conditions, NULL, NULL, NULL);
   ConditionsSetBoundaryVelocity(conditions, NULL, NULL, NULL);
   ConditionsSetBoundaryTemperature(conditions, NULL, NULL, NULL);
-  ConditionsSetBoundarySalinity(conditions, NULL, NULL, NULL);
+  ConditionsSetBoundarySalineConcentration(conditions, NULL, NULL, NULL);
   TDyFree(conditions);
   PetscFunctionReturn(0);
 }
@@ -150,16 +150,16 @@ PetscErrorCode ConditionsSetBoundaryTemperature(Conditions *conditions,
 /// @param [in] context A context pointer to be passed to f
 /// @param [in] f A function that computes the boundary salinity forcing at a given number of points
 /// @param [in] dtor A function that destroys the context when conditions is destroyed (can be NULL).
-PetscErrorCode ConditionsSetBoundarySalinity(Conditions *conditions,
-                                             void *context,
-                                             PetscErrorCode (*f)(void*,PetscInt,PetscReal*,PetscReal*),
-                                             PetscErrorCode (*dtor)(void*)) {
+PetscErrorCode ConditionsSetBoundarySalineConcentration(Conditions *conditions,
+                                                        void *context,
+                                                        PetscErrorCode (*f)(void*,PetscInt,PetscReal*,PetscReal*),
+                                                        PetscErrorCode (*dtor)(void*)) {
   PetscFunctionBegin;
-  if (conditions->boundary_salinity_context && conditions->boundary_salinity_dtor)
-    conditions->boundary_salinity_dtor(conditions->boundary_salinity_context);
-  conditions->boundary_salinity_context = context;
-  conditions->compute_boundary_salinity = f;
-  conditions->boundary_salinity_dtor = dtor;
+  if (conditions->boundary_saline_conc_context && conditions->boundary_saline_conc_dtor)
+    conditions->boundary_saline_conc_dtor(conditions->boundary_saline_conc_context);
+  conditions->boundary_saline_conc_context = context;
+  conditions->compute_boundary_saline_conc = f;
+  conditions->boundary_saline_conc_dtor = dtor;
   PetscFunctionReturn(0);
 }
 
@@ -191,8 +191,8 @@ PetscBool ConditionsHasBoundaryTemperature(Conditions *conditions) {
   return (conditions->compute_boundary_temperature != NULL);
 }
 
-PetscBool ConditionsHasBoundarySalinity(Conditions *conditions) {
-  return (conditions->compute_boundary_salinity != NULL);
+PetscBool ConditionsHasBoundarySalineConcentration(Conditions *conditions) {
+  return (conditions->compute_boundary_saline_conc != NULL);
 }
 
 PetscErrorCode ConditionsComputeForcing(Conditions *conditions, PetscInt n,
@@ -241,11 +241,11 @@ PetscErrorCode ConditionsComputeBoundaryTemperature(Conditions *conditions,
                                                   n, x, T);
 }
 
-PetscErrorCode ConditionsComputeBoundarySalinity(Conditions *conditions,
-                                                 PetscInt n, PetscReal *x,
-                                                 PetscReal *S) {
-  return conditions->compute_boundary_salinity(conditions->boundary_salinity_context,
-                                               n, x, S);
+PetscErrorCode ConditionsComputeBoundarySalineConcentration(Conditions *conditions,
+                                                            PetscInt n, PetscReal *x,
+                                                            PetscReal *S) {
+  return conditions->compute_boundary_saline_conc(conditions->boundary_saline_conc_context,
+                                                  n, x, S);
 }
 
 static PetscErrorCode ConstantBoundaryFn(void *context,
@@ -295,15 +295,15 @@ PetscErrorCode ConditionsSetConstantBoundaryTemperature(Conditions *conditions,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode ConditionsSetConstantBoundarySalinity(Conditions *conditions,
-                                                     PetscReal S0) {
+PetscErrorCode ConditionsSetConstantBoundarySalineConcentration(Conditions *conditions,
+                                                                PetscReal S0) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   PetscReal *val;
   ierr = TDyAlloc(sizeof(PetscReal), &val); CHKERRQ(ierr);
   *val = S0;
-  ierr = ConditionsSetBoundarySalinity(conditions, val, ConstantBoundaryFn,
-                                       TDyFree); CHKERRQ(ierr);
+  ierr = ConditionsSetBoundarySalineConcentration(conditions, val, ConstantBoundaryFn,
+                                                  TDyFree); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -273,6 +273,8 @@ static PetscErrorCode SetDefaultOptions(TDy tdy) {
   options->soil_density=2650.;
   options->soil_specific_heat=1000.0;
   options->thermal_conductivity=1.0;
+  options->saline_molecular_weight = 58.44;
+  options->saline_diffusivity = 1.e-8;
 
   options->residual_saturation=0.15;
   options->gardner_n=0.5;
@@ -544,6 +546,7 @@ static PetscErrorCode ReadCommandLineOptions(TDy tdy) {
   ierr = PetscOptionsReal("-tdy_gravity", "Magnitude of gravity vector", NULL, options->gravity_constant, &options->gravity_constant, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsEnum("-tdy_water_density","Water density vertical profile", "TDySetWaterDensityType", TDyWaterDensityTypes, (PetscEnum)options->rho_type, (PetscEnum *)&options->rho_type, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsEnum("-tdy_water_viscosity","Water viscosity model", "TDySetWaterViscosityType", TDyWaterViscosityTypes, (PetscEnum)options->mu_type, (PetscEnum *)&options->mu_type, NULL); CHKERRQ(ierr);
+  ierr = PetscOptionsEnum("-tdy_water_enthalpy","Water enthalpy model", "TDySetWaterEnthalpyType", TDyWaterEnthalpyTypes, (PetscEnum)options->enthalpy_type, (PetscEnum *)&options->enthalpy_type, NULL); CHKERRQ(ierr);
 
   // Create source/sink/boundary conditions.
   ierr = ConditionsCreate(&tdy->conditions); CHKERRQ(ierr);
@@ -949,6 +952,13 @@ PetscErrorCode TDySetWaterViscosityType(TDy tdy, TDyWaterViscosityType vistype) 
   PetscValidPointer(tdy,1);
   PetscFunctionBegin;
   tdy->options.mu_type = vistype;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySetWaterEnthalpyType(TDy tdy, TDyWaterEnthalpyType enthtype) {
+  PetscValidPointer(tdy,1);
+  PetscFunctionBegin;
+  tdy->options.enthalpy_type = enthtype;
   PetscFunctionReturn(0);
 }
 
@@ -1934,7 +1944,7 @@ PetscErrorCode TDySetIJacobian(TS ts,TDy tdy) {
       ierr = TSSetIJacobian(ts,tdy->J,tdy->J,TDyMPFAOIJacobian_TH,tdy); CHKERRQ(ierr);
       break;
     case SALINITY:
-      ierr = TSSetIJacobian(ts,tdy->J,tdy->J,TDyMPFAOIJacobian,tdy); CHKERRQ(ierr);
+      //ierr = TSSetIJacobian(ts,tdy->J,tdy->J,TDyMPFAOIJacobian,tdy); CHKERRQ(ierr);
       break;
     }
     break;

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -1365,6 +1365,18 @@ PetscErrorCode TDySetBoundaryPressureTypeFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDySetBoundaryVelocityFunction(TDy tdy,
+                                              TDyVectorSpatialFunction f) {
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  WrapperStruct *wrapper;
+  ierr = TDyAlloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
+  wrapper->func = f;
+  ierr = ConditionsSetBoundaryVelocity(tdy->conditions, wrapper,
+                                       WrapperFunction, TDyFree); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode TDySetBoundaryTemperatureFunction(TDy tdy,
                                                  TDyScalarSpatialFunction f) {
   PetscErrorCode ierr;
@@ -1377,14 +1389,14 @@ PetscErrorCode TDySetBoundaryTemperatureFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetBoundaryVelocityFunction(TDy tdy,
-                                              TDyVectorSpatialFunction f) {
+PetscErrorCode TDySetBoundarySalinityFunction(TDy tdy,
+                                              TDyScalarSpatialFunction f) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   WrapperStruct *wrapper;
   ierr = TDyAlloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
   wrapper->func = f;
-  ierr = ConditionsSetBoundaryVelocity(tdy->conditions, wrapper,
+  ierr = ConditionsSetBoundarySalinity(tdy->conditions, wrapper,
                                        WrapperFunction, TDyFree); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
@@ -1419,6 +1431,16 @@ PetscErrorCode TDySelectBoundaryPressureFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode TDySelectBoundaryVelocityFunction(TDy tdy,
+                                                 const char *func_name) {
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  TDySpatialFunction f;
+  ierr = TDyGetFunction(func_name, &f); CHKERRQ(ierr);
+  ierr = TDySetBoundaryVelocityFunction(tdy, f); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode TDySelectBoundaryTemperatureFunction(TDy tdy,
                                                     const char *func_name) {
   PetscErrorCode ierr;
@@ -1429,13 +1451,13 @@ PetscErrorCode TDySelectBoundaryTemperatureFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySelectBoundaryVelocityFunction(TDy tdy,
+PetscErrorCode TDySelectBoundarySalinityFunction(TDy tdy,
                                                  const char *func_name) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   TDySpatialFunction f;
   ierr = TDyGetFunction(func_name, &f); CHKERRQ(ierr);
-  ierr = TDySetBoundaryVelocityFunction(tdy, f); CHKERRQ(ierr);
+  ierr = TDySetBoundarySalinityFunction(tdy, f); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -1389,15 +1389,15 @@ PetscErrorCode TDySetBoundaryTemperatureFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySetBoundarySalinityFunction(TDy tdy,
-                                              TDyScalarSpatialFunction f) {
+PetscErrorCode TDySetBoundarySalineConcentrationFunction(TDy tdy,
+                                                         TDyScalarSpatialFunction f) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   WrapperStruct *wrapper;
   ierr = TDyAlloc(sizeof(WrapperStruct), &wrapper); CHKERRQ(ierr);
   wrapper->func = f;
-  ierr = ConditionsSetBoundarySalinity(tdy->conditions, wrapper,
-                                       WrapperFunction, TDyFree); CHKERRQ(ierr);
+  ierr = ConditionsSetBoundarySalineConcentration(tdy->conditions, wrapper,
+                                                  WrapperFunction, TDyFree); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 
@@ -1451,13 +1451,13 @@ PetscErrorCode TDySelectBoundaryTemperatureFunction(TDy tdy,
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode TDySelectBoundarySalinityFunction(TDy tdy,
-                                                 const char *func_name) {
+PetscErrorCode TDySelectBoundarySalineConcenctrationFunction(TDy tdy,
+                                                             const char *func_name) {
   PetscErrorCode ierr;
   PetscFunctionBegin;
   TDySpatialFunction f;
   ierr = TDyGetFunction(func_name, &f); CHKERRQ(ierr);
-  ierr = TDySetBoundarySalinityFunction(tdy, f); CHKERRQ(ierr);
+  ierr = TDySetBoundarySalineConcentrationFunction(tdy, f); CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -274,7 +274,7 @@ static PetscErrorCode SetDefaultOptions(TDy tdy) {
   options->soil_specific_heat=1000.0;
   options->thermal_conductivity=1.0;
   options->saline_molecular_weight = 58.44;
-  options->saline_diffusivity = 1.e-8;
+  options->saline_diffusivity = 1.e-6;
 
   options->residual_saturation=0.15;
   options->gardner_n=0.5;

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -114,11 +114,19 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
           SETERRQ(comm,PETSC_ERR_USER,"SNES not supported for TH mode.");
           break;
         case SALINITY:
-          SETERRQ(comm,PETSC_ERR_USER,"SNES not supported for TH mode.");
           break;
       }
       break;
     case TDyTS:
+      switch (tdy->options.mode) {
+        case RICHARDS:
+          break;
+        case TH:
+          break;
+ 	      case SALINITY:
+       	  SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"TS not supported for SALINITY mode.");
+          break;
+      }
       break;
     default:
         SETERRQ(comm,PETSC_ERR_USER,"Unrecognized time integration method.");

--- a/src/tdydriver.c
+++ b/src/tdydriver.c
@@ -2,6 +2,7 @@
 #include <private/tdyrichardsimpl.h>
 #include <private/tdymaterialpropertiesimpl.h>
 #include <private/tdythimpl.h>
+#include <private/tdysalinityimpl.h>
 #include <private/tdyioimpl.h>
 #include <tdytimers.h>
 #include <private/tdycharacteristiccurvesimpl.h>
@@ -77,6 +78,13 @@ PetscErrorCode TDyDriverInitializeTDy(TDy tdy) {
     if (!MaterialPropHasSoilSpecificHeat(tdy->matprop)) {
       ierr = MaterialPropSetConstantSoilSpecificHeat(tdy->matprop,
           tdy->options.soil_specific_heat); CHKERRQ(ierr);
+    }
+  } else if (tdy->options.mode == SALINITY) {
+    ierr = TDySetConstantSalineMolecularWeight(tdy,
+      tdy->options.saline_molecular_weight);CHKERRQ(ierr);
+    if (!MaterialPropHasSalineDiffusivity(tdy->matprop)) {
+      ierr = TDySetConstantIsotropicSalineDiffusivity(tdy,
+        tdy->options.saline_diffusivity);CHKERRQ(ierr);
     }
   }
 

--- a/src/tdysalinity.c
+++ b/src/tdysalinity.c
@@ -1,0 +1,118 @@
+#include <private/tdycoreimpl.h>
+#include <private/tdysalinityimpl.h>
+
+PetscErrorCode TDySalinityInitialize(TDy tdy) {
+  PetscErrorCode ierr;
+  Vec temp_vec;
+  PetscReal *soln_p;
+  PetscReal *temp_p;
+  PetscInt local_size;
+  PetscFunctionBegin;
+
+  PetscPrintf(PETSC_COMM_WORLD,"Running Salinity mode.\n");
+
+  if (tdy->options.init_with_random_field) {
+    PetscRandom rand;
+    ierr = PetscRandomCreate(PETSC_COMM_WORLD,&rand); CHKERRQ(ierr);
+    ierr = VecGetLocalSize(tdy->soln,&local_size); CHKERRQ(ierr);
+    ierr = TDyCreateGlobalVector(tdy,&temp_vec); CHKERRQ(ierr);
+    // pressure
+    ierr = PetscRandomSetInterval(rand,1.e4,1.e5); CHKERRQ(ierr);
+    ierr = VecSetRandom(temp_vec,rand); CHKERRQ(ierr);
+    ierr = VecGetArray(tdy->soln,&soln_p); CHKERRQ(ierr);
+    ierr = VecGetArray(temp_vec,&temp_p); CHKERRQ(ierr);
+    for (int i=0; i<local_size; i+=2) soln_p[i] = temp_p[i];
+    ierr = VecRestoreArray(temp_vec,&temp_p); CHKERRQ(ierr);
+    // concentration
+    ierr = PetscRandomSetInterval(rand,0.1,0.8); CHKERRQ(ierr);
+    ierr = VecSetRandom(temp_vec,rand); CHKERRQ(ierr);
+    ierr = VecGetArray(temp_vec,&temp_p); CHKERRQ(ierr);
+    for (int i=1; i<local_size; i+=2) soln_p[i] = temp_p[i];
+    ierr = VecRestoreArray(temp_vec,&temp_p); CHKERRQ(ierr);
+    ierr = VecRestoreArray(tdy->soln,&soln_p); CHKERRQ(ierr);
+    ierr = VecDestroy(&temp_vec); CHKERRQ(ierr);
+    ierr = PetscRandomDestroy(&rand); CHKERRQ(ierr);
+  }
+  else {
+    ierr = VecSet(tdy->soln,101325.); CHKERRQ(ierr);
+  }
+
+  //TODO: add call to update density functions to watzle and wang
+
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySalinityTSPostStep(TS ts) {
+  PetscErrorCode ierr;
+  PetscReal dt;
+  PetscReal time;
+  PetscInt istep;
+  PetscInt nit;
+  PetscInt lit;
+  SNES snes;
+  SNESConvergedReason reason;
+  MPI_Comm comm;
+  PetscMPIInt rank;
+  PetscFunctionBegin;
+  ierr = PetscObjectGetComm((PetscObject)ts,&comm); CHKERRQ(ierr);
+  ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
+  ierr = TSGetTimeStep(ts,&dt); CHKERRQ(ierr);
+  ierr = TSGetTime(ts,&time); CHKERRQ(ierr);
+  ierr = TSGetStepNumber(ts,&istep); CHKERRQ(ierr);
+  ierr = TSGetSNES(ts,&snes); CHKERRQ(ierr);
+  ierr = SNESGetIterationNumber(snes,&nit); CHKERRQ(ierr); ierr = SNESGetLinearSolveIterations(snes,&lit); CHKERRQ(ierr);
+  ierr = SNESGetConvergedReason(snes,&reason); CHKERRQ(ierr);
+  if (!rank)
+    printf("Time step %d: time = %f dt = %f ni = %d li = %d rsn = %s\n",
+           istep,time,dt,nit,lit,SNESConvergedReasons[reason]);
+//           ti->istep,ti->time,ti->dt,nit,lit);
+  PetscFunctionReturn(0);
+}
+
+
+PetscErrorCode TDySalinitySNESPostCheck(SNESLineSearch linesearch,
+                                        Vec X, Vec Y, Vec W,
+                                        PetscBool *changed_Y,
+                                        PetscBool *changed_W,void *ctx) {
+  //PetscErrorCode ierr;
+  PetscFunctionBegin;
+
+//#define DEBUG
+#if defined(DEBUG)
+  PetscViewer viewer;
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"post_update.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(Y,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"post_solution.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(W,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+#endif
+
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode TDySalinityConvergenceTest(SNES snes, PetscInt it,
+                 PetscReal xnorm, PetscReal unorm, PetscReal fnorm,
+                 SNESConvergedReason *reason, void *ctx) {
+  //TDy tdy = (TDy)ctx;
+  PetscErrorCode ierr;
+  Vec r;
+  MPI_Comm comm;
+  PetscMPIInt rank;
+  PetscFunctionBegin;
+  ierr = PetscObjectGetComm((PetscObject)snes,&comm); CHKERRQ(ierr);
+  ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
+  ierr = SNESConvergedDefault(snes,it,xnorm,unorm,fnorm,reason,ctx);
+         CHKERRQ(ierr);
+  ierr = SNESGetFunction(snes,&r,NULL,NULL); CHKERRQ(ierr);
+#if defined(DEBUG)
+  PetscViewer viewer;
+  ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD,"residual.vec",&viewer); CHKERRQ(ierr);
+  ierr = VecView(r,viewer);
+  ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+#endif
+  if (!rank)
+    printf("%3d: %9.2e %9.2e %9.2e\n",it,fnorm,xnorm,unorm);
+
+  PetscFunctionReturn(0);
+}

--- a/src/tdysalinity.c
+++ b/src/tdysalinity.c
@@ -37,8 +37,6 @@ PetscErrorCode TDySalinityInitialize(TDy tdy) {
     ierr = VecSet(tdy->soln,101325.); CHKERRQ(ierr);
   }
 
-  //TODO: add call to update density functions to watzle and wang
-
   PetscFunctionReturn(0);
 }
 

--- a/src/tdyti.c
+++ b/src/tdyti.c
@@ -124,6 +124,9 @@ PetscErrorCode TDyTimeIntegratorRunToTime(TDy tdy,PetscReal sync_time) {
           case TH:
             ierr = PetscPrintf(PETSC_COMM_WORLD,"===== TH MODE ====================================\n"); CHKERRQ(ierr);
             break;
+          case SALINITY:
+            ierr = PetscPrintf(PETSC_COMM_WORLD,"===== SALINITY MODE ==============================\n"); CHKERRQ(ierr);
+            break;
         }
         ierr = TDyTimeIntegratorSetTargetTime(ti,sync_time); CHKERRQ(ierr);
         ierr = TDySetDtimeForSNESSolver(tdy,ti->dt); CHKERRQ(ierr);


### PR DESCRIPTION
Hi everyone,

@leorosie and I were working on a lot of things at the same time, so our paths diverged. This PR is a reimagining of PR #239 in the new code structure in which material models, characteristic curves, etc are factored out, and our new "polymorphic" model is in place, with vectorized functions and all that wacky stuff.

I've revised each of Rosie's commits and stuck both of our names on them using a convention suggested by @jedbrown (thanks!). Hopefully the code is similar enough for us to evaluate it alongside PR #239 . I took the liberty of changing the names of a few things ("concentration" to "salinity" to be more specific, and "PorDiff" to "SalineDiffusivity", etc), but these are just suggestions.

It looks like there may be some test failures in the transient MPFAO F90 demos. Perhaps they result from the slight change in the "constant" density of water introduced in this PR.