### PR TITLE
Sphinx fix, attempt #2

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'breathe',
     'hoverxref.extension',
     'recommonmark',
-    'sphinx_markdown_tables',
+#    'sphinx_markdown_tables', # rotted!
     'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',


### PR DESCRIPTION
The last PR failed to build docs because I didn't remove a reference to the extension we deleted. I am resisting getting a PhD in Sphinx (not a fan).