### PR TITLE
The markdown-tables extension broke our doc build. Are we even using it?

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,6 +1,6 @@
 sphinx>=3.0
 breathe>=4.17
-markdown==3.2.1
+markdown==3.4
 recommonmark
 sphinx_rtd_theme
 sphinxcontrib-bibtex
@@ -8,4 +8,3 @@ sphinxcontrib-katex
 sphinxcontrib-mermaid
 sphinxcontrib-svg2pdfconverter
 sphinx-hoverxref>=0.3b1
-sphinx-markdown-tables


### PR DESCRIPTION
This PR bumps the version of Markdown to fix a doc build warning, and eliminates the markdown-tables extension, which has rotted and broken our build.