### PR TITLE
Update PetscOptionsBegin/End for petsc-3.18/main

### DIFF
--- a/demo/SPE10/steady.c
+++ b/demo/SPE10/steady.c
@@ -108,14 +108,14 @@ int main(int argc, char **argv) {
   ierr = TDyCreate(&tdy); CHKERRQ(ierr);
   ierr = TDySetDiscretizationMethod(tdy,WY); CHKERRQ(ierr);
 
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"SPE Options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"SPE Options","");
   ierr = PetscOptionsInt ("-dim","Problem dimension","",
 			  dim,&dim,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-N","Number of cells in each dimension","",
 			  N,&N,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-angle","Permeability angle","",
 			  ang,&ang,NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   /* Create and distribute the mesh */
   DM dm, dmDist = NULL;

--- a/demo/qa_test/qa_test.c
+++ b/demo/qa_test/qa_test.c
@@ -38,8 +38,7 @@ int main(int argc, char **argv) {
   char exofile[256];
   PetscBool exo = PETSC_FALSE;
   ierr = PetscInitialize(&argc,&argv,(char *)0,0); CHKERRQ(ierr);
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
-  CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
   ierr = PetscOptionsInt ("-dim","Problem dimension","",dim,&dim,NULL);
   CHKERRQ(ierr);
   ierr = PetscOptionsInt ("-N","Number of elements in 1D","",N,&N,NULL);
@@ -48,7 +47,7 @@ int main(int argc, char **argv) {
   CHKERRQ(ierr);
   ierr = PetscOptionsInt("-successful_exit_code","Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   /* Create and distribute the mesh */
   DM dm, dmDist = NULL;

--- a/demo/richards/richards_driver.c
+++ b/demo/richards/richards_driver.c
@@ -19,13 +19,12 @@ int main(int argc, char **argv) {
   ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
   ierr = MPI_Comm_size(comm,&size); CHKERRQ(ierr);
   PetscPrintf(comm,"Beginning Richards Driver simulation.\n");
-  ierr = PetscOptionsBegin(comm,NULL,"Sample Options","");
-                           CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"Sample Options","");
   ierr = PetscOptionsInt("-successful_exit_code",
                          "Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
                          CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // default mode and method must be set prior to TDySetFromOptions()
   ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);

--- a/demo/salinity/salinity.c
+++ b/demo/salinity/salinity.c
@@ -23,13 +23,12 @@ int main(int argc, char **argv) {
   ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
   ierr = MPI_Comm_size(comm,&size); CHKERRQ(ierr);
   PetscPrintf(comm,"Beginning salinity simulation.\n");
-  ierr = PetscOptionsBegin(comm,NULL,"Sample Options","");
-                           CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"Sample Options","");
   ierr = PetscOptionsInt("-successful_exit_code",
                          "Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
                          CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   ierr = TDySetWaterDensityType(tdy,WATER_DENSITY_BATZLE_AND_WANG);
   ierr = TDySetWaterViscosityType(tdy,WATER_VISCOSITY_BATZLE_AND_WANG);

--- a/demo/steady/steady.c
+++ b/demo/steady/steady.c
@@ -733,7 +733,7 @@ int main(int argc, char **argv) {
   ierr = TDySetMode(tdy,RICHARDS); CHKERRQ(ierr);
   ierr = TDySetDiscretization(tdy,MPFA_O); CHKERRQ(ierr);
 
-  ierr = PetscOptionsBegin(comm,NULL,"Sample Options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"Sample Options","");
   ierr = PetscOptionsInt("-dim","Problem dimension","",dim,&dim,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-N","Number of elements in 1D","",N,&N,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-problem","Problem number","",problem,&problem,NULL); CHKERRQ(ierr);
@@ -745,7 +745,7 @@ int main(int argc, char **argv) {
   ierr = PetscOptionsString("-view_centroids","Filename to save centroids","",centroids_filename,centroids_filename,256,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsString("-view_true_pressure","Filename to save true pressure","",true_pres_filename,true_pres_filename,256,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsString("-view_forcing","Filename to save forcing","",forcing_filename,forcing_filename,256,NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   ierr = PetscStrcasecmp(paper,"wheeler2006",&wheeler2006); CHKERRQ(ierr);
   ierr = PetscStrcasecmp(paper,"wheeler2012",&wheeler2012); CHKERRQ(ierr);

--- a/demo/th/th_driver.c
+++ b/demo/th/th_driver.c
@@ -19,13 +19,12 @@ int main(int argc, char **argv) {
   ierr = MPI_Comm_rank(comm,&rank); CHKERRQ(ierr);
   ierr = MPI_Comm_size(comm,&size); CHKERRQ(ierr);
   PetscPrintf(comm,"Beginning TH Driver simulation.\n");
-  ierr = PetscOptionsBegin(comm,NULL,"Sample Options","");
-                           CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"Sample Options","");
   ierr = PetscOptionsInt("-successful_exit_code",
                          "Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
                          CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // default mode and method must be set prior to TDySetFromOptions()
   ierr = TDySetFromOptions(tdy); CHKERRQ(ierr);

--- a/demo/transient/transient.c
+++ b/demo/transient/transient.c
@@ -109,15 +109,14 @@ int main(int argc, char **argv) {
   ierr = TDySetMode(tdy, RICHARDS); CHKERRQ(ierr);
   ierr = TDySetDiscretization(tdy,WY); CHKERRQ(ierr);
 
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,
-			   "Transient Options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL, "Transient Options","");
   ierr = PetscOptionsInt("-N","Number of elements in 1D",
 			 "",N,&N,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsInt("-successful_exit_code","Code passed on successful completion","",
                          successful_exit_code,&successful_exit_code,NULL);
   ierr = PetscOptionsString("-exo","Mesh file in exodus format","",
 			    exofile,exofile,256,&exo); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Specify a special DM to be constructed for this demo, and pass it the
   // relevant options.

--- a/src/fe/tdybdm.c
+++ b/src/fe/tdybdm.c
@@ -61,12 +61,12 @@ PetscErrorCode TDySetFromOptions_BDM(void *context, TDyOptions *options) {
   TDyBDM *bdm = context;
 
   // Set options.
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: BDM options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: BDM options","");
   TDyQuadratureType qtype = FULL;
   ierr = PetscOptionsEnum("-tdy_quadrature","Quadrature type for finite element methods",
     "TDyWYSetQuadrature",TDyQuadratureTypes,(PetscEnum)qtype,
     (PetscEnum *)&bdm->qtype,NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   PetscFunctionReturn(0);
 }

--- a/src/fe/tdywy.c
+++ b/src/fe/tdywy.c
@@ -286,12 +286,12 @@ PetscErrorCode TDySetFromOptions_WY(void *context, TDyOptions *options) {
   wy->Pref = 101325;
 
   // Set options.
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: WY options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: WY options","");
   TDyQuadratureType qtype = FULL;
   ierr = PetscOptionsEnum("-tdy_quadrature","Quadrature type for finite element methods",
     "TDyWYSetQuadrature",TDyQuadratureTypes,(PetscEnum)qtype,
     (PetscEnum *)&wy->qtype,NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Set characteristic curve data.
   wy->vangenuchten_m = options->vangenuchten_m;

--- a/src/fv/fvtpf/tdyfvtpf.c
+++ b/src/fv/fvtpf/tdyfvtpf.c
@@ -61,7 +61,7 @@ PetscErrorCode TDySetFromOptions_FVTPF(void *context, TDyOptions *options) {
   TDyFVTPF* fvtpf = context;
 
   // Set FV-TPF options.
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: FV-TPF options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: FV-TPF options","");
   TDyBoundaryConditionType bctype = DIRICHLET_BC;
 
   PetscBool flag;
@@ -72,7 +72,7 @@ PetscErrorCode TDySetFromOptions_FVTPF(void *context, TDyOptions *options) {
   if (flag && (bctype != fvtpf->bc_type)) {
     fvtpf->bc_type = bctype;
   }
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Set characteristic curve data.
   fvtpf->vangenuchten_m = options->vangenuchten_m;

--- a/src/fv/mpfao/tdympfao.c
+++ b/src/fv/mpfao/tdympfao.c
@@ -580,7 +580,7 @@ PetscErrorCode TDySetFromOptions_MPFAO(void *context, TDyOptions *options) {
   TDyMPFAO* mpfao = context;
 
   // Set MPFA-O options.
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: MPFA-O options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"TDyCore: MPFA-O options","");
   ierr = PetscOptionsEnum("-tdy_mpfao_gmatrix_method","MPFA-O gmatrix method",
     "TDySetMPFAOGmatrixMethod",TDyMPFAOGmatrixMethods,
     (PetscEnum)mpfao->gmatrix_method,(PetscEnum *)&mpfao->gmatrix_method,NULL);
@@ -605,7 +605,7 @@ PetscErrorCode TDySetFromOptions_MPFAO(void *context, TDyOptions *options) {
     SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"Only one of -tdy_output_geom_attributes and -tdy_read_geom_attributes can be specified");
   }
   */
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Set characteristic curve data.
   mpfao->vangenuchten_m = options->vangenuchten_m;

--- a/src/materials/tdycharacteristiccurves.c
+++ b/src/materials/tdycharacteristiccurves.c
@@ -530,8 +530,7 @@ static PetscErrorCode CubicPolynomialSetup(PetscReal x0, PetscReal x1, PetscReal
   dgesv_( &n, &nrhs, A, &lda, ipiv, rhs, &ldb, &info );
 
   if (info > 0) {
-    PetscPrintf(PETSC_COMM_WORLD,"");
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_USER,"CubicPolynomialSetup failed");
+    SETERRQ(PETSC_COMM_SELF,PETSC_ERR_USER,"CubicPolynomialSetup failed");
   }
 
   PetscFunctionReturn(0);

--- a/src/tdycore.c
+++ b/src/tdycore.c
@@ -517,31 +517,31 @@ static PetscErrorCode ReadCommandLineOptions(TDy tdy) {
   TDyOptions *options = &tdy->options;
 
   PetscValidHeaderSpecific(tdy,TDY_CLASSID,1);
-  ierr = PetscObjectOptionsBegin((PetscObject)tdy); CHKERRQ(ierr);
+  PetscObjectOptionsBegin((PetscObject)tdy);
   PetscBool flag;
 
   TDyMode mode = options->mode;
   TDyDiscretization discretization = options->discretization;
 
   // Material property options
-  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Material property options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"TDyCore: Material property options","");
   ierr = PetscOptionsReal("-tdy_porosity", "Value of porosity", NULL, options->porosity, &options->porosity, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_permability", "Value of permeability", NULL, options->permeability, &options->permeability, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_soil_density", "Value of soil density", NULL, options->soil_density, &options->soil_density, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_soil_specific_heat", "Value of soil specific heat", NULL, options->soil_specific_heat, &options->soil_specific_heat, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_thermal_conductivity", "Value of thermal conductivity", NULL, options->porosity, &options->porosity, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Characteristic curve options
-  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Characteristic curve options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"TDyCore: Characteristic curve options","");
   ierr = PetscOptionsReal("-tdy_residual_satuaration", "Value of residual saturation", NULL, options->residual_saturation, &options->residual_saturation, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_gardner_param_n", "Value of Gardner n parameter", NULL, options->gardner_n, &options->gardner_n, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_vangenuchten_param_m", "Value of VanGenuchten m parameter", NULL, options->vangenuchten_m, &options->vangenuchten_m, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_vangenuchten_param_alpha", "Value of VanGenuchten alpha parameter", NULL, options->vangenuchten_alpha, &options->vangenuchten_alpha, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Model options
-  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Model options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"TDyCore: Model options","");
   ierr = PetscOptionsEnum("-tdy_mode","Flow mode", "TDySetMode",TDyModes,(PetscEnum)options->mode, (PetscEnum *)&mode, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_gravity", "Magnitude of gravity vector", NULL, options->gravity_constant, &options->gravity_constant, NULL); CHKERRQ(ierr);
   ierr = PetscOptionsEnum("-tdy_water_density","Water density vertical profile", "TDySetWaterDensityType", TDyWaterDensityTypes, (PetscEnum)options->rho_type, (PetscEnum *)&options->rho_type, NULL); CHKERRQ(ierr);
@@ -584,12 +584,12 @@ static PetscErrorCode ReadCommandLineOptions(TDy tdy) {
     } else { // TODO: what goes here??
     }
   }
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Numerics options
-  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Numerics options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"TDyCore: Numerics options","");
   ierr = PetscOptionsEnum("-tdy_discretization","Discretization", "TDySetDiscretization",TDyDiscretizations, (PetscEnum)options->discretization,(PetscEnum *)&discretization, NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Override the mode and/or discretization if needed.
   if (options->mode != mode) {
@@ -607,15 +607,15 @@ static PetscErrorCode ReadCommandLineOptions(TDy tdy) {
   }
 
   // Mesh-related options
-  ierr = PetscOptionsBegin(comm,NULL,"TDyCore: Mesh options",""); CHKERRQ(ierr);
+  PetscOptionsBegin(comm,NULL,"TDyCore: Mesh options","");
   ierr = PetscOptionsGetString(NULL,NULL,"-tdy_read_mesh", options->mesh_file,sizeof(options->mesh_file),&options->read_mesh); CHKERRQ(ierr);
   ierr = PetscOptionsGetString(NULL,NULL,"-tdy_read_pflotran_mesh", options->mesh_file,sizeof(options->mesh_file),&options->read_pflotran_mesh); CHKERRQ(ierr);
   ierr = PetscOptionsBool("-tdy_output_mesh","Enable output of mesh attributes","",options->output_mesh,&(options->output_mesh),NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   // Other options
   ierr = PetscOptionsBool("-tdy_regression_test","Enable output of a regression file","",options->regression_testing,&(options->regression_testing),NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   PetscFunctionReturn(0);
 }

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -38,8 +38,7 @@ PetscErrorCode TDyIOCreate(TDyIO *_io) {
   io->ic_dataset[0] = '\0';
   io->anisotropic_permeability = PETSC_FALSE;
 
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
-                           CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Sample Options","");
   ierr = PetscOptionsString("-init_permeability_file",
                             "Input Permeability Filename","",
 			    io->permeability_filename,io->permeability_filename,
@@ -88,7 +87,7 @@ PetscErrorCode TDyIOCreate(TDyIO *_io) {
 			  io->output_timestep_interval,
 			  &io->output_timestep_interval, NULL);
                           CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   PetscFunctionReturn(0);
 }

--- a/src/tdyio.c
+++ b/src/tdyio.c
@@ -542,7 +542,7 @@ PetscErrorCode TDyIOAddExodusTime(char *ofilename, PetscReal time, DM dm, TDyIO 
 
   io->num_times = io->num_times + 1;
   exoid = ex_open(ofilename, EX_WRITE, &CPU_word_size, &IO_word_size, &version);
-  if (exoid < 0) SETERRQ(PETSC_COMM_SELF, PETSC_ERR_FILE_UNEXPECTED, "Unable to open exodus file %\n", ofilename);
+  if (exoid < 0) SETERRQ(PETSC_COMM_SELF, PETSC_ERR_FILE_UNEXPECTED, "Unable to open exodus file %s\n", ofilename);
   ierr = ex_put_time(exoid,io->num_times,&time);CHKERRQ(ierr);
   ierr = DMSetOutputSequenceNumber(dm,io->num_times-1,time);CHKERRQ(ierr);
   ierr = ex_close(exoid);CHKERRQ(ierr);

--- a/src/tdyregression.c
+++ b/src/tdyregression.c
@@ -33,7 +33,7 @@ PetscErrorCode TDyRegressionInitialize(TDy tdy) {
 
   regression->num_cells_per_process = 2;
 
-  ierr = PetscObjectOptionsBegin((PetscObject)tdy); CHKERRQ(ierr);
+  PetscObjectOptionsBegin((PetscObject)tdy);
 
   ierr = PetscOptionsInt ("-tdy_regression_test_num_cells_per_process",
 			  "Number of cells per MPI process","",
@@ -131,7 +131,7 @@ PetscErrorCode TDyRegressionInitialize(TDy tdy) {
   tdy->regression = regression;
 
   ierr = VecDestroy(&U); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
   ierr = TDyFree(int_array); CHKERRQ(ierr);
 
   TDY_STOP_FUNCTION_TIMER()
@@ -267,7 +267,7 @@ PetscErrorCode TDyRegressionOutput(TDy tdy, Vec U) {
   }
 
   ierr = VecDestroy(&U_pres); CHKERRQ(ierr);
-  if (tdy->options.mode == TH) ierr = VecDestroy(&U_temp); CHKERRQ(ierr);
+  if (tdy->options.mode == TH) {ierr = VecDestroy(&U_temp); CHKERRQ(ierr);}
 
   TDY_STOP_FUNCTION_TIMER()
   PetscFunctionReturn(0);

--- a/src/tdyti.c
+++ b/src/tdyti.c
@@ -25,8 +25,7 @@ PetscErrorCode TDyTimeIntegratorCreate(TDyTimeIntegrator *_ti) {
   ti->istep = 0;
 
   time_integration_method[0] = '\0';
-  ierr = PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Time Integration Options","");
-                           CHKERRQ(ierr);
+  PetscOptionsBegin(PETSC_COMM_WORLD,NULL,"Time Integration Options","");
   ierr = PetscOptionsReal("-tdy_final_time","Final Time","",ti->final_time,
                           &ti->final_time,NULL); CHKERRQ(ierr);
   ierr = PetscOptionsReal("-tdy_dt_max","Maximum Timestep Size","",ti->dt_max,
@@ -43,7 +42,7 @@ PetscErrorCode TDyTimeIntegratorCreate(TDyTimeIntegrator *_ti) {
                             "Time Integration Method","",
                             time_integration_method,time_integration_method,32,
                             NULL); CHKERRQ(ierr);
-  ierr = PetscOptionsEnd(); CHKERRQ(ierr);
+  PetscOptionsEnd();
 
   size_t len;
   ierr = PetscStrlen(time_integration_method,&len); CHKERRQ(ierr);


### PR DESCRIPTION
We could consider adopting `PetscCall` notation and clang-format if others like it, but this gets things compiling (and fixes a couple format strings).